### PR TITLE
Add changelog & release docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [v1.0.0] 2021-01-06
+
+### Added
+
+- outline-on-keyboard-focus mixin
+- Initial commit for frontend-shared

--- a/README.md
+++ b/README.md
@@ -35,4 +35,5 @@ import { SvgIcon } from '@hypothesis/frontend-shared';
 
 ### Additional documentation
 
-[Development guide](docs/developing.md)
+- [Development guide](docs/developing.md)
+- [Release guide](docs/releases.md)

--- a/changelog-template.hbs
+++ b/changelog-template.hbs
@@ -1,0 +1,17 @@
+
+{{#each releases}}
+
+  ## [{{title}}] - {{date}}
+  {{#if summary}}
+    {{summary}}
+  {{/if}}
+  {{#each merges}}
+    - {{#if commit.breaking}}**Breaking change:** {{/if}}{{message}}{{#if href}} [#{{id}}]({{href}}){{/if}}
+  {{/each}}
+  {{#each fixes}}
+    - {{#if commit.breaking}}**Breaking change:** {{/if}}{{commit.subject}}{{#if href}} [#{{id}}]({{href}}){{/if}}
+  {{/each}}
+  {{#each commits}}
+    - {{#if breaking}}**Breaking change:** {{/if}}{{subject}}{{#if href}} [#{{shorthash}}]({{href}}){{/if}}
+  {{/each}}
+{{/each}}

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -1,0 +1,48 @@
+# Release process
+
+The release process in broken up into 3 steps.
+
+1. Increment the version and add a new tag
+2. Modify the changelog
+3. Merge the release branch and create a "github release"
+
+## 1. Increment the version and add a new tag
+
+To update the version in package.json and create a tag run:
+
+```shell
+$ yarn version
+```
+
+The version number should be updated following [Semantic Versioning](https://semver.org/#semantic-versioning-200). The only change should be to package.json, and there should be a new tag on the commit prefixed with a "v".
+
+## 2. Modify the changelog
+
+`CHANGELOG.md` highlights changes that are relevant for consumers of the package. Our changelog follows [keepachangelog](https://keepachangelog.com/en/1.0.0/).
+
+### Steps to append to the changelog
+
+Immediately after a version commit & tag, run the following command to create a draft list of changes relating to the new version.
+
+```shell
+$ gulp changelog
+```
+
+This command will generate a partial changelog and output it to the console. Copy the text and paste it above the previous version in `CHANGELOG.md` and be sure to leave a blank line between versions. The output is git logs between the current new version and the previous released version. It will be important to edit and trim down that list so that only the consumer-relevant changes are included.
+
+### Edit the output
+
+1. Delete any commits that are not relevant for a consumer.
+2. Categorize the remaining important commits into various [types of changes](https://keepachangelog.com/en/1.0.0/#how).
+3. Make sure to prefix anything that might break with "BREAKING CHANGE:"
+4. Refactor the messages as needed to ensure they can be understood by a consumer.
+
+When writing the changelog, please follow the [Keep a Changelog advice](https://keepachangelog.com/en/1.0.0/#how).
+
+### Save and commit
+
+Commit the changelog file with a simple message, then push the branch (make sure to push tags too) and merge to `main` after CI passes.
+
+## 3. Create a new GitHub release
+
+Create a [new github release](https://github.com/hypothesis/frontend-shared/releases/new/). The title of the release should be identical to the tag name and the message can copied from the result of step #2. When you are done, click "Publish".

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -38,6 +38,29 @@ function parseCommandLine() {
 }
 
 const karmaOptions = parseCommandLine();
+const { run } = require('./scripts/gulp/run');
+
+/**
+ * Task to output a draft changelog to be appended to CHANGELOG.md at the
+ * top of the file.
+ *
+ * See docs/releases.md
+ */
+
+gulp.task('changelog', async () => {
+  const tag = await run('git', ['describe', '--abbrev=0', '--tags']);
+  const changelog = await run('yarn', [
+    'auto-changelog',
+    `--starting-version`,
+    tag.trim(),
+    '--stdout',
+    '--template',
+    'changelog-template.hbs',
+  ]);
+  // Copy and paste the result to CHANGELOG.md, then edit as needed.
+  // eslint-disable-next-line no-console
+  console.log(changelog.toString());
+});
 
 /**
  * Task to build a CSS bundle.

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "@babel/preset-env": "^7.1.6",
     "@babel/preset-react": "^7.0.0",
     "axe-core": "^4.0.0",
+    "auto-changelog": "^2.2.1",
     "babel-plugin-mockable-imports": "^1.5.1",
     "babelify": "^10.0.0",
     "browserify": "^17.0.0",
@@ -56,7 +57,8 @@
     "checkformatting": "prettier --check '**/*.{js,scss}'",
     "format": "prettier --list-different --write '**/*.{js,scss,md}'",
     "test": "gulp test",
-    "push": "yarn build && yalc push"
+    "push": "yarn build && yalc push",
+    "changelog": "gulp changelog"
   },
   "prettier": {
     "arrowParens": "avoid",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "Shared components, styles and utilities for Hypothesis projects",
   "license": "BSD-2-Clause",
-  "repository": "hypothesis/client",
+  "repository": "hypothesis/frontend-shared",
   "devDependencies": {
     "@babel/cli": "^7.1.6",
     "@babel/core": "^7.1.6",

--- a/scripts/gulp/run.js
+++ b/scripts/gulp/run.js
@@ -1,0 +1,43 @@
+/* eslint-env node */
+
+'use strict';
+
+const { spawn } = require('child_process');
+
+/**
+ * Run a command and return a promise for when it completes.
+ *
+ * Output and environment is forwarded as if running a CLI command in the terminal
+ * or make.
+ *
+ * This function is useful for running CLI tools as part of a gulp command.
+ *
+ * @param {string} cmd - Command to run
+ * @param {string[]} args - Command arguments
+ * @param {object} options - Options to forward to `spawn`
+ * @return {Promise<string>}
+ */
+function run(cmd, args, options = {}) {
+  return new Promise((resolve, reject) => {
+    const stdout = [];
+    const stderr = [];
+    const cp = spawn(cmd, args, { env: process.env, ...options });
+    cp.on('exit', code => {
+      if (code === 0) {
+        resolve(stdout.join(''));
+      } else {
+        reject(
+          new Error(`${cmd} exited with status ${code}. \n${stderr.join('')}`)
+        );
+      }
+    });
+    cp.stdout.on('data', data => {
+      stdout.push(data.toString());
+    });
+    cp.stderr.on('data', data => {
+      stderr.push(data.toString());
+    });
+  });
+}
+
+module.exports = { run };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1321,6 +1321,18 @@ atob@^2.1.2:
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz"
   integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
 
+auto-changelog@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/auto-changelog/-/auto-changelog-2.2.1.tgz#a031fbf1dfe140dda2ec8c77a524031478a0e933"
+  integrity sha512-XlykJfZrXlWUAADBqGoN1elmntrRcx7oEymyYB3NRPEZxv0TfYHfivmwzejUMnwAdXKCgbQPo7GV5ULs3jwpfw==
+  dependencies:
+    commander "^5.0.0"
+    handlebars "^4.7.3"
+    lodash.uniqby "^4.7.0"
+    node-fetch "^2.6.0"
+    parse-github-url "^1.0.2"
+    semver "^6.3.0"
+
 available-typed-arrays@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/available-typed-arrays/-/available-typed-arrays-1.0.2.tgz"
@@ -3540,6 +3552,18 @@ gulplog@^1.0.0:
   dependencies:
     glogg "^1.0.0"
 
+handlebars@^4.7.3:
+  version "4.7.7"
+  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.7.tgz#9ce33416aad02dbd6c8fafa8240d5d98004945a1"
+  integrity sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==
+  dependencies:
+    minimist "^1.2.5"
+    neo-async "^2.6.0"
+    source-map "^0.6.1"
+    wordwrap "^1.0.0"
+  optionalDependencies:
+    uglify-js "^3.1.4"
+
 has-flag@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz"
@@ -4468,6 +4492,11 @@ lodash.memoize@~3.0.3:
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-3.0.4.tgz"
   integrity sha1-LcvSwofLwKVcxCMovQxzYVDVPj8=
 
+lodash.uniqby@^4.7.0:
+  version "4.7.0"
+  resolved "https://registry.yarnpkg.com/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz#d99c07a669e9e6d24e1362dfe266c67616af1302"
+  integrity sha1-2ZwHpmnp5tJOE2Lf4mbGdhavEwI=
+
 lodash@^4.17.14, lodash@^4.17.19, lodash@^4.17.20:
   version "4.17.20"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz"
@@ -4773,6 +4802,11 @@ negotiator@0.6.2:
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.2.tgz"
   integrity sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==
 
+neo-async@^2.6.0:
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
+  integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
+
 next-tick@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/next-tick/-/next-tick-1.0.0.tgz"
@@ -4796,7 +4830,7 @@ no-case@^2.2.0:
   dependencies:
     lower-case "^1.1.1"
 
-node-fetch@^2.6.1:
+node-fetch@^2.6.0, node-fetch@^2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz"
   integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
@@ -5122,6 +5156,11 @@ parse-filepath@^1.0.1:
     is-absolute "^1.0.0"
     map-cache "^0.2.0"
     path-root "^0.1.1"
+
+parse-github-url@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/parse-github-url/-/parse-github-url-1.0.2.tgz#242d3b65cbcdda14bb50439e3242acf6971db395"
+  integrity sha512-kgBf6avCbO3Cn6+RnzRGLkUsv4ZVqv/VfAYkRsyBcgkshNvVBkRn1FEZcW0Jb+npXQWm2vHPnnOqFteZxRRGNw==
 
 parse-json@^2.2.0:
   version "2.2.0"
@@ -5832,6 +5871,11 @@ semver@7.0.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.0.0.tgz"
   integrity sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==
 
+semver@^6.3.0:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
+  integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
+
 semver@^7.2.1:
   version "7.3.4"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.4.tgz"
@@ -6520,6 +6564,11 @@ uglify-js@3.0.x:
     commander "~2.11.0"
     source-map "~0.5.1"
 
+uglify-js@^3.1.4:
+  version "3.12.8"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.12.8.tgz#a82e6e53c9be14f7382de3d068ef1e26e7d4aaf8"
+  integrity sha512-fvBeuXOsvqjecUtF/l1dwsrrf5y2BCUk9AOJGzGcm6tE7vegku5u/YvqjyDaAGr422PLoLnrxg3EnRvTqsdC1w==
+
 umd@^3.0.0:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/umd/-/umd-3.0.3.tgz"
@@ -6849,6 +6898,11 @@ word-wrap@^1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.3.tgz"
   integrity sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==
+
+wordwrap@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
+  integrity sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=
 
 workerpool@6.0.2:
   version "6.0.2"


### PR DESCRIPTION
### Commits

Fix repo name

-------
Add changelog command …

- Add releases.md which documents how to perform a release and modify the CHANGELOG.md file.

nb. The current published releases in npmjs goes to up to version 1.8, but there are no corresponding tags for these releases because it was in the client/ repo at that time. After version 1.9.0, the tags will match back to the appropriate commit in this repo.

------

New release document
https://github.com/hypothesis/frontend-shared/blob/add-changelog/docs/releases.md

This PR tails from https://github.com/hypothesis/frontend-shared/pull/7

After these changes are approved, we can test this process out with v.1.9.0.  (or even move to 2.0.0 shortly)

fixes https://github.com/hypothesis/client/issues/3016


TODO:
- [x] - add link from README to this document