### PR TITLE
Add Checkbox component and patterns

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "enzyme": "^3.8.0",
     "enzyme-adapter-preact-pure": "^3.0.0",
     "eslint": "^7.3.1",
-    "eslint-config-hypothesis": "^2.4.0",
+    "eslint-config-hypothesis": "^2.5.0",
     "eslint-plugin-jsx-a11y": "^6.2.3",
     "eslint-plugin-mocha": "^8.0.0",
     "eslint-plugin-react": "^7.12.4",

--- a/src/components/Checkbox.js
+++ b/src/components/Checkbox.js
@@ -1,16 +1,25 @@
 /**
  * @typedef CheckboxBaseProps
  * @prop {string} name - The `name` of the checkbox.
- * @prop {import('preact').Ref<HTMLInputElement>} [inputRef]
+ * @prop {import('preact').Ref<HTMLInputElement>} [inputRef] - Access to the input
+ *    element in case a parent element wants for example to focus on it.
  * @prop {(checked: boolean) => void} [onToggle] - Callback when checkbox is
  *   checked/unchecked
  * @prop {never} [type] - Type is always 'checkbox'
  * @prop {never} [children] - Children are not allowed
  *
- * @typedef {Omit<import('Preact').JSX.HTMLAttributes<HTMLInputElement>, 'onToggle'> & CheckboxBaseProps} CheckboxProps
+ * The props for Checkbox component extends and narrows the attributes of the native input element.
+ * `onToggle` event should only be associated to HTMLDetailsElement, but Preact is not very strict with types.
+ * We omit the `onToggle` because it clashes with our definition.
+ * @typedef {Omit<import('preact').JSX.HTMLAttributes<HTMLInputElement>, 'onToggle'> & CheckboxBaseProps} CheckboxProps
+ */
+
+/**
+ * @typedef LabeledCheckboxBaseProps
+ * @prop {import('preact').ComponentChildren} children - Label text or elements
+ * @prop {'before'|'after'} [position] - Position the label before or after the checkbox. Defaults to 'before'.
  *
- * @typedef LabeledCheckboxProps
- * @prop {string} label - Label text
+ * @typedef {Omit<CheckboxProps, 'children'> & LabeledCheckboxBaseProps} LabeledCheckboxProps
  */
 
 /**
@@ -20,7 +29,7 @@
  */
 export function Checkbox({ inputRef, onToggle, onClick, ...restProps }) {
   /**
-   * @param {import('Preact').JSX.TargetedMouseEvent<HTMLInputElement>} event
+   * @param {import('preact').JSX.TargetedMouseEvent<HTMLInputElement>} event
    * @this HTMLInputElement
    */
   function onPressed(event) {
@@ -39,14 +48,20 @@ export function Checkbox({ inputRef, onToggle, onClick, ...restProps }) {
 /**
  * A labeled checkbox input
  *
- * @param {CheckboxProps & LabeledCheckboxProps} props
+ * @param {LabeledCheckboxProps} props
  */
-export function LabeledCheckbox({ label, id, ...restProps }) {
+export function LabeledCheckbox({
+  children,
+  position = 'before',
+  id,
+  ...restProps
+}) {
   id ??= restProps.name;
   return (
     <>
-      <label htmlFor={id}>{label}</label>
+      {position === 'before' && <label htmlFor={id}>{children}</label>}
       <Checkbox id={id} {...restProps} />
+      {position === 'after' && <label htmlFor={id}>{children}</label>}
     </>
   );
 }

--- a/src/components/Checkbox.js
+++ b/src/components/Checkbox.js
@@ -1,0 +1,58 @@
+import { useEffect, useRef, useState } from 'preact/hooks';
+
+const noop = () => {};
+
+/**
+ * @typedef CheckboxProps
+ * @prop {boolean} [defaultChecked] - Should the checkbox be selected/checked
+ *  by default?
+ * @prop {string} name - The `name` of the checkbox. Will be used as `id` if
+ *   `id` not provided
+ * @prop {string} [id] - HTML ID for the checkbox element
+ * @prop {string} label - Checkbox label
+ * @prop {(checked: boolean) => any} [onChanged] - Callback when checkbox is
+ *   checked/unchecked
+ */
+
+/**
+ * A checkbox input
+ *
+ * @param {CheckboxProps} props
+ */
+export function Checkbox({
+  defaultChecked = false,
+  id,
+  name,
+  label,
+  onChanged,
+}) {
+  let [isChecked, setChecked] = useState(defaultChecked);
+  onChanged = onChanged ?? noop;
+  id = id ?? name;
+
+  const wasChecked = useRef(isChecked);
+  useEffect(() => {
+    if (wasChecked.current !== isChecked && typeof onChanged === 'function') {
+      wasChecked.current = isChecked;
+      onChanged(isChecked);
+    }
+  }, [isChecked, onChanged]);
+
+  function onChange(event) {
+    const isChecked = event.target.checked;
+    setChecked(isChecked);
+  }
+
+  return (
+    <>
+      <input
+        type="checkbox"
+        id={id}
+        name={name}
+        checked={isChecked}
+        onChange={e => onChange(e)}
+      />
+      <label htmlFor={id}>{label}</label>
+    </>
+  );
+}

--- a/src/components/Checkbox.js
+++ b/src/components/Checkbox.js
@@ -52,7 +52,7 @@ export function Checkbox({ inputRef, onToggle, onClick, ...restProps }) {
  */
 export function LabeledCheckbox({
   children,
-  position = 'before',
+  position = 'after',
   id,
   ...restProps
 }) {

--- a/src/components/test/Checkbox-test.js
+++ b/src/components/test/Checkbox-test.js
@@ -9,7 +9,7 @@ describe('Checkbox', () => {
     return mount(<Checkbox name="my-checkbox" {...props} />);
   }
 
-  it('inputRef points to the input element', () => {
+  it('passes along a `ref` to the input element through `inputRef`', () => {
     const inputRef = {};
     createComponent({ inputRef });
     assert.isTrue(inputRef.current instanceof HTMLInputElement);
@@ -37,15 +37,16 @@ describe('LabeledCheckbox', () => {
     );
   }
 
-  it('contains a label after the input element (default position)', () => {
+  it('places the `label` element after the `input` element', () => {
     const inputRef = {};
+    // The default `position` prop is 'before'
     const wrapper = createComponent({ inputRef });
     const labelElement = wrapper.find('label');
     assert.equal(labelElement.text(), 'My Action');
     assert.equal(inputRef.current.nextElementSibling.tagName, 'LABEL');
   });
 
-  it('contains a label before the input element ', () => {
+  it('places the `label` element before the `input` element', () => {
     const inputRef = {};
     const wrapper = createComponent({ inputRef, position: 'before' });
     const labelElement = wrapper.find('label');
@@ -53,7 +54,7 @@ describe('LabeledCheckbox', () => {
     assert.equal(inputRef.current.previousElementSibling.tagName, 'LABEL');
   });
 
-  it('contains children element in the label', () => {
+  it('renders children in a `label` element', () => {
     const wrapper = createComponent({ children: <code>My Code</code> });
     const labelElement = wrapper.find('label');
     assert.isTrue(labelElement.find('code').exists());

--- a/src/components/test/Checkbox-test.js
+++ b/src/components/test/Checkbox-test.js
@@ -28,26 +28,29 @@ describe('Checkbox', () => {
 describe('LabeledCheckbox', () => {
   function createComponent(props = {}) {
     return mount(
-      <LabeledCheckbox name="my-checkbox" {...props}>
-        {props.children || 'My Action'}
-      </LabeledCheckbox>
+      <div>
+        {/** wrapped on a div to pass the a11y test */}
+        <LabeledCheckbox name="my-checkbox" {...props}>
+          {props.children || 'My Action'}
+        </LabeledCheckbox>
+      </div>
     );
   }
 
-  it('contains a label before the input element (default position)', () => {
+  it('contains a label after the input element (default position)', () => {
     const inputRef = {};
     const wrapper = createComponent({ inputRef });
     const labelElement = wrapper.find('label');
     assert.equal(labelElement.text(), 'My Action');
-    assert.equal(inputRef.current.previousElementSibling.tagName, 'LABEL');
+    assert.equal(inputRef.current.nextElementSibling.tagName, 'LABEL');
   });
 
-  it('contains a label after the input element', () => {
+  it('contains a label before the input element ', () => {
     const inputRef = {};
-    const wrapper = createComponent({ inputRef, position: 'after' });
+    const wrapper = createComponent({ inputRef, position: 'before' });
     const labelElement = wrapper.find('label');
     assert.equal(labelElement.text(), 'My Action');
-    assert.equal(inputRef.current.nextElementSibling.tagName, 'LABEL');
+    assert.equal(inputRef.current.previousElementSibling.tagName, 'LABEL');
   });
 
   it('contains children element in the label', () => {
@@ -65,8 +68,9 @@ describe('LabeledCheckbox', () => {
 
   it('uses the `name` as an `id` attr if no `id` provided', () => {
     const wrapper = createComponent();
-    const inputElement = wrapper.find('input').getDOMNode();
-    assert.equal(inputElement.id, wrapper.props().name);
+    const labeledCheckbox = wrapper.find('label');
+    const inputElement = wrapper.find('input');
+    assert.equal(inputElement.prop('id'), labeledCheckbox.prop('htmlFor'));
   });
 
   it('uses provided `id` attr', () => {

--- a/src/components/test/Checkbox-test.js
+++ b/src/components/test/Checkbox-test.js
@@ -1,25 +1,41 @@
 import { mount } from 'enzyme';
-import { act } from 'preact/test-utils';
 
 import { checkAccessibility } from '../../../test/util/accessibility';
 
-import { Checkbox } from '../Checkbox';
+import { LabeledCheckbox, Checkbox } from '../Checkbox';
 
 describe('Checkbox', () => {
   function createComponent(props = {}) {
-    return mount(<Checkbox name="my-checkbox" label="My Action" {...props} />);
+    return mount(<Checkbox name="my-checkbox" {...props} />);
+  }
+
+  it('inputRef points to the input element', () => {
+    const inputRef = {};
+    createComponent({ inputRef });
+    assert.isTrue(inputRef.current instanceof HTMLInputElement);
+  });
+
+  it('invokes onClick callback on click', () => {
+    const inputRef = {};
+    const onClick = sinon.stub();
+    createComponent({ inputRef, onClick });
+
+    inputRef.current.click();
+    assert.calledOnce(onClick);
+  });
+});
+
+describe('LabeledCheckbox', () => {
+  function createComponent(props = {}) {
+    return mount(
+      <LabeledCheckbox name="my-checkbox" label="My Action" {...props} />
+    );
   }
 
   it('does not check the checkbox by default', () => {
     const wrapper = createComponent();
-    const input = wrapper.find('input');
-    assert.isFalse(input.props().checked);
-  });
-
-  it('sets the checkbox to checked if `defaultChecked` is true', () => {
-    const wrapper = createComponent({ defaultChecked: true });
-    const input = wrapper.find('input');
-    assert.isTrue(input.props().checked);
+    const inputElement = wrapper.find('input').getDOMNode();
+    assert.isFalse(inputElement.checked);
   });
 
   it('uses the `name` as an `id` attr if no `id` provided', () => {
@@ -34,44 +50,25 @@ describe('Checkbox', () => {
     assert.equal(inputElement.id, 'much-needed-pretzel-snack');
   });
 
-  it('invokes callback on change', () => {
-    const onChanged = sinon.stub();
-    const wrapper = createComponent({ onChanged });
+  it('invokes onToggle callback on click', () => {
+    const onToggle = sinon.stub();
+    const wrapper = createComponent({ onToggle });
     const inputElement = wrapper.find('input').getDOMNode();
 
-    act(() => {
-      // We can't muck around with `target` in  `change` Event objects
-      // so we'll manually set the `checked` attr (this does not fire `change`)
-      inputElement.checked = true;
-      inputElement.dispatchEvent(new Event('change'));
-      // The `checked` attr hasn't changed since last `change` event, so
-      // this should not call the callback again
-      inputElement.dispatchEvent(new Event('change'));
-    });
+    inputElement.click();
 
-    assert.calledOnce(onChanged);
-    assert.calledWith(onChanged, true);
-    onChanged.reset();
+    assert.calledOnce(onToggle);
+    assert.calledWith(onToggle, true);
+    onToggle.reset();
 
-    act(() => {
-      inputElement.checked = false;
-      inputElement.dispatchEvent(new Event('change'));
-      inputElement.dispatchEvent(new Event('change'));
-    });
+    inputElement.click();
 
-    assert.calledOnce(onChanged);
-    assert.calledWith(onChanged, false);
-    onChanged.reset();
+    assert.calledOnce(onToggle);
+    assert.calledWith(onToggle, false);
+    onToggle.reset();
   });
 
-  // TODO: This fails, and I believe spuriously, on a no-explicit-label
-  // error. This component does render a <label> that by all squinting I can do
-  // appears to be correctly associated with the <input> This test can be made
-  // to pass by wrapping the entire <input> _inside_ the <label> (i.e. <label>
-  // as an outer element), or by putting the <label> before the <input>,
-  // but both mess up default browser layout and seem like they shouldn't
-  // be necessary.
-  it.skip(
+  it(
     'should pass a11y checks',
     checkAccessibility({
       content: () => createComponent({ id: 'whatever' }),

--- a/src/components/test/Checkbox-test.js
+++ b/src/components/test/Checkbox-test.js
@@ -1,0 +1,80 @@
+import { mount } from 'enzyme';
+import { act } from 'preact/test-utils';
+
+import { checkAccessibility } from '../../../test/util/accessibility';
+
+import { Checkbox } from '../Checkbox';
+
+describe('Checkbox', () => {
+  function createComponent(props = {}) {
+    return mount(<Checkbox name="my-checkbox" label="My Action" {...props} />);
+  }
+
+  it('does not check the checkbox by default', () => {
+    const wrapper = createComponent();
+    const input = wrapper.find('input');
+    assert.isFalse(input.props().checked);
+  });
+
+  it('sets the checkbox to checked if `defaultChecked` is true', () => {
+    const wrapper = createComponent({ defaultChecked: true });
+    const input = wrapper.find('input');
+    assert.isTrue(input.props().checked);
+  });
+
+  it('uses the `name` as an `id` attr if no `id` provided', () => {
+    const wrapper = createComponent();
+    const inputElement = wrapper.find('input').getDOMNode();
+    assert.equal(inputElement.id, wrapper.props().name);
+  });
+
+  it('uses provided `id` attr', () => {
+    const wrapper = createComponent({ id: 'much-needed-pretzel-snack' });
+    const inputElement = wrapper.find('input').getDOMNode();
+    assert.equal(inputElement.id, 'much-needed-pretzel-snack');
+  });
+
+  it('invokes callback on change', () => {
+    const onChanged = sinon.stub();
+    const wrapper = createComponent({ onChanged });
+    const inputElement = wrapper.find('input').getDOMNode();
+
+    act(() => {
+      // We can't muck around with `target` in  `change` Event objects
+      // so we'll manually set the `checked` attr (this does not fire `change`)
+      inputElement.checked = true;
+      inputElement.dispatchEvent(new Event('change'));
+      // The `checked` attr hasn't changed since last `change` event, so
+      // this should not call the callback again
+      inputElement.dispatchEvent(new Event('change'));
+    });
+
+    assert.calledOnce(onChanged);
+    assert.calledWith(onChanged, true);
+    onChanged.reset();
+
+    act(() => {
+      inputElement.checked = false;
+      inputElement.dispatchEvent(new Event('change'));
+      inputElement.dispatchEvent(new Event('change'));
+    });
+
+    assert.calledOnce(onChanged);
+    assert.calledWith(onChanged, false);
+    onChanged.reset();
+  });
+
+  // TODO: This fails, and I believe spuriously, on a no-explicit-label
+  // error. This component does render a <label> that by all squinting I can do
+  // appears to be correctly associated with the <input> This test can be made
+  // to pass by wrapping the entire <input> _inside_ the <label> (i.e. <label>
+  // as an outer element), or by putting the <label> before the <input>,
+  // but both mess up default browser layout and seem like they shouldn't
+  // be necessary.
+  it.skip(
+    'should pass a11y checks',
+    checkAccessibility({
+      content: () => createComponent({ id: 'whatever' }),
+    })
+  );
+});

--- a/src/components/test/Checkbox-test.js
+++ b/src/components/test/Checkbox-test.js
@@ -28,9 +28,34 @@ describe('Checkbox', () => {
 describe('LabeledCheckbox', () => {
   function createComponent(props = {}) {
     return mount(
-      <LabeledCheckbox name="my-checkbox" label="My Action" {...props} />
+      <LabeledCheckbox name="my-checkbox" {...props}>
+        {props.children || 'My Action'}
+      </LabeledCheckbox>
     );
   }
+
+  it('contains a label before the input element (default position)', () => {
+    const inputRef = {};
+    const wrapper = createComponent({ inputRef });
+    const labelElement = wrapper.find('label');
+    assert.equal(labelElement.text(), 'My Action');
+    assert.equal(inputRef.current.previousElementSibling.tagName, 'LABEL');
+  });
+
+  it('contains a label after the input element', () => {
+    const inputRef = {};
+    const wrapper = createComponent({ inputRef, position: 'after' });
+    const labelElement = wrapper.find('label');
+    assert.equal(labelElement.text(), 'My Action');
+    assert.equal(inputRef.current.nextElementSibling.tagName, 'LABEL');
+  });
+
+  it('contains children element in the label', () => {
+    const wrapper = createComponent({ children: <code>My Code</code> });
+    const labelElement = wrapper.find('label');
+    assert.isTrue(labelElement.find('code').exists());
+    assert.equal(labelElement.text(), 'My Code');
+  });
 
   it('does not check the checkbox by default', () => {
     const wrapper = createComponent();

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 // Components
+export { Checkbox } from './components/Checkbox';
 export { IconButton, LabeledButton, LinkButton } from './components/buttons';
 export { Panel } from './components/Panel';
 export { SvgIcon, registerIcons } from './components/SvgIcon';

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 // Components
-export { Checkbox } from './components/Checkbox';
+export { LabeledCheckbox, Checkbox } from './components/Checkbox';
 export { IconButton, LabeledButton, LinkButton } from './components/buttons';
 export { Panel } from './components/Panel';
 export { SvgIcon, registerIcons } from './components/SvgIcon';

--- a/src/pattern-library/components/PlaygroundApp.js
+++ b/src/pattern-library/components/PlaygroundApp.js
@@ -6,6 +6,7 @@ import SharedOrganismPatterns from './patterns/SharedOrganismPatterns';
 
 // Components
 import SharedButtonPatterns from './patterns/SharedButtonPatterns';
+import SharedFormPatterns from './patterns/SharedFormPatterns';
 import SharedPanelPatterns from './patterns/SharedPanelPatterns';
 
 import { useRoute } from '../router';
@@ -55,6 +56,11 @@ const componentRoutes = [
     route: '/shared-buttons',
     title: 'Buttons',
     component: SharedButtonPatterns,
+  },
+  {
+    route: '/shared-forms',
+    title: 'Forms',
+    component: SharedFormPatterns,
   },
   {
     route: '/shared-panel',

--- a/src/pattern-library/components/patterns/SharedFormPatterns.js
+++ b/src/pattern-library/components/patterns/SharedFormPatterns.js
@@ -1,10 +1,6 @@
-<<<<<<< HEAD
 import { useState } from 'preact/hooks';
 
 import { LabeledCheckbox } from '../../../';
-=======
-import { Checkbox } from '../../../';
->>>>>>> 5aca4b7 (Add `Checkbox` basic patterns to pattern library)
 
 import {
   PatternPage,
@@ -13,7 +9,6 @@ import {
   PatternExample,
 } from '../PatternPage';
 
-<<<<<<< HEAD
 export default function SharedFormPatterns() {
   const [wantSandwich, setWantSandwich] = useState(true);
   const [wantWatermelon, setWantWatermelon] = useState(false);
@@ -35,54 +30,15 @@ export default function SharedFormPatterns() {
               I want a sandwich
             </LabeledCheckbox>
           </PatternExample>
-          <PatternExample details="A custom label positioned after the checkbox">
+          <PatternExample details="A custom label positioned before the checkbox">
             <LabeledCheckbox
               checked={wantWatermelon}
               name="test-alternative"
-              position="after"
+              position="before"
               onToggle={setWantWatermelon}
             >
               <code>I want a watermelon</code>
             </LabeledCheckbox>
-=======
-function gimmeSandwich(isChecked) {
-  const visibility = isChecked ? 'visible' : 'hidden';
-  const elem = /** @type HTMLElement */ (document.querySelector(
-    '#showme-sandwich'
-  ));
-  if (elem) {
-    elem.style.visibility = visibility;
-  }
-}
-
-export default function SharedFormPatterns() {
-  return (
-    <PatternPage title="Forms">
-      <Pattern title="Checkbox">
-        <span
-          id="showme-sandwich"
-          role="img"
-          aria-label="seriously, just an emoji of sandwich"
-          style="font-size: 2em; visibility:hidden"
-        >
-          🥪
-        </span>
-        <PatternExamples>
-          <PatternExample details="A simple checkbox (Check me!)">
-            <Checkbox
-              label="I want a sandwich"
-              id="sandwich"
-              name="test"
-              onChanged={isChecked => gimmeSandwich(isChecked)}
-            />
-          </PatternExample>
-          <PatternExample details="A checkbox, defaulting to checked">
-            <Checkbox
-              label="I want a sandwich"
-              name="test"
-              defaultChecked={true}
-            />
->>>>>>> 5aca4b7 (Add `Checkbox` basic patterns to pattern library)
           </PatternExample>
         </PatternExamples>
       </Pattern>

--- a/src/pattern-library/components/patterns/SharedFormPatterns.js
+++ b/src/pattern-library/components/patterns/SharedFormPatterns.js
@@ -1,4 +1,6 @@
-import { Checkbox } from '../../../';
+import { useState } from 'preact/hooks';
+
+import { LabeledCheckbox } from '../../../';
 
 import {
   PatternPage,
@@ -7,42 +9,28 @@ import {
   PatternExample,
 } from '../PatternPage';
 
-function gimmeSandwich(isChecked) {
-  const visibility = isChecked ? 'visible' : 'hidden';
-  const elem = /** @type HTMLElement */ (document.querySelector(
-    '#showme-sandwich'
-  ));
-  if (elem) {
-    elem.style.visibility = visibility;
-  }
-}
-
 export default function SharedFormPatterns() {
+  const [show, setShow] = useState(true);
   return (
     <PatternPage title="Forms">
       <Pattern title="Checkbox">
         <span
-          id="showme-sandwich"
           role="img"
           aria-label="seriously, just an emoji of sandwich"
-          style="font-size: 2em; visibility:hidden"
+          style={{
+            fontSize: '2em',
+            visibility: show ? 'visible' : 'hidden',
+          }}
         >
           🥪
         </span>
         <PatternExamples>
-          <PatternExample details="A simple checkbox (Check me!)">
-            <Checkbox
-              label="I want a sandwich"
-              id="sandwich"
-              name="test"
-              onChanged={isChecked => gimmeSandwich(isChecked)}
-            />
-          </PatternExample>
           <PatternExample details="A checkbox, defaulting to checked">
-            <Checkbox
+            <LabeledCheckbox
               label="I want a sandwich"
               name="test"
-              defaultChecked={true}
+              checked={show}
+              onToggle={isChecked => setShow(isChecked)}
             />
           </PatternExample>
         </PatternExamples>

--- a/src/pattern-library/components/patterns/SharedFormPatterns.js
+++ b/src/pattern-library/components/patterns/SharedFormPatterns.js
@@ -1,6 +1,10 @@
+<<<<<<< HEAD
 import { useState } from 'preact/hooks';
 
 import { LabeledCheckbox } from '../../../';
+=======
+import { Checkbox } from '../../../';
+>>>>>>> 5aca4b7 (Add `Checkbox` basic patterns to pattern library)
 
 import {
   PatternPage,
@@ -9,6 +13,7 @@ import {
   PatternExample,
 } from '../PatternPage';
 
+<<<<<<< HEAD
 export default function SharedFormPatterns() {
   const [wantSandwich, setWantSandwich] = useState(true);
   const [wantWatermelon, setWantWatermelon] = useState(false);
@@ -39,6 +44,45 @@ export default function SharedFormPatterns() {
             >
               <code>I want a watermelon</code>
             </LabeledCheckbox>
+=======
+function gimmeSandwich(isChecked) {
+  const visibility = isChecked ? 'visible' : 'hidden';
+  const elem = /** @type HTMLElement */ (document.querySelector(
+    '#showme-sandwich'
+  ));
+  if (elem) {
+    elem.style.visibility = visibility;
+  }
+}
+
+export default function SharedFormPatterns() {
+  return (
+    <PatternPage title="Forms">
+      <Pattern title="Checkbox">
+        <span
+          id="showme-sandwich"
+          role="img"
+          aria-label="seriously, just an emoji of sandwich"
+          style="font-size: 2em; visibility:hidden"
+        >
+          🥪
+        </span>
+        <PatternExamples>
+          <PatternExample details="A simple checkbox (Check me!)">
+            <Checkbox
+              label="I want a sandwich"
+              id="sandwich"
+              name="test"
+              onChanged={isChecked => gimmeSandwich(isChecked)}
+            />
+          </PatternExample>
+          <PatternExample details="A checkbox, defaulting to checked">
+            <Checkbox
+              label="I want a sandwich"
+              name="test"
+              defaultChecked={true}
+            />
+>>>>>>> 5aca4b7 (Add `Checkbox` basic patterns to pattern library)
           </PatternExample>
         </PatternExamples>
       </Pattern>

--- a/src/pattern-library/components/patterns/SharedFormPatterns.js
+++ b/src/pattern-library/components/patterns/SharedFormPatterns.js
@@ -10,28 +10,35 @@ import {
 } from '../PatternPage';
 
 export default function SharedFormPatterns() {
-  const [show, setShow] = useState(true);
+  const [wantSandwich, setWantSandwich] = useState(true);
+  const [wantWatermelon, setWantWatermelon] = useState(false);
   return (
     <PatternPage title="Forms">
       <Pattern title="Checkbox">
-        <span
-          role="img"
-          aria-label="seriously, just an emoji of sandwich"
-          style={{
-            fontSize: '2em',
-            visibility: show ? 'visible' : 'hidden',
-          }}
-        >
-          🥪
-        </span>
+        <div style="font-size: 2em">
+          {wantSandwich && '🥪'}
+          {wantWatermelon && '🍉'}
+          &nbsp;
+        </div>
         <PatternExamples>
           <PatternExample details="A checkbox, defaulting to checked">
             <LabeledCheckbox
-              label="I want a sandwich"
               name="test"
-              checked={show}
-              onToggle={isChecked => setShow(isChecked)}
-            />
+              checked={wantSandwich}
+              onToggle={isChecked => setWantSandwich(isChecked)}
+            >
+              I want a sandwich
+            </LabeledCheckbox>
+          </PatternExample>
+          <PatternExample details="A custom label positioned after the checkbox">
+            <LabeledCheckbox
+              checked={wantWatermelon}
+              name="test-alternative"
+              position="after"
+              onToggle={setWantWatermelon}
+            >
+              <code>I want a watermelon</code>
+            </LabeledCheckbox>
           </PatternExample>
         </PatternExamples>
       </Pattern>

--- a/src/pattern-library/components/patterns/SharedFormPatterns.js
+++ b/src/pattern-library/components/patterns/SharedFormPatterns.js
@@ -1,0 +1,52 @@
+import { Checkbox } from '../../../';
+
+import {
+  PatternPage,
+  Pattern,
+  PatternExamples,
+  PatternExample,
+} from '../PatternPage';
+
+function gimmeSandwich(isChecked) {
+  const visibility = isChecked ? 'visible' : 'hidden';
+  const elem = /** @type HTMLElement */ (document.querySelector(
+    '#showme-sandwich'
+  ));
+  if (elem) {
+    elem.style.visibility = visibility;
+  }
+}
+
+export default function SharedFormPatterns() {
+  return (
+    <PatternPage title="Forms">
+      <Pattern title="Checkbox">
+        <span
+          id="showme-sandwich"
+          role="img"
+          aria-label="seriously, just an emoji of sandwich"
+          style="font-size: 2em; visibility:hidden"
+        >
+          🥪
+        </span>
+        <PatternExamples>
+          <PatternExample details="A simple checkbox (Check me!)">
+            <Checkbox
+              label="I want a sandwich"
+              id="sandwich"
+              name="test"
+              onChanged={isChecked => gimmeSandwich(isChecked)}
+            />
+          </PatternExample>
+          <PatternExample details="A checkbox, defaulting to checked">
+            <Checkbox
+              label="I want a sandwich"
+              name="test"
+              defaultChecked={true}
+            />
+          </PatternExample>
+        </PatternExamples>
+      </Pattern>
+    </PatternPage>
+  );
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2978,10 +2978,10 @@ escape-string-regexp@^1.0.5:
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
 
-eslint-config-hypothesis@^2.4.0:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-hypothesis/-/eslint-config-hypothesis-2.4.0.tgz"
-  integrity sha512-k2MXBLafvxqsDh+RBoTMvuFv9f8A/Dg6RJN6tI0KzHvIeGO/fV/VMkqBAKuWMAu2kcw+uH2DGsxGP00W2eX7OQ==
+eslint-config-hypothesis@^2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-hypothesis/-/eslint-config-hypothesis-2.5.0.tgz#bc9c281b07923666696c5df1c1f96f3cbace266b"
+  integrity sha512-3KiknU/zX117ggOhDetdbnqn+RupdIsp4XXl9kn8NICc/1ObVY3dt802L01A//ajCGHgiYu5/vR2afsuChlnhw==
 
 eslint-plugin-jsx-a11y@^6.2.3:
   version "6.4.1"


### PR DESCRIPTION
This PR adds a very basic `Checkbox` component, tests and some simple patterns in the pattern library.

~~Putting this in draft because of an issue with the `axe` a11y tests—failure on "no-explicit-label", which I believe to be possibly...wrong.~~ (Update: After discussion with team, we've decided to look at the test failure as a separate issue—I believe this component meets general a11y guidelines).

Aside:

I can make the a11y tests pass if:

* I wrap the `<input>` field in the `<label>` element, OR
* I put the `<label>` element before the `<input>` (source order)

This bugs me, because both break what is otherwise completely appropriate default styling in the browser. And I’m fairly sure there’s nothing wrong with the original markup (it follows MDN examples, for one thing, exactly). But maybe I have a thing or two to learn?

This task was good for dogfooding the new pattern-library setup and `frontend-shared` workflow. Seemed to go pretty well.

Oh, you'll note there's no actual _styling_. That's by, pun, design. I'm not sure yet if we want to impose any visual styling on our checkboxes just yet—we certainly can if we desire. In the case where this checkbox is to be used in the immediate future—the LMS assignment-configure interface—the interface we're modeling after doesn't style their checkboxes. So I've opted to start simple. But: world's our oyster.

## To see it

Pull this branch and run `make dev`; go here http://localhost:4001/ui-playground and look at the "Forms" patterns.

Part of https://github.com/hypothesis/frontend-shared/issues/26