### PR TITLE
Release 1.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v1.10.0] - 2021-03-09
+
+### Added
+- Add `yarn push` to be able to link to the client for development [#8](https://github.com/hypothesis/frontend-shared/pull/8)
+- Add commands for testing / lint / typecheck / format [#1](https://github.com/hypothesis/frontend-shared/pull/1)
+- Move `useElementShouldClose` and `normalizeKeyName` into frontend-shared package [#22ede8c](https://github.com/hypothesis/frontend-shared/commit/22ede8ccab173a7da8b2bc5218ad583bd630f8d1)
+- Move `SvgIcon` to frontend-shared package [#0b02df5](https://github.com/hypothesis/frontend-shared/commit/0b02df5f4b3f72d4348570dd05f8f962a3a1b92e)
+- Add SASS entry file [#0751cdb](https://github.com/hypothesis/frontend-shared/commit/0751cdbcf4ed2ec1b0f3862ececb0cec4ed909d7)
+- Add `outline-on-keyboard-focus` mixin [#65dac43](https://github.com/hypothesis/frontend-shared/commit/65dac436c50d516ababa7d2b4a5708e5b51124b5)
+
 ## [v1.0.0] 2021-01-06
 
 ### Added
-
-- outline-on-keyboard-focus mixin
 - Initial commit for frontend-shared

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hypothesis/frontend-shared",
-  "version": "1.0.0",
+  "version": "1.10.0",
   "description": "Shared components, styles and utilities for Hypothesis projects",
   "license": "BSD-2-Clause",
   "repository": "hypothesis/frontend-shared",
@@ -9,8 +9,8 @@
     "@babel/core": "^7.1.6",
     "@babel/preset-env": "^7.1.6",
     "@babel/preset-react": "^7.0.0",
-    "axe-core": "^4.0.0",
     "auto-changelog": "^2.2.1",
+    "axe-core": "^4.0.0",
     "babel-plugin-mockable-imports": "^1.5.1",
     "babelify": "^10.0.0",
     "browserify": "^17.0.0",


### PR DESCRIPTION
This is a first go at trying a release process.

**CHANGELOG**
https://github.com/hypothesis/frontend-shared/blob/release/CHANGELOG.md

### Discussion

This release in particular is more ad-hoc than normal because we have already released versions up to 1.9.0 in npmjs.org and its unclear which PRs fell into which version. For our purposes, we can just claim everything to fall under this "new" release so we can move forward. That means v1.0.0 was pretty much an empty folder and everything else can go under 1.10.0. 

I changed around the changelog to more accurately reflect that and also added back some links to commits with user-facing changes. For reasons I don't yet understand, there are some commits that did get get output in the `auto-changelog` command. I suspect it has something to do with the fact that these commits were imported from client, but some of those imports actually did show up so it's perplexing. In short, I manually looked over the history and tried to make a reasonable changelog for 1.10.0.  I think this will be easier going forward.

For reference. `yarn changelog` produces this result.

```
## [v1.10.0] - 2021-03-09
- Add changelog & release docs [#10](https://github.com/hypothesis/frontend-shared/pull/10)
- Improve test task [#12](https://github.com/hypothesis/frontend-shared/pull/12)
- Remove license [#11](https://github.com/hypothesis/frontend-shared/pull/11)
- Update docs to match new process [#9](https://github.com/hypothesis/frontend-shared/pull/9)
- Add yalc [#8](https://github.com/hypothesis/frontend-shared/pull/8)
- Add accessibility file to run axe tests [#5](https://github.com/hypothesis/frontend-shared/pull/5)
- Add build-css gulp task for testing [#4](https://github.com/hypothesis/frontend-shared/pull/4)
- Standup CI & publish action [#2](https://github.com/hypothesis/frontend-shared/pull/2)
- Remove karam.config.js from /lib output [#3](https://github.com/hypothesis/frontend-shared/pull/3)
- Add support for testing / lint / typecheck / format [#1](https://github.com/hypothesis/frontend-shared/pull/1)
- Modify github action to setup link to frontend-shared [#f4c1cef](https://github.com/hypothesis/frontend-shared/commit/f4c1cef38dd4d53a301fbf8ff7827ef709046d7b)
- Add svg-icon to frontend-shared package [#0b02df5](https://github.com/hypothesis/frontend-shared/commit/0b02df5f4b3f72d4348570dd05f8f962a3a1b92e)
- Add support for unit tests [#bcbacdf](https://github.com/hypothesis/frontend-shared/commit/bcbacdfcba564c3aaa848cbc6ab019f09c4b9bbf)
```


### Next steps

- [ ] - Create a github release and ensure the action published the v1.10.0 package to npmjs.