### PR TITLE
Remove license

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,13 +36,3 @@ import { SvgIcon } from '@hypothesis/frontend-shared';
 ### Additional documentation
 
 [Development guide](docs/developing.md)
-
-### License
-
-The Hypothesis client is released under the [2-Clause BSD License][bsd2c],
-sometimes referred to as the "Simplified BSD License". Some third-party
-components are included. They are subject to their own licenses. All of the
-license information can be found in the included [LICENSE][license] file.
-
-[bsd2c]: http://www.opensource.org/licenses/BSD-2-Clause
-[license]: https://github.com/hypothesis/client/blob/master/LICENSE


### PR DESCRIPTION
Remove license text from README.md …
3bf563d
The license type is defined in package.json and so text is redundant. The link and repo name here is also outdated (incorrect)


depends on https://github.com/hypothesis/frontend-shared/pull/9