### PR TITLE
Use latest ecmaVersion for eslint

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -6,5 +6,8 @@
     "react/react-in-jsx-scope": "off",
     // Replaced by TypeScript's static checking.
     "react/prop-types": "off"
+  },
+  "parserOptions": {
+    "ecmaVersion": 2021
   }
 }


### PR DESCRIPTION
I want support for the new feature in ECMAScript 2021, logical
assignments:
https://dev.to/faithfulojebiyi/new-features-in-ecmascript-2021-with-code-examples-302h#logical-assignment-operator