### PR TITLE
Set default `type` property of buttons to "button"

### DIFF
--- a/src/components/buttons.js
+++ b/src/components/buttons.js
@@ -44,6 +44,7 @@ import { SvgIcon } from './SvgIcon';
  * @param {ButtonBaseProps} props
  */
 function ButtonBase({
+  // Custom props.
   buttonRef,
   className,
   icon,
@@ -52,6 +53,9 @@ function ButtonBase({
   variant = 'normal',
   expanded,
   pressed,
+
+  // Standard <button> props.
+  type = 'button',
   ...restProps
 }) {
   const ariaProps = {
@@ -71,6 +75,7 @@ function ButtonBase({
           [`${className}--icon-${iconPosition}`]: icon,
         }
       )}
+      type={type}
       {...ariaProps}
       {...restProps}
     />

--- a/src/components/test/buttons-test.js
+++ b/src/components/test/buttons-test.js
@@ -114,6 +114,16 @@ function addCommonTests({ componentName, createComponentFn, withIcon = true }) {
       );
     });
 
+    it('sets `type` to "button" by default', () => {
+      const wrapper = createComponentFn();
+      assert.equal(wrapper.getDOMNode().type, 'button');
+    });
+
+    it('allows overriding type', () => {
+      const wrapper = createComponentFn({ type: 'submit' });
+      assert.equal(wrapper.getDOMNode().type, 'submit');
+    });
+
     [
       {
         propName: 'expanded',


### PR DESCRIPTION
Override the default "submit" value for the `type` property of buttons
to "button". This avoids a hazard where a button can unexpectedly submit
a containing form that it is not intended to.

This choice mirrors button components in several other major React UI
libraries (Material UI, Fluent UI, React Bootstrap), as well as the
`Button` component in the Hypothesis lms app.