### PR TITLE
Add `buttonRef` to buttons

### DIFF
--- a/src/components/buttons.js
+++ b/src/components/buttons.js
@@ -4,6 +4,7 @@ import { SvgIcon } from './SvgIcon';
 
 /**
  * @typedef ButtonProps
+ * @prop {import('preact').Ref<HTMLButtonElement>} [buttonRef]
  * @prop {import("preact").ComponentChildren} [children]
  * @prop {string} [className]
  * @prop {string} [icon] - Name of `SvgIcon` to render in the button
@@ -37,6 +38,7 @@ import { SvgIcon } from './SvgIcon';
  * @param {ButtonProps} props
  */
 function ButtonBase({
+  buttonRef,
   className,
   icon,
   iconPosition = 'left',
@@ -52,6 +54,7 @@ function ButtonBase({
 
   return (
     <button
+      ref={buttonRef}
       className={classnames(
         className,
         `${className}--${size}`,

--- a/src/components/test/buttons-test.js
+++ b/src/components/test/buttons-test.js
@@ -1,4 +1,5 @@
 import { mount } from 'enzyme';
+import { createRef } from 'preact';
 
 import { IconButton, LabeledButton, LinkButton } from '../buttons.js';
 import { $imports } from '../buttons.js';
@@ -19,6 +20,20 @@ function addCommonTests({ componentName, createComponentFn, withIcon = true }) {
         assert.isTrue(button.hasClass(`${componentName}--icon-left`));
       });
     }
+
+    it('passes along a `ref` to the button element through `buttonRef`', () => {
+      const buttonRef = createRef();
+      createComponentFn({ buttonRef: buttonRef });
+
+      assert.isTrue(buttonRef.current instanceof Node);
+    });
+
+    it('does not attach a `ref` to the button element when `buttonRef is undefined', () => {
+      const buttonRef = createRef();
+      createComponentFn({ buttonRef: undefined });
+
+      assert.notExists(buttonRef.current);
+    });
 
     it('invokes callback on click', () => {
       const onClick = sinon.stub();


### PR DESCRIPTION
In LMS, we need to pass along a button ref in order to set focus() on the button when a dialog opens. In order to pass along the ref, we need to forward the ref down to the HTML component. Preact consumes the `ref` prop so we can't override that directly and `forwardRef()` is only included in `preact/compact` lib which has some adverse side effects--so we should avoid that import. So the simple solution is to use a custom named prop (`buttonRef`) to pass along the ref.

