### PR TITLE
Add underlying `panel` pattern and supporting structure

### DIFF
--- a/src/pattern-library/components/patterns/SharedMoleculePatterns.js
+++ b/src/pattern-library/components/patterns/SharedMoleculePatterns.js
@@ -5,13 +5,74 @@ import {
   Pattern,
 } from '../PatternPage';
 
+import { IconButton, LabeledButton } from '../../../';
+
 export default function SharedMoleculePatterns() {
   return (
     <PatternPage title="Molecules">
       <Pattern title="Frame">
+        <p>
+          A <code>frame</code> has a border and a background, but no other
+          layout affordances.
+        </p>
         <PatternExamples>
-          <PatternExample details="A frame gives a border and a background but no other layout affordances">
+          <PatternExample details="basic frame">
             <div className="frame">This is in a frame.</div>
+          </PatternExample>
+        </PatternExamples>
+      </Pattern>
+
+      <Pattern title="Card">
+        <p>
+          A <code>card</code> is a frame with internal margins and padding, and
+          a hover effect.
+        </p>
+        <PatternExamples>
+          <PatternExample details="basic card">
+            <div className="card">This is in a card.</div>
+          </PatternExample>
+          <PatternExample details="a card with multiple child elements, showing default vertical rhythm">
+            <div className="card">
+              <div className="u-border">Child content in a card.</div>
+              <div className="u-border">Child content in a card.</div>
+              <div className="u-border">Child content in a card.</div>
+            </div>
+          </PatternExample>
+          <PatternExample details="A card with some actions">
+            <div className="card">
+              <div>
+                This is some text in a card that also contains some available
+                actions.
+              </div>
+              <div className="actions">
+                <IconButton title="User" icon="profile" />
+                <IconButton title="Edit" icon="edit" />
+                <IconButton title="Delete" icon="trash" />
+              </div>
+            </div>
+          </PatternExample>
+        </PatternExamples>
+      </Pattern>
+
+      <Pattern title="Actions">
+        <p>
+          The <code>actions</code> pattern presents a collection of actions
+          (typically buttons) spaced out in a row, aligned right.
+        </p>
+        <PatternExamples>
+          <PatternExample details="A set of LabeledButtons">
+            <div className="actions">
+              <LabeledButton icon="profile">User</LabeledButton>
+              <LabeledButton icon="edit">Edit</LabeledButton>
+              <LabeledButton icon="trash">Delete</LabeledButton>
+            </div>
+          </PatternExample>
+          <PatternExample details="A set of IconButtons">
+            <div className="actions">
+              <IconButton title="User" icon="profile" />
+              <IconButton title="Edit" icon="edit" />
+              <IconButton title="Delete" icon="trash" />
+            </div>
           </PatternExample>
         </PatternExamples>
       </Pattern>

--- a/src/pattern-library/components/patterns/SharedOrganismPatterns.js
+++ b/src/pattern-library/components/patterns/SharedOrganismPatterns.js
@@ -5,19 +5,79 @@ import {
   Pattern,
 } from '../PatternPage';
 
+import { IconButton, LabeledButton } from '../../../';
+
 export default function SharedOrganismPatterns() {
   return (
     <PatternPage title="Organisms">
-      <Pattern title="Card">
+      <Pattern title="Panel">
+        <p>
+          A panel is a card with a header and affordances for a close button.
+          Use the <code>--closeable</code> modifier when using{' '}
+          <code>panel</code> with an icon-only close button.
+        </p>
         <PatternExamples>
-          <PatternExample details="A card is a framed element with internal margins and padding, and a hover shadow effect">
-            <div className="card">This is in a card.</div>
+          <PatternExample
+            details="Panel with no header"
+            style={{ maxWidth: '400px' }}
+          >
+            <div className="panel">
+              This is in a panel that has no header. A header is not required,
+              but you are encouraged to use <code>card</code> in that case. Note
+              that a <code>panel</code> will currently fill all available space.
+              The containing element has been set to{' '}
+              <code>max-width: 400px</code> here.
+            </div>
           </PatternExample>
-          <PatternExample details="A card applies vertical rhythm to its immediate-child elements: borders added here to highlight this">
-            <div className="card">
-              <div className="u-border">Child content in a card.</div>
-              <div className="u-border">Child content in a card.</div>
-              <div className="u-border">Child content in a card.</div>
+          <PatternExample details="Panel with title but no close button">
+            <div className="panel">
+              <header>
+                <h2 className="panel__title">
+                  This is a panel title in a panel header
+                </h2>
+              </header>
+              <div>
+                This is panel content. There is a header but no close
+                affordance.
+              </div>
+            </div>
+          </PatternExample>
+
+          <PatternExample details="Closeable panel (using IconButton): preferred">
+            <div className="panel--closeable">
+              <header>
+                <h2 className="panel__title">
+                  Panel title on a closeable panel
+                </h2>
+                <div className="panel__close">
+                  <IconButton icon="cancel" title="Close" />
+                </div>
+              </header>
+              <div>
+                This is panel content in a panel, using <code>--closeable</code>
+                .
+              </div>
+            </div>
+          </PatternExample>
+
+          <PatternExample details="Panel with actions">
+            <div className="panel--closeable">
+              <header>
+                <h2 className="panel__title">Panel title</h2>
+                <div className="panel__close">
+                  <IconButton icon="cancel" title="Close" />
+                </div>
+              </header>
+              <div>
+                This is panel content in a panel that also has some available
+                actions.
+              </div>
+              <div className="actions">
+                <LabeledButton title="Cancel">Cancel</LabeledButton>
+                <LabeledButton title="Try again" variant="primary">
+                  Try again
+                </LabeledButton>
+              </div>
             </div>
           </PatternExample>
         </PatternExamples>

--- a/styles/mixins/_layout.scss
+++ b/styles/mixins/_layout.scss
@@ -1,6 +1,50 @@
 @use '../variables' as var;
 
-$-layout-space: var.$layout-space;
+$-space: var.$layout-space;
+
+/**
+ * Abstract mixin for establishing basic flex container. External users should
+ * use `row` or `column` as needed. Default values here reflect default CSS
+ * values for flex rules.
+ *
+ * @param {string} $direction [row] - value for flex-direction (row or column).
+ * @param {string} $justify [flex-start] - How to align contents on main axis.
+ *                                    Accepts and maps special value of 'right'
+ *                                   (roughly analogous to horizontal alignment)
+ * @param {string} $align [stretch] - How to align contents on cross axis.
+ *                                    (roughly analogous to vertical alignment)
+ */
+@mixin flex($direction: row, $justify: flex-start, $align: stretch) {
+  display: flex;
+  flex-direction: $direction;
+
+  @if $justify == right {
+    justify-content: flex-end;
+  } @else {
+    justify-content: $justify;
+  }
+  align-items: $align;
+}
+
+/**
+ * Establish a column (flex-direction: column) flex container.
+ *
+ * @param {string} $justify [flex-start] - How to justify flex contents
+ * @param {string} $align [stretch] - How to align flex contents
+ */
+@mixin column($justify: flex-start, $align: stretch) {
+  @include flex(column, $justify, $align);
+}
+
+/**
+ * Establish a row (flex-direction: column) flex container.
+ *
+ * @param {string} $justify [flex-start] - How to justify flex contents
+ * @param {string} $align [stretch] - How to align flex contents
+ */
+@mixin row($justify: flex-start, $align: stretch) {
+  @include flex(row, $justify, $align);
+}
 
 /**
  * Establish a vertical (margin) rhythm for this element's immediate
@@ -14,10 +58,27 @@ $-layout-space: var.$layout-space;
  * This mixin uses a "lobotomized owl" selector.
  * See https://css-tricks.com/lobotomized-owls/
  *
- * @param $size [$layout-space]: Spacing size (padding)
+ * @param $size [$-space]: Spacing size (padding)
  */
-@mixin vertical-rhythm($size: $-layout-space) {
+@mixin vertical-rhythm($size: $-space) {
   & > * + * {
     margin-top: $size !important;
+  }
+}
+
+/**
+ * Establish a horizontal (margin) rhythm for this element's immediate
+ * children (i.e. put equal space between children).
+ *
+ * This mixin uses `!important` such that it can compete with specificity
+ * of reset rules that set some of our element's margins to 0. That allows
+ * these rules—which are applied to a parent element—to be able to assert
+ * margins, as it should be able to do.
+ *
+ * @param $size [$-space * 0.5] - Size of horizontal margin between child elements
+ */
+@mixin horizontal-rhythm($size: $-space * 0.5) {
+  & > * + * {
+    margin-left: $size !important;
   }
 }

--- a/styles/mixins/_molecules.scss
+++ b/styles/mixins/_molecules.scss
@@ -1,9 +1,11 @@
 @use '../variables' as var;
 
 @use 'atoms';
+@use 'layout';
 
 $-border-radius: var.$border-radius;
 $-color-background: var.$color-background;
+$-space: var.$layout-space;
 
 /**
  * Patterns that are composites of multiple atomic utilities, but
@@ -29,4 +31,26 @@ $-color-background: var.$color-background;
       @include atoms.shadow($active: true);
     }
   }
+}
+
+/**
+ * An element with a frame, shadow, internal vertical rhythm and padding:
+ * serves as a container for card- and panel-like patterns.
+ */
+@mixin card {
+  @include frame($with-hover: true);
+  @include layout.vertical-rhythm;
+
+  width: 100%;
+  padding: $-space;
+
+  // TODO: Add clean-theme affordances
+}
+
+/**
+ * A container that lays out a collection of actions—typically buttons—in a single row.
+ */
+@mixin actions {
+  @include layout.row(right);
+  @include layout.horizontal-rhythm($-space * 0.75);
 }

--- a/styles/mixins/_organisms.scss
+++ b/styles/mixins/_organisms.scss
@@ -1,19 +1,53 @@
 @use '../variables' as var;
 
+@use 'atoms';
 @use 'layout';
 @use 'molecules';
 
-$-layout-space: var.$layout-space;
+$-color-brand: var.$color-brand;
+$-space: var.$layout-space;
 
 /**
- * An element with a frame, shadow, internal vertical rhythm and padding:
- * serves as a container for card- and panel-like patterns.
+ * A panel is a card that adds an optional header and/or close button positioning.
+ * Panels using an icon-only button as a close button should use the `--closeable`
+ * modifier.
  */
-@mixin card {
-  @include molecules.frame($with-hover: true);
-  @include layout.vertical-rhythm;
+@mixin panel {
+  @include molecules.card;
 
-  padding: $-layout-space;
+  & > header,
+  &__header {
+    @include layout.row($align: center);
+    @include atoms.border(bottom);
+    @include layout.horizontal-rhythm($-space);
+    padding-bottom: $-space;
+  }
 
-  // TODO: Add clean-theme affordances
+  &__title {
+    // TODO Replace with appropriate mixin once typography layer established
+    font-size: 1.1em;
+    color: $-color-brand;
+    font-weight: 600;
+    line-height: 1;
+    flex-grow: 1;
+  }
+
+  // When there is an icon-only close button, tighten up affordances around the
+  // header as the button will have more height than the heading text. This has the
+  // effect of making the vertical space around the header look more even.
+  &--closeable > header,
+  &--closeable &__header {
+    padding-bottom: $-space * 0.25;
+    margin-top: $-space * -0.5;
+  }
+
+  &--closeable > header &__close,
+  &--closeable > &__header &__close {
+    // TODO replace font-sizing with appropriate approach when typography layer
+    // available.
+    // This also right-aligns the edge of the close icon with the right edge
+    // of the bottom border using a negative right margin.
+    font-size: 1.375em;
+    margin-right: $-space * -0.75;
+  }
 }

--- a/styles/pattern-library.scss
+++ b/styles/pattern-library.scss
@@ -9,12 +9,14 @@ body {
   font-size: 100%;
 }
 
-h1 {
+.PlaygroundApp__sidebar h1,
+.PatternPage > h1 {
   font-size: 1.75em;
   font-weight: bold;
 }
 
-h2 {
+.PlaygroundApp__sidebar h2,
+.Pattern > h2 {
   font-size: 1.25em;
   width: 100%;
   border-left: 6px solid var.$color-brand;
@@ -101,7 +103,7 @@ pre {
     font-size: 125%;
   }
 
-  h2 {
+  & > h2 {
     margin-left: -1em;
   }
 }

--- a/styles/util/_layout.scss
+++ b/styles/util/_layout.scss
@@ -1,7 +1,23 @@
 @use '../mixins/layout';
 
-// Apply vertical rhythm (margins between immediate-child elements) at the
-// default rhythm-unit size
+// Apply vertical rhythm (top/bottom margins between immediate-child elements)
+// at the default rhythm-unit size
 .u-vertical-rhythm {
   @include layout.vertical-rhythm;
+}
+
+// Apply horizontal rhythm (left/right margins between immediate-child elements)
+// at the default horizontal-rhythm size
+.u-horizontal-rhythm {
+  @include layout.horizontal-rhythm;
+}
+
+// Establish a row flex container
+.u-layout-row {
+  @include layout.row;
+}
+
+// Establish a column flex container
+.u-layout-column {
+  @include layout.column;
 }

--- a/styles/util/_molecules.scss
+++ b/styles/util/_molecules.scss
@@ -7,3 +7,11 @@
 .frame {
   @include molecules.frame;
 }
+
+.card {
+  @include molecules.card;
+}
+
+.actions {
+  @include molecules.actions;
+}

--- a/styles/util/_organisms.scss
+++ b/styles/util/_organisms.scss
@@ -4,6 +4,26 @@
  * Utility classes for organism mixins
  */
 
-.card {
-  @include organisms.card;
+/**
+  * Usage:
+  * 1. Panel with title and no close button
+  * <div class="panel">
+  *  <header><h2 class="panel__title">Panel title</h2></header>
+  *  <div>This panel has no close button</div>
+  * </div>
+  *
+  * 2. Panel with title and close button
+  * <div className="panel--closeable">
+  *   <header>
+  *     <h2 class="panel__title">Panel title</h2>
+  *     <div class="panel__close">
+  *       <IconButton icon="cancel" title="Close" />
+  *     </div>
+  *   </header>
+  *   <div>This panel has an icon-only close button</div>
+  * </div>
+  */
+.panel,
+.panel--closeable {
+  @include organisms.panel;
 }

--- a/styles/variables/_layout.scss
+++ b/styles/variables/_layout.scss
@@ -1,8 +1,2 @@
 // Base rhythm units for layout and spacing (margins, padding)
 $space: 1rem;
-$space--xxs: $space * (1/4);
-$space--xs: $space * (1/2);
-$space--s: $space * (3/4);
-$space--m: $space;
-$space--l: $space * 2;
-$space--xl: $space * 4;


### PR DESCRIPTION
This PR adds a `panel` pattern (organism) and some supporting structure for it. This pattern will be used by upcoming shared `Panel` and `Dialog` components. This work extracts the visual styling implementation from the UI component implementation.

Most of the diff here is in the final commit, which updates the pattern-library pages for `panel` other molecule/organism patterns and shouldn't require close scrutiny.

## Additions

* `panel` organism mixin and utility styles. See the `Organisms` page in the local pattern library to review its purpose and constituent parts
* `actions` molecule mixin — we commonly lay out a series of buttons in a single row, generally aligned right. And we often call the container element `*__actions`. This extracts the pattern. See the `Molecules` page in the pattern library to review
* Copied over a handful of layout-related mixins and util classes from the `client` projects that were dependencies for the above

## Changes

* The `card` pattern is now a molecule instead of an organism. Expect to see things move around as we build this design system. It felt more like a molecule at second glance.
* The named spacing variables have been removed in favor of a single base-unit value: `var.$layout-space` that can be scaled (using standard multiplier math) in rules as needed. Expect that this may likely change in the future as we see how things feel. The named variants were problematic as the scale wasn't immediately evident based on the naming.
* Increased specificity on a few pattern-library CSS rules to avoid interference with patterns themselves. There is more to do here.

## To Review

Check out this branch, run `make dev` and visit the [Pattern Library](http://localhost:4001/ui-playground) _Molecules_ and _Organisms_ pages.

## What's next?

Implementation of `Panel` or `Dialog` component, with a possible interstitial step if an underlying additional styling pattern is needed for `Dialog`.