### PR TITLE
Add link color

### DIFF
--- a/styles/variables/_colors.scss
+++ b/styles/variables/_colors.scss
@@ -34,6 +34,7 @@ $grey-7: #202020;
 
 $brand: #bd1c2b;
 
+$link: $brand !default;
 $link-hover: #84141e !default;
 
 $focus-outline: #51a7e8;


### PR DESCRIPTION
This color variable is needed by reset SASS—I overlooked it when I swapped around the earlier PR (#32).