### PR TITLE
Reduce selector insanity on `panel` pattern

### DIFF
--- a/src/pattern-library/components/patterns/SharedOrganismPatterns.js
+++ b/src/pattern-library/components/patterns/SharedOrganismPatterns.js
@@ -44,7 +44,7 @@ export default function SharedOrganismPatterns() {
           </PatternExample>
 
           <PatternExample details="Closeable panel (using IconButton): preferred">
-            <div className="panel--closeable">
+            <div className="panel panel--closeable">
               <header>
                 <h2 className="panel__title">
                   Panel title on a closeable panel
@@ -61,7 +61,7 @@ export default function SharedOrganismPatterns() {
           </PatternExample>
 
           <PatternExample details="Panel with actions">
-            <div className="panel--closeable">
+            <div className="panel panel--closeable">
               <header>
                 <h2 className="panel__title">Panel title</h2>
                 <div className="panel__close">

--- a/styles/util/_organisms.scss
+++ b/styles/util/_organisms.scss
@@ -13,7 +13,7 @@
   * </div>
   *
   * 2. Panel with title and close button
-  * <div className="panel--closeable">
+  * <div className="panel panel--closeable">
   *   <header>
   *     <h2 class="panel__title">Panel title</h2>
   *     <div class="panel__close">
@@ -23,7 +23,6 @@
   *   <div>This panel has an icon-only close button</div>
   * </div>
   */
-.panel,
-.panel--closeable {
+.panel {
   @include organisms.panel;
 }


### PR DESCRIPTION
I realized today that the new implementation of the `panel` pattern in SASS caused a whole glut of selectors to be generated for certain sub-elements in `panel`s. To wit, before:

<img width="467" alt="Screen Shot 2021-05-10 at 4 06 06 PM" src="https://user-images.githubusercontent.com/439947/117718671-63b07f00-b1aa-11eb-971b-ec8567247135.png">

and after:

<img width="447" alt="Screen Shot 2021-05-10 at 4 08 04 PM" src="https://user-images.githubusercontent.com/439947/117718702-6b702380-b1aa-11eb-99bf-e1f3e9e6e26d.png">

Usage change (this isn't used anywhere else, so the change won't affect anything):

Before:

`<div className="panel--closeable"> ... </div>`

After:

`<div className="panel panel--closeable"> ...</div>`

Examples are updated accordingly.