### PR TITLE
Add pattern-library source JS and SASS (Pattern Library 1/n)

### DIFF
--- a/src/pattern-library/.eslintrc
+++ b/src/pattern-library/.eslintrc
@@ -1,0 +1,8 @@
+{
+  "parserOptions": {
+    "sourceType": "module"
+  },
+  "rules": {
+    "react/prop-types": "off"
+  }
+}

--- a/src/pattern-library/components/PatternPage.js
+++ b/src/pattern-library/components/PatternPage.js
@@ -1,0 +1,137 @@
+import { toChildArray } from 'preact';
+
+import { jsxToString } from '../util/jsx-to-string';
+
+/**
+ * Components to render patterns and examples. Typical structure of a "Demo"
+ * page might be:
+ *
+ * <PatternPage title="Zoo Animals">
+ *   <Pattern title="Elephant">
+ *     <p>Everyone loves an elephant.</p>
+ *
+ *     <PatternExamples title="Colored elephants">
+ *       <PatternExample details="Pink elephant">
+ *          <Elephant color="pink" />
+ *       </PatternExample>
+ *       <PatternExample details="Blue elephant">
+ *          <Elephant color="blue" />
+ *       </PatternExample>
+ *     </PatternExamples>
+ *
+ *     <PatternExamples title="Patterned elephants">
+ *       <PatternExample details="Spotted elephant">
+ *          <Elephant variant="spotted" />
+ *       </PatternExample>
+ *     </PatternExamples>
+ *   </Pattern>
+ *
+ *   <Pattern title="Monkeys">
+ *     <PatternExamples>
+ *       <PatternExample details="Your basic monkey">
+ *         <Monkey />
+ *       </PatternExample>
+ *     </PatternExamples>
+ *   </Pattern>
+ * </PatternPage>
+ */
+
+/**
+ * @typedef PatternPageProps
+ * @prop {import("preact").ComponentChildren} children
+ * @prop {string} title
+ */
+
+/**
+ * Render a page of patterns
+ * @param {PatternPageProps} props
+ */
+export function PatternPage({ children, title }) {
+  return (
+    <section className="PatternPage">
+      <h1>{title}</h1>
+      <div className="PatternPage__content">{children}</div>
+    </section>
+  );
+}
+
+/**
+ * @typedef PatternProps
+ * @prop {import("preact").ComponentChildren} children
+ * @prop {string} title
+ */
+
+/**
+ * A pattern and its examples
+ * @param {PatternProps} props
+ */
+export function Pattern({ children, title }) {
+  return (
+    <section className="Pattern">
+      <h2>{title}</h2>
+      {children}
+    </section>
+  );
+}
+
+/**
+ * @typedef PatternExamplesProps
+ * @prop {import("preact").ComponentChildren} children
+ * @prop {string} [title]
+ */
+
+/**
+ * Tabular layout of one or more `PatternExample` components, with optional
+ * title.
+ *
+ * @param {PatternExamplesProps} props
+ */
+export function PatternExamples({ children }) {
+  return (
+    <table className="PatternExamples">
+      <tr>
+        <th>Example</th>
+        <th>Details</th>
+        <th>Source</th>
+      </tr>
+      {children}
+    </table>
+  );
+}
+
+/**
+ * @typedef PatternExampleProps
+ * @prop {import("preact").ComponentChildren} children - Example source
+ * @prop {string} details - Details about the pattern example
+ * @prop {Object} [style] - Optional additional inline styles to apply to the
+ *   table cell with the rendered example
+ */
+
+/**
+ * Tabular layout of a single example. Will render its `children` as the
+ * example, as well as the source JSX of its `children`
+ *
+ * @param {PatternExampleProps} props
+ */
+export function PatternExample({ children, details, style = {} }) {
+  const source = toChildArray(children).map((child, idx) => {
+    return (
+      <li key={idx}>
+        <code>
+          <pre>{jsxToString(child)}</pre>
+        </code>
+      </li>
+    );
+  });
+  return (
+    <tr>
+      <td style={style}>
+        <div className="PatternExample__example">{children}</div>
+      </td>
+      <td>{details}</td>
+      <td>
+        <ul>{source}</ul>
+      </td>
+    </tr>
+  );
+}

--- a/src/pattern-library/components/PlaygroundApp.js
+++ b/src/pattern-library/components/PlaygroundApp.js
@@ -1,0 +1,116 @@
+import { SvgIcon } from '../../components/SvgIcon';
+
+import SharedButtonPatterns from './patterns/SharedButtonPatterns';
+
+import { useRoute } from '../router';
+
+/**
+ * @typedef PlaygroundRoute - Route "handler" that provides a component (function)
+ *   that should be rendered for the indicated route
+ * @prop {RegExp|string} route - Pattern or string path relative to
+ *   `baseURL`, e.g. '/my-patterns'
+ * @prop {string} title
+ * @prop {import("preact").FunctionComponent<{}>} component
+ */
+
+function HomeRoute() {
+  return (
+    <>
+      <h1 className="heading">UI component playground</h1>
+      <p>Select a component to view examples.</p>
+    </>
+  );
+}
+
+/** @type {PlaygroundRoute[]} */
+const routes = [
+  {
+    route: /^\/?$/,
+    title: 'Home',
+    component: HomeRoute,
+  },
+  {
+    route: '/shared-buttons',
+    title: 'Buttons',
+    component: SharedButtonPatterns,
+  },
+];
+
+const demoRoutes = routes.filter(r => r.component !== HomeRoute);
+
+/**
+ * @typedef PlaygroundAppProps
+ * @prop {string} [baseURL]
+ * @prop {PlaygroundRoute[]} [extraRoutes] - Local-/application-specific routes
+ *   to add to this pattern library in addition to the shared/common routes
+ */
+
+/**
+ * Render web content for the playground application. This includes the "frame"
+ * around the page and a navigation channel, as well as the content rendered
+ * by the component handling the current route.
+ *
+ * @param {PlaygroundAppProps} props
+ */
+export default function PlaygroundApp({
+  baseURL = '/ui-playground',
+  extraRoutes = [],
+}) {
+  const allRoutes = routes.concat(extraRoutes);
+  const [route, navigate] = useRoute(baseURL, allRoutes);
+  const content = route ? (
+    <route.component />
+  ) : (
+    <>
+      <h1 className="heading">:(</h1>
+      <p>Page not found.</p>
+    </>
+  );
+
+  return (
+    <main className="PlaygroundApp">
+      <div className="PlaygroundApp__sidebar">
+        <div className="PlaygroundApp__sidebar-home">
+          <a href={baseURL} onClick={e => navigate(e, '/')}>
+            <SvgIcon name="logo" />
+          </a>
+        </div>
+        <h2>Common Patterns</h2>
+        <ul>
+          {demoRoutes.map(c => (
+            <li key={c.route}>
+              <a
+                className="PlaygroundApp__nav-link"
+                key={c.route}
+                href={/** @type string */ (c.route)}
+                onClick={e => navigate(e, c.route)}
+              >
+                {c.title}
+              </a>
+            </li>
+          ))}
+        </ul>
+        {extraRoutes.length > 0 && (
+          <>
+            <h2>Application Patterns</h2>
+            <ul>
+              {extraRoutes.map(c => (
+                <li key={c.route}>
+                  <a
+                    className="PlaygroundApp__nav-link"
+                    key={c.route}
+                    href={/** @type string */ (c.route)}
+                    onClick={e => navigate(e, c.route)}
+                  >
+                    {c.title}
+                  </a>
+                </li>
+              ))}
+            </ul>
+          </>
+        )}
+      </div>
+      <div className="PlaygroundApp__content">{content}</div>
+    </main>
+  );
+}

--- a/src/pattern-library/components/patterns/SharedButtonPatterns.js
+++ b/src/pattern-library/components/patterns/SharedButtonPatterns.js
@@ -1,0 +1,383 @@
+import { IconButton, LabeledButton, LinkButton } from '../../../';
+
+import {
+  PatternPage,
+  Pattern,
+  PatternExamples,
+  PatternExample,
+} from '../PatternPage';
+
+export default function SharedButtonPatterns() {
+  return (
+    <PatternPage title="Buttons">
+      <Pattern title="IconButton">
+        <p>A button containing an icon and no other content.</p>
+
+        <h3>Sizes</h3>
+        <p>
+          The optional <code>size</code> property affects the proportions and
+          overall size of the button by way of padding. It does not change the
+          size of the icon itself, which is sized at&nbsp;
+          <code>1em</code>. The default sizing is <code>medium</code>.
+        </p>
+        <PatternExamples>
+          <PatternExample details="Sizes: medium is default">
+            <IconButton icon="edit" title="Edit" size="small" />
+            <IconButton icon="edit" title="Edit" size="medium" />
+            <IconButton icon="edit" title="Edit" size="large" />
+          </PatternExample>
+        </PatternExamples>
+
+        <h3>Default variant</h3>
+        <PatternExamples>
+          <PatternExample details="Default state">
+            <IconButton icon="trash" title="Delete annotation" />
+          </PatternExample>
+
+          <PatternExample details="Pressed">
+            <IconButton icon="trash" title="Delete annotation" pressed />
+          </PatternExample>
+
+          <PatternExample details="Expanded">
+            <IconButton icon="trash" title="Delete annotation" expanded />
+          </PatternExample>
+
+          <PatternExample details="Disabled">
+            <IconButton icon="trash" title="Delete annotation" disabled />
+          </PatternExample>
+        </PatternExamples>
+
+        <h3>Primary variant</h3>
+        <PatternExamples>
+          <PatternExample details="Basic usage">
+            <IconButton icon="edit" title="Edit" variant="primary" />
+          </PatternExample>
+
+          <PatternExample details="Pressed">
+            <IconButton
+              icon="trash"
+              title="Delete annotation"
+              pressed
+              variant="primary"
+            />
+          </PatternExample>
+
+          <PatternExample details="Expanded">
+            <IconButton
+              icon="trash"
+              title="Delete annotation"
+              expanded
+              variant="primary"
+            />
+          </PatternExample>
+
+          <PatternExample details="Disabled">
+            <IconButton
+              icon="trash"
+              title="Delete annotation"
+              disabled
+              variant="primary"
+            />
+          </PatternExample>
+        </PatternExamples>
+
+        <h3>Light variant</h3>
+        <p>
+          This variant should only be used for non-critical icons on white
+          backgrounds (low contrast).
+        </p>
+        <PatternExamples>
+          <PatternExample
+            details="Basic usage"
+            style={{ backgroundColor: 'white' }}
+          >
+            <IconButton icon="collapsed" title="Edit" variant="light" />
+          </PatternExample>
+
+          <PatternExample
+            details="Pressed"
+            style={{ backgroundColor: 'white' }}
+          >
+            <IconButton
+              icon="collapsed"
+              title="Delete annotation"
+              pressed
+              variant="light"
+            />
+          </PatternExample>
+
+          <PatternExample
+            details="Expanded"
+            style={{ backgroundColor: 'white' }}
+          >
+            <IconButton
+              icon="collapsed"
+              title="Delete annotation"
+              expanded
+              variant="light"
+            />
+          </PatternExample>
+
+          <PatternExample
+            details="Disabled"
+            style={{ backgroundColor: 'white' }}
+          >
+            <IconButton
+              icon="collapsed"
+              title="Delete annotation"
+              disabled
+              variant="light"
+            />
+          </PatternExample>
+        </PatternExamples>
+      </Pattern>
+
+      <Pattern title="LabeledButton">
+        <p>A button with content and, optionally, an icon.</p>
+
+        <h3>Sizes</h3>
+        <p>
+          As with <code>IconButton</code>, sizing affects proportions and
+          overall size via padding.
+        </p>
+
+        <PatternExamples>
+          <PatternExample details="Label only">
+            <LabeledButton size="small">Edit</LabeledButton>
+            <LabeledButton>Edit</LabeledButton>
+            <LabeledButton size="large">Edit</LabeledButton>
+          </PatternExample>
+
+          <PatternExample details="Label and icon">
+            <LabeledButton icon="profile" size="small">
+              Edit User
+            </LabeledButton>
+            <LabeledButton icon="profile">Edit User</LabeledButton>
+            <LabeledButton icon="profile" size="large">
+              Edit User
+            </LabeledButton>
+          </PatternExample>
+
+          <PatternExample details="Label and icon: icon on right">
+            <LabeledButton icon="profile" size="small" iconPosition="right">
+              Edit User
+            </LabeledButton>
+            <LabeledButton icon="profile" iconPosition="right">
+              Edit User
+            </LabeledButton>
+            <LabeledButton icon="profile" size="large" iconPosition="right">
+              Edit User
+            </LabeledButton>
+          </PatternExample>
+        </PatternExamples>
+
+        <h3>Default variant</h3>
+
+        <PatternExamples>
+          <PatternExample details="Default state">
+            <LabeledButton>Edit</LabeledButton>
+            <LabeledButton icon="edit">Edit</LabeledButton>
+          </PatternExample>
+
+          <PatternExample details="Pressed">
+            <LabeledButton pressed>Edit</LabeledButton>
+            <LabeledButton icon="edit" pressed>
+              Edit
+            </LabeledButton>
+          </PatternExample>
+
+          <PatternExample details="Expanded">
+            <LabeledButton expanded>Edit</LabeledButton>
+            <LabeledButton icon="edit" expanded>
+              Edit
+            </LabeledButton>
+          </PatternExample>
+
+          <PatternExample details="Disabled">
+            <LabeledButton disabled>Edit</LabeledButton>
+            <LabeledButton icon="edit" disabled>
+              Edit
+            </LabeledButton>
+          </PatternExample>
+        </PatternExamples>
+
+        <h3>Primary variant</h3>
+
+        <PatternExamples>
+          <PatternExample details="Default state">
+            <LabeledButton variant="primary">Edit user</LabeledButton>
+            <LabeledButton icon="profile" variant="primary">
+              Edit user
+            </LabeledButton>
+          </PatternExample>
+
+          <PatternExample details="Pressed">
+            <LabeledButton pressed variant="primary">
+              Edit user
+            </LabeledButton>
+            <LabeledButton icon="profile" pressed variant="primary">
+              Edit user
+            </LabeledButton>
+          </PatternExample>
+
+          <PatternExample details="Expanded">
+            <LabeledButton expanded variant="primary">
+              Edit user
+            </LabeledButton>
+            <LabeledButton icon="profile" expanded variant="primary">
+              Edit user
+            </LabeledButton>
+          </PatternExample>
+
+          <PatternExample details="Disabled">
+            <LabeledButton disabled variant="primary">
+              Edit user
+            </LabeledButton>
+            <LabeledButton icon="profile" disabled variant="primary">
+              Edit user
+            </LabeledButton>
+          </PatternExample>
+        </PatternExamples>
+
+        <h3>Dark variant</h3>
+
+        <p>Intended for use on non-white, very light grey backgrounds.</p>
+        <PatternExamples>
+          <PatternExample
+            details="Default state"
+            style={{ backgroundColor: '#ececec' }}
+          >
+            <LabeledButton variant="dark">Buy ice cream</LabeledButton>
+            <LabeledButton icon="trash" variant="dark">
+              Buy ice cream
+            </LabeledButton>
+          </PatternExample>
+
+          <PatternExample
+            details="Pressed"
+            style={{ backgroundColor: '#ececec' }}
+          >
+            <LabeledButton pressed variant="dark">
+              Buy ice cream
+            </LabeledButton>
+            <LabeledButton icon="trash" pressed variant="dark">
+              Buy ice cream
+            </LabeledButton>
+          </PatternExample>
+
+          <PatternExample
+            details="Expanded"
+            style={{ backgroundColor: '#ececec' }}
+          >
+            <LabeledButton expanded variant="dark">
+              Buy ice cream
+            </LabeledButton>
+            <LabeledButton expanded icon="edit" variant="dark">
+              Buy ice cream
+            </LabeledButton>
+          </PatternExample>
+
+          <PatternExample
+            details="Disabled"
+            style={{ backgroundColor: '#ececec' }}
+          >
+            <LabeledButton disabled variant="dark">
+              Buy ice cream
+            </LabeledButton>
+            <LabeledButton disabled icon="edit" variant="dark">
+              Buy ice cream
+            </LabeledButton>
+          </PatternExample>
+        </PatternExamples>
+      </Pattern>
+
+      <Pattern title="LinkButton">
+        <p>A button styled to look like a link (anchor tag).</p>
+
+        <h3>Default variant</h3>
+        <PatternExamples>
+          <PatternExample details="Basic usage">
+            <LinkButton>Show replies (10)</LinkButton>
+          </PatternExample>
+
+          <PatternExample details="Pressed">
+            <LinkButton pressed>Show replies (10)</LinkButton>
+          </PatternExample>
+
+          <PatternExample details="Expanded">
+            <LinkButton expanded>Show replies (10)</LinkButton>
+          </PatternExample>
+
+          <PatternExample details="Disabled">
+            <LinkButton disabled>Show replies (10)</LinkButton>
+          </PatternExample>
+        </PatternExamples>
+
+        <h3>Primary variant</h3>
+
+        <PatternExamples>
+          <PatternExample details="Basic usage">
+            <LinkButton variant="primary">Show replies (10)</LinkButton>
+          </PatternExample>
+
+          <PatternExample details="Pressed">
+            <LinkButton pressed variant="primary">
+              Show replies (10)
+            </LinkButton>
+          </PatternExample>
+
+          <PatternExample details="Expanded">
+            <LinkButton expanded variant="primary">
+              Show replies (10)
+            </LinkButton>
+          </PatternExample>
+
+          <PatternExample details="Disabled">
+            <LinkButton disabled variant="primary">
+              Show replies (10)
+            </LinkButton>
+          </PatternExample>
+        </PatternExamples>
+
+        <h3>Dark variant</h3>
+        <p>For use on light grey (non-white) backgrounds.</p>
+
+        <PatternExamples>
+          <PatternExample
+            details="Basic usage"
+            style={{ backgroundColor: '#ececec' }}
+          >
+            <LinkButton variant="dark">Show replies (10)</LinkButton>
+          </PatternExample>
+
+          <PatternExample
+            details="Pressed"
+            style={{ backgroundColor: '#ececec' }}
+          >
+            <LinkButton pressed variant="dark">
+              Show replies (10)
+            </LinkButton>
+          </PatternExample>
+
+          <PatternExample
+            details="Expanded"
+            style={{ backgroundColor: '#ececec' }}
+          >
+            <LinkButton expanded variant="dark">
+              Show replies (10)
+            </LinkButton>
+          </PatternExample>
+
+          <PatternExample
+            details="Disabled"
+            style={{ backgroundColor: '#ececec' }}
+          >
+            <LinkButton disabled variant="dark">
+              Show replies (10)
+            </LinkButton>
+          </PatternExample>
+        </PatternExamples>
+      </Pattern>
+    </PatternPage>
+  );
+}

--- a/src/pattern-library/router.js
+++ b/src/pattern-library/router.js
@@ -1,0 +1,36 @@
+import { useEffect, useMemo, useState } from 'preact/hooks';
+
+function routeFromCurrentURL(baseURL) {
+  return location.pathname.slice(baseURL.length);
+}
+
+export function useRoute(baseURL, routes) {
+  const [route, setRoute] = useState(() => routeFromCurrentURL(baseURL));
+  const routeData = useMemo(() => routes.find(r => route.match(r.route)), [
+    route,
+    routes,
+  ]);
+  const title = `${routeData.title}: Hypothesis UI playground`;
+
+  useEffect(() => {
+    document.title = title;
+  }, [title]);
+
+  useEffect(() => {
+    const popstateListener = () => {
+      setRoute(routeFromCurrentURL(baseURL));
+    };
+    window.addEventListener('popstate', popstateListener);
+    return () => {
+      window.removeEventListener('popstate', popstateListener);
+    };
+  }, [baseURL]);
+
+  const navigate = (event, route) => {
+    event.preventDefault();
+    history.pushState({}, title, baseURL + route);
+    setRoute(route);
+  };
+
+  return [routeData, navigate];
+}

--- a/src/pattern-library/util/jsx-to-string.js
+++ b/src/pattern-library/util/jsx-to-string.js
@@ -1,0 +1,93 @@
+/**
+ * Escape `str` for use in a "-quoted string.
+ *
+ * @param {string} str
+ */
+function escapeQuotes(str) {
+  return str.replace(/"/g, '\\"');
+}
+
+function componentName(type) {
+  if (typeof type === 'string') {
+    return type;
+  } else {
+    return type.displayName || type.name;
+  }
+}
+
+/**
+ * Indent a multi-line string by `indent` spaces.
+ *
+ * @param {string} str
+ * @param {number} indent
+ */
+function indentLines(str, indent) {
+  const indentStr = ' '.repeat(indent);
+  const lines = str.split('\n');
+  return lines.map(line => indentStr + line).join('\n');
+}
+
+/**
+ * Render a JSX expression as a code string.
+ *
+ * Currently this only supports serializing props with simple types (strings,
+ * booleans, numbers).
+ *
+ * @example
+ *   jsxToString(<Widget expanded={true} label="Thing"/>) // returns `<Widget expanded label="Thing"/>`
+ *
+ * @param {import('preact').ComponentChildren} vnode
+ * @return {string}
+ */
+export function jsxToString(vnode) {
+  if (
+    typeof vnode === 'string' ||
+    typeof vnode === 'number' ||
+    typeof vnode === 'bigint'
+  ) {
+    return vnode.toString();
+  } else if (typeof vnode === 'boolean') {
+    return '';
+  } else if (vnode && 'type' in vnode) {
+    const name = componentName(vnode.type);
+
+    // nb. The special `key` and `ref` props are not included in `vnode.props`.
+    // `ref` is not serializable to a string and `key` is generally set dynamically
+    // (eg. from an index or item ID) so it doesn't make sense to include it either.
+    let propStr = Object.entries(vnode.props)
+      .map(([name, value]) => {
+        if (name === 'children') {
+          return '';
+        }
+
+        // Boolean props are assumed to default to `false`, in which case they
+        // can be omitted.
+        if (typeof value === 'boolean') {
+          return value ? name : '';
+        }
+
+        const valueStr =
+          typeof value === 'string' ? `"${escapeQuotes(value)}"` : `{${value}}`;
+        return `${name}=${valueStr}`;
+      })
+      .join(' ')
+      .trim();
+    if (propStr.length > 0) {
+      propStr = ' ' + propStr;
+    }
+
+    const children = vnode.props.children;
+    if (children) {
+      let childrenStr = Array.isArray(children)
+        ? children.map(jsxToString).join('\n')
+        : jsxToString(children);
+      childrenStr = indentLines(childrenStr, 2);
+      return `<${name}${propStr}>\n${childrenStr}\n</${name}>`;
+    } else {
+      // No children - use a self-closing tag.
+      return `<${name}${propStr} />`;
+    }
+  } else {
+    return '';
+  }
+}

--- a/styles/pattern-library.scss
+++ b/styles/pattern-library.scss
@@ -1,0 +1,167 @@
+@use 'base/reset';
+@use 'base/elements';
+@use 'variables' as var;
+
+// Include component styles
+@use 'index';
+
+body {
+  font-size: 100%;
+}
+
+h1 {
+  font-size: 1.75em;
+  font-weight: bold;
+}
+
+h2 {
+  font-size: 1.25em;
+  width: 100%;
+  border-left: 6px solid var.$color-brand;
+  font-weight: bold;
+  padding-left: 0.5em;
+}
+
+h3 {
+  font-size: 1.125em;
+  font-weight: normal;
+  font-style: italic;
+  margin: 1em 0;
+}
+
+h4 {
+  font-size: 1em;
+  font-weight: 500;
+  font-style: italic;
+}
+
+pre {
+  margin: 0;
+}
+
+// Utilities
+.u-center {
+  align-self: center;
+}
+
+// Component styles
+.PlaygroundApp {
+  display: grid;
+  grid-template-areas:
+    'navigation'
+    'content';
+
+  &__content {
+    padding: 1em;
+  }
+
+  &__sidebar {
+    grid-area: 'navigation';
+    max-height: 20em;
+    overflow: scroll;
+    background-color: var.$color-grey-2;
+  }
+
+  &__sidebar-home {
+    text-align: center;
+    padding: 1em;
+  }
+
+  &__content {
+    grid-area: 'content';
+  }
+}
+
+.PlaygroundApp__nav-link {
+  width: 100%;
+  padding: 1em;
+  font-size: 16px; // TODO: variable later
+  border-left: 5px solid transparent;
+  &:hover {
+    background-color: var.$color-grey-3;
+  }
+}
+
+.PatternPage {
+  font-size: 14px;
+
+  &__content {
+    padding: 2em 0;
+  }
+}
+
+.Pattern {
+  margin: 0 0 4em 1em;
+  p {
+    margin: 1em;
+    margin-left: 0;
+  }
+
+  & > p:first-of-type {
+    font-size: 125%;
+  }
+
+  h2 {
+    margin-left: -1em;
+  }
+}
+
+.PatternExamples {
+  border: 1px solid var.$color-grey-3;
+  border-collapse: collapse;
+  width: 100%;
+  margin-top: 1em;
+  margin-bottom: 2em;
+
+  th,
+  td {
+    padding: 0.5em;
+  }
+
+  th {
+    background-color: var.$color-grey-1;
+    border-bottom: 1px solid var.$color-grey-3;
+    text-align: left;
+  }
+
+  td {
+    padding-top: 10px;
+    padding-bottom: 10px;
+  }
+
+  tr:nth-child(even) {
+    background: var.$color-grey-0;
+  }
+
+  code {
+    color: var.$color-grey-mid;
+  }
+}
+
+.PatternExample {
+  &__example {
+    display: flex;
+    align-items: center;
+    & > * + * {
+      margin-left: 1em;
+    }
+  }
+}
+
+// Element styles
+body {
+  font-family: sans-serif;
+}
+
+@media screen and (min-width: 60em) {
+  .PlaygroundApp {
+    height: 100vh;
+    grid-template-columns: 20em auto;
+    column-gap: 1em;
+    grid-template-areas: 'navigation content';
+
+    &__sidebar {
+      max-height: none;
+    }
+  }
+}


### PR DESCRIPTION
To make #36 more human-manageable, this PR breaks off a chunk of it that is simply (yeah, I said _simply_) copying over components, JS source, and SASS source from the `client` repo. The only changes from what exists now in the `client` are some paths.

The JS and SASS will be included in the published package.

Part of #20 