### PR TITLE
Add build-css gulp task for testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
 lib/
+build/
 
 # Use Yarn rather than npm to manage the lockfile.
 package-lock.json

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -2,7 +2,27 @@
 
 'use strict';
 
+const fs = require('fs');
 const gulp = require('gulp');
+const sass = require('sass');
+
+/**
+ * Task to build a CSS bundle.
+ *
+ * nb. This is only used for unit tests that need CSS to verify accessibility requirements.
+ */
+gulp.task('build-css', done => {
+  fs.mkdirSync('build', { recursive: true });
+  const result = sass.renderSync({
+    file: 'styles/_index.scss',
+    outFile: 'build/styles.css',
+    sourceMap: true,
+  });
+
+  fs.writeFileSync('build/styles.css', result.css);
+  fs.writeFileSync('build/styles.css.map', result.map);
+  done();
+});
 
 function runKarma({ singleRun }, done) {
   const karma = require('karma');
@@ -16,7 +36,7 @@ function runKarma({ singleRun }, done) {
 }
 
 // Unit and integration testing tasks.
-gulp.task('test', done => {
-  runKarma({ singleRun: true });
-  done();
-});
+gulp.task(
+  'test',
+  gulp.series('build-css', done => runKarma({ singleRun: true }, done))
+);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -40,3 +40,8 @@ gulp.task(
   'test',
   gulp.series('build-css', done => runKarma({ singleRun: true }, done))
 );
+
+gulp.task(
+  'test-watch',
+  gulp.series('build-css', done => runKarma({ singleRun: false }, done))
+);

--- a/package.json
+++ b/package.json
@@ -36,13 +36,11 @@
     "prettier": "^2.2.1",
     "prop-types": "^15.7.2",
     "puppeteer": "^7.1.0",
+    "sass": "^1.32.8",
     "sinon": "^9.0.0",
     "stringify": "^5.1.0",
     "typescript": "^4.1.5",
     "watchify": "^3.7.0"
-  },
-  "peerDependencies": {
-    "preact": "^10.4"
   },
   "peerDependencies": {
     "preact": "^10.4.0"
@@ -56,7 +54,6 @@
     "checkformatting": "prettier --check '**/*.{js,scss}'",
     "format": "prettier --list-different --write '**/*.{js,scss}'",
     "test": "gulp test"
-
   },
   "prettier": {
     "arrowParens": "avoid",

--- a/src/karma.config.js
+++ b/src/karma.config.js
@@ -29,6 +29,13 @@ module.exports = function (config) {
 
         type: 'js',
       })),
+
+      // CSS bundle relied upon by accessibility tests (eg. for color-contrast
+      // checks).
+      {
+        pattern: '../build/styles.css',
+        watched: false,
+      },
     ],
 
     // list of files to exclude

--- a/yarn.lock
+++ b/yarn.lock
@@ -1888,6 +1888,21 @@ chokidar@3.4.3:
   optionalDependencies:
     fsevents "~2.1.2"
 
+"chokidar@>=2.0.0 <4.0.0", chokidar@^3.4.0, chokidar@^3.4.2:
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.1.tgz"
+  integrity sha512-9+s+Od+W0VJJzawDma/gvBNQqkTiqYTWLuZoyAsivsI4AaWTCzHG06/TMjsf1cYe9Cb97UCEhjz7HvnPk2p/tw==
+  dependencies:
+    anymatch "~3.1.1"
+    braces "~3.0.2"
+    glob-parent "~5.1.0"
+    is-binary-path "~2.1.0"
+    is-glob "~4.0.1"
+    normalize-path "~3.0.0"
+    readdirp "~3.5.0"
+  optionalDependencies:
+    fsevents "~2.3.1"
+
 chokidar@^2.0.0, chokidar@^2.1.1:
   version "2.1.8"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-2.1.8.tgz"
@@ -1906,21 +1921,6 @@ chokidar@^2.0.0, chokidar@^2.1.1:
     upath "^1.1.1"
   optionalDependencies:
     fsevents "^1.2.7"
-
-chokidar@^3.4.0, chokidar@^3.4.2:
-  version "3.5.1"
-  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.1.tgz"
-  integrity sha512-9+s+Od+W0VJJzawDma/gvBNQqkTiqYTWLuZoyAsivsI4AaWTCzHG06/TMjsf1cYe9Cb97UCEhjz7HvnPk2p/tw==
-  dependencies:
-    anymatch "~3.1.1"
-    braces "~3.0.2"
-    glob-parent "~5.1.0"
-    is-binary-path "~2.1.0"
-    is-glob "~4.0.1"
-    normalize-path "~3.0.0"
-    readdirp "~3.5.0"
-  optionalDependencies:
-    fsevents "~2.3.1"
 
 chownr@^1.1.1:
   version "1.1.4"
@@ -5759,6 +5759,13 @@ safe-regex@^1.1.0:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
+
+sass@^1.32.8:
+  version "1.32.8"
+  resolved "https://registry.yarnpkg.com/sass/-/sass-1.32.8.tgz#f16a9abd8dc530add8834e506878a2808c037bdc"
+  integrity sha512-Sl6mIeGpzjIUZqvKnKETfMf0iDAswD9TNlv13A7aAF3XZlRPMq4VvJWBC2N2DXbp94MQVdNSFG6LfF/iOXrPHQ==
+  dependencies:
+    chokidar ">=2.0.0 <4.0.0"
 
 semver-greatest-satisfied-range@^1.1.0:
   version "1.1.0"


### PR DESCRIPTION
Add styles.css to karam config. Unit tests rely on css for a11y requirements such as contrast.

The `styles.css` and `styles.css.map` files are output to `build/` dir which has no other purpose than to support these files for testing **only**. I'm not sure that's the best choice for the folder name and I'm open to other suggestions. 

TODO:
add `accessibility.js` module from the client.