### PR TITLE
Update project configuration

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -3,6 +3,8 @@
   "rules": {
     // https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html#eslint
     "react/jsx-uses-react": "off",
-    "react/react-in-jsx-scope": "off"
+    "react/react-in-jsx-scope": "off",
+    // Replaced by TypeScript's static checking.
+    "react/prop-types": "off"
   }
 }

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,57 @@
+.PHONY: default
+default: help
+
+.PHONY: help
+help:
+	@echo "make help              Show this help message"
+	@echo "make dev               Run the pattern library application (TODO)"
+	@echo "make build             Build the package"
+	@echo "make lint              Run the code linter(s) and print any warnings"
+	@echo "make checkformatting   Check code formatting"
+	@echo "make format            Automatically format code"
+	@echo "make test              Run the unit tests once"
+	@echo "make sure              Make sure that the formatter, linter, tests, etc all pass"
+	@echo "make clean             Delete development artefacts (cached files, "
+	@echo "                       dependencies, etc)"
+
+.PHONY: dev
+dev: node_modules/.uptodate
+	@echo 'TODO: run local dev server with pattern library'
+
+.PHONY: test
+test: node_modules/.uptodate
+ifdef ARGS
+	yarn test $(ARGS)
+else
+	yarn test
+endif
+
+.PHONY: lint
+lint: node_modules/.uptodate
+	yarn run lint
+	yarn run typecheck
+
+.PHONY: clean
+clean:
+	rm -f node_modules/.uptodate
+	rm -rf lib
+	rm -rf build
+
+.PHONY: format
+format: node_modules/.uptodate
+	yarn run format
+
+.PHONY: checkformatting
+checkformatting: node_modules/.uptodate
+	yarn run checkformatting
+
+.PHONY: sure
+sure: checkformatting lint test
+
+.PHONY: build
+build: node_modules/.uptodate
+	yarn run build
+
+node_modules/.uptodate: package.json yarn.lock
+	yarn install
+	@touch $@


### PR DESCRIPTION
This PR makes a couple of smallish changes to bring this project even further into consistency with other projects.

* Remove `propTypes` enforcement (shared button components, which come next, don't use `propTypes`)
* Add a `Makefile`. This is especially useful for the `make sure` command, and there is a stub of a target for `make dev`, which I anticipate using once there is a pattern library/local devserver in this project