### PR TITLE
Standup CI & publish action

### DIFF
--- a/.github/wip.yml
+++ b/.github/wip.yml
@@ -1,0 +1,8 @@
+locations:
+- title
+- label_name
+- commit_subject
+terms:
+- do not merge
+- fixup
+- wip

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,0 +1,23 @@
+name: Continuous integration
+on: [push]
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Cache the node_modules dir
+      uses: actions/cache@v2
+      with:
+        path: node_modules
+        key: ${{ runner.os }}-node_modules-${{ hashFiles('yarn.lock') }}
+    - name: Install
+      run: yarn install --frozen-lockfile
+    - name: Format
+      run: yarn checkformatting
+    - name: Lint
+      run: yarn lint
+    - name: Typecheck
+      run: yarn typecheck
+    - name: Test
+      run: yarn test

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,24 @@
+name: Publish frontend-shared package
+on:
+  release:
+    types:
+      - published
+jobs:
+  build-and-publish-package:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Setup Nodejs
+      uses: actions/setup-node@v1
+      with:
+        node-version: '12.x'
+        registry-url: 'https://registry.npmjs.org'
+    - name: Install
+      run: yarn install --frozen-lockfile
+    - name: Build lib files
+      run: yarn build
+    - name: Publish package
+      run: npm publish --access public
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Mostly just cut from the client with the minor difference of not installing the /frontend-shared subfolder or doing any of the version bumping. I performed various testing to ensure all pieces fail individually when appropriate. 

The releases (for now) will be done manually via github IU. At some point we might want to perform automated releases similar to how the client does it with `create-github-release.js`, but I don't know how to do that without a manual step intervention when we take away Jenkins. So for now, the UI is sufficient. 

We also may want to soon port over the `generate-change-list.js` script so when we do a release, we can accurately document what has changed. 