### PR TITLE
Add HTMLAttributes to button props

### DIFF
--- a/src/components/buttons.js
+++ b/src/components/buttons.js
@@ -5,22 +5,25 @@ import { SvgIcon } from './SvgIcon';
 /**
  * @typedef ButtonProps
  * @prop {import('preact').Ref<HTMLButtonElement>} [buttonRef]
- * @prop {import("preact").ComponentChildren} [children]
- * @prop {string} [className]
  * @prop {string} [icon] - Name of `SvgIcon` to render in the button
  * @prop {'left'|'right'} [iconPosition] - Icon positioned to left or to
  *   right of button text
- * @prop {boolean} [disabled]
  * @prop {boolean} [expanded] - Is the element associated with this button
  *   expanded (set `aria-expanded`)
  * @prop {boolean} [pressed] - Is this button currently "active?" (set
  *   `aria-pressed`)
- * @prop {(event: Event) => void} [onClick]
  * @prop {'small'|'medium'|'large'} [size='medium'] - Relative button size:
  *   affects padding
- * @prop {Object} [style] - Optional inline styles
  * @prop {string} [title] - Button title; used for `aria-label` attribute
  * @prop {'normal'|'primary'|'light'|'dark'} [variant='normal'] - For styling: element variant
+ */
+
+/**
+ * Fold in HTML button prop definitions into ButtonProps, but ignore `size` because it's inherited
+ * from HTMLElement and conflicts with the _ButtonProps.size prop above.
+ *
+ * @typedef {Omit<import('Preact').JSX.HTMLAttributes<HTMLButtonElement>, 'size'> } HTMLButtonElementProps
+ * @typedef {ButtonProps & HTMLButtonElementProps} ButtonBaseProps
  */
 
 /**
@@ -31,11 +34,11 @@ import { SvgIcon } from './SvgIcon';
  */
 
 /**
- * @typedef {ButtonProps & IconButtonBaseProps} IconButtonProps
+ * @typedef {ButtonBaseProps & IconButtonBaseProps} IconButtonProps
  */
 
 /**
- * @param {ButtonProps} props
+ * @param {ButtonBaseProps} props
  */
 function ButtonBase({
   buttonRef,
@@ -85,7 +88,7 @@ export function IconButton({ className = 'IconButton', ...restProps }) {
 /**
  * A labeled button, with or without an icon
  *
- * @param {ButtonProps} props
+ * @param {ButtonBaseProps} props
  */
 export function LabeledButton({
   children,
@@ -105,7 +108,7 @@ export function LabeledButton({
 /**
  * A button styled to appear as an HTML link (<a>)
  *
- * @param {ButtonProps} props
+ * @param {ButtonBaseProps} props
  */
 export function LinkButton(props) {
   return <ButtonBase className="LinkButton" {...props} />;


### PR DESCRIPTION
The button should be able to set the `type` prop . Otherwise it defaults to "submit" and will submit any form that embeds it. `type` is a native prop on button and so it makes sense to just inherit the actual types from button from Preact. In doing so, we can remove some redundant props and replace them with HTMLInputElement props.

`size` is the one prop that conflicts because of the way Preact constructs HTMLInputElement--which is derived from HTMLElement and inherits the `size` prop even though it's not relevant for button. The simple fix is to omit `size` when pulling in HTMLInputElement.


This change will require adding type to each button so thats something we need to consider. One alternative could be to override type as optional and pass a default.