### PR TITLE
Bump to v1.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v1.11.0] - 2021-04-15
+
+### Added
+
+- Add button components and styles [#22](https://github.com/hypothesis/frontend-shared/pull/22)
+- Add Makefile and update project configuration [#21](https://github.com/hypothesis/frontend-shared/pull/21)
+
 ## [v1.10.0] - 2021-03-09
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hypothesis/frontend-shared",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "description": "Shared components, styles and utilities for Hypothesis projects",
   "license": "BSD-2-Clause",
   "repository": "hypothesis/frontend-shared",


### PR DESCRIPTION
I was able to get the version bumping and changelog into a single commit and update the version tag to point at that commit. 