### PR TITLE
Improve test task

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "description": "Shared components, styles and utilities for Hypothesis projects",
   "license": "BSD-2-Clause",
   "repository": "hypothesis/client",
-  "dependencies": {},
   "devDependencies": {
     "@babel/cli": "^7.1.6",
     "@babel/core": "^7.1.6",
@@ -16,6 +15,7 @@
     "browserify": "^17.0.0",
     "chai": "^4.1.2",
     "classnames": "^2.2.6",
+    "commander": "^7.1.0",
     "enzyme": "^3.8.0",
     "enzyme-adapter-preact-pure": "^3.0.0",
     "eslint": "^7.3.1",

--- a/src/karma.config.js
+++ b/src/karma.config.js
@@ -1,4 +1,6 @@
-/* global process */
+/* eslint-env node */
+
+const glob = require('glob');
 
 let chromeFlags = [];
 
@@ -6,6 +8,16 @@ process.env.CHROME_BIN = require('puppeteer').executablePath();
 
 module.exports = function (config) {
   let testFiles = ['**/test/*-test.js'];
+
+  if (config.grep) {
+    const allFiles = testFiles
+      .map(pattern => glob.sync(pattern, { cwd: __dirname }))
+      .flat();
+    testFiles = allFiles.filter(path => path.match(config.grep));
+
+    // eslint-disable-next-line no-console
+    console.log(`Running tests matching pattern "${config.grep}": `, testFiles);
+  }
 
   config.set({
     // base path that will be used to resolve all patterns (eg. files, exclude)

--- a/yarn.lock
+++ b/yarn.lock
@@ -2096,6 +2096,11 @@ commander@^4.0.1:
   resolved "https://registry.yarnpkg.com/commander/-/commander-4.1.1.tgz"
   integrity sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==
 
+commander@^7.1.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-7.1.0.tgz#f2eaecf131f10e36e07d894698226e36ae0eb5ff"
+  integrity sha512-pRxBna3MJe6HKnBGsDyMv8ETbptw3axEdYHoqNh7gu5oDcew8fs0xnivZGm06Ogk8zGAJ9VX+OPEr2GXEQK4dg==
+
 commander@~2.11.0:
   version "2.11.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.11.0.tgz#157152fd1e7a6c8d98a5b715cf376df928004563"


### PR DESCRIPTION
- Use new commander options for test task exactly how the client is configured.
  - Add --grep, --browser, --no-browser, and --watch options to `test` task
  - Remove `test-watch` task (replaced with `test --watch`)
  
  
 ------


Similar to https://github.com/hypothesis/client/pull/2989  
