### PR TITLE
Add hover cursor styling to buttons

### DIFF
--- a/styles/components/buttons/_base.scss
+++ b/styles/components/buttons/_base.scss
@@ -15,6 +15,7 @@
   &:hover:not([disabled]) {
     color: map.get($colormap, 'hover-foreground');
     background-color: map.get($colormap, 'hover-background');
+    cursor: pointer;
   }
   transition: color 0.2s ease-out, background-color 0.2s ease-out,
     opacity 0.2s ease-out;


### PR DESCRIPTION
LMS does not have the same defaults as the client. The hover styling in the client is done in reset.scss and LMS has does not have that.  The styling should probably be in the frontend-shared for buttons in the first place. I filed a ticket for the client to clean up styling there.

relates to https://github.com/hypothesis/client/issues/3327
