### PR TITLE
Add reset styles and mixins

### DIFF
--- a/styles/base/_reset.scss
+++ b/styles/base/_reset.scss
@@ -1,0 +1,114 @@
+@use '../mixins/reset';
+
+/*
+  Consistency fixes
+  adopted from http://necolas.github.com/normalize.css/
+  */
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  height: 100%;
+  text-size-adjust: 100%;
+}
+
+body {
+  min-height: 100%;
+  font-size: 100%;
+  margin: 0;
+}
+
+sub,
+sup {
+  font-size: 75%;
+  line-height: 0;
+  position: relative;
+}
+
+sup {
+  top: -0.5em;
+}
+sub {
+  bottom: -0.25em;
+}
+
+pre {
+  white-space: pre;
+  white-space: pre-wrap;
+  word-wrap: break-word;
+}
+
+b,
+strong {
+  font-weight: bold;
+}
+abbr[title] {
+  border-bottom: 1px dotted;
+}
+
+a img,
+img {
+  -ms-interpolation-mode: bicubic;
+}
+
+input,
+textarea,
+button,
+select {
+  @include reset.reset-font;
+  line-height: normal;
+  margin: 0;
+}
+
+button,
+html input[type='button'],
+input[type='reset'],
+input[type='submit'] {
+  cursor: pointer;
+  -webkit-appearance: button;
+}
+
+textarea {
+  overflow: auto;
+}
+
+img::selection,
+img::-moz-selection {
+  background: transparent;
+}
+
+ul,
+ol,
+dl,
+dd,
+dt,
+li {
+  @include reset.reset-box-model;
+}
+
+ul,
+ol {
+  list-style: none;
+}
+
+blockquote {
+  margin: 0;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font: inherit;
+  font-size: 100%;
+  font-weight: normal;
+  font-style: normal;
+  vertical-align: baseline;
+}

--- a/styles/mixins/_reset.scss
+++ b/styles/mixins/_reset.scss
@@ -1,0 +1,97 @@
+@mixin reset-font {
+  font: inherit;
+  font-size: 100%;
+  vertical-align: baseline;
+}
+
+@mixin reset-box-model {
+  margin: 0;
+  padding: 0;
+  border: 0;
+}
+
+// Adapted from http://compass-style.org/reference/compass/reset/utilities/#mixin-nested-reset
+@mixin nested-reset {
+  div,
+  span,
+  applet,
+  object,
+  iframe,
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6,
+  p,
+  blockquote,
+  pre,
+  a,
+  abbr,
+  acronym,
+  address,
+  big,
+  cite,
+  code,
+  del,
+  dfn,
+  em,
+  img,
+  ins,
+  kbd,
+  q,
+  s,
+  samp,
+  small,
+  strike,
+  strong,
+  sub,
+  sup,
+  tt,
+  var,
+  b,
+  u,
+  i,
+  center,
+  dl,
+  dt,
+  dd,
+  ol,
+  ul,
+  li,
+  fieldset,
+  form,
+  label,
+  legend,
+  table,
+  caption,
+  tbody,
+  tfoot,
+  thead,
+  tr,
+  th,
+  td,
+  article,
+  aside,
+  canvas,
+  details,
+  embed,
+  figure,
+  figcaption,
+  footer,
+  header,
+  hgroup,
+  menu,
+  nav,
+  output,
+  ruby,
+  section,
+  summary,
+  time,
+  mark,
+  audio,
+  video {
+    @include reset-box-model;
+    @include reset-font;
+  }
+}


### PR DESCRIPTION
This is a second whack at introducing reset styles and mixins to this repository in a simpler fashion. This is a simple copy-and-paste from the client. For now, I'm using a `base` directory, per the [SASS 7-1 pattern](https://gist.github.com/rveitch/84cea9650092119527bc), loosely. I'm not necessarily advocating that we adopt this pattern, but for the purposes of moving fast _right now_, might as well use something conventional.

These reset styles and mixins are a dependency of the pattern library CSS.

Part of #20 
