### PR TITLE
Prettify one of the example of the LabeledCheckbox

### DIFF
--- a/src/pattern-library/components/patterns/FormPatterns.js
+++ b/src/pattern-library/components/patterns/FormPatterns.js
@@ -35,7 +35,7 @@ export default function FormPatterns() {
               checked={wantWatermelon}
               name="test-alternative"
               position="before"
-              onToggle={setWantWatermelon}
+              onToggle={isChecked => setWantWatermelon(isChecked)}
             >
               <code>I want a watermelon</code>
             </LabeledCheckbox>


### PR DESCRIPTION
`jsxToString` output of the previous function wasn't super pretty. This change
displays the following instead, which is nicer:
```
<LabeledCheckbox name="test-alternative" position="before" onToggle={isChecked => setWantWatermelon(isChecked)}>
  <code>
    I want a watermelon
  </code>
</LabeledCheckbox>
```