### PR TITLE
Prefix all utility and pattern classes with `.hyp-` and update docs

### DIFF
--- a/src/pattern-library/components/patterns/SharedMoleculePatterns.js
+++ b/src/pattern-library/components/patterns/SharedMoleculePatterns.js
@@ -17,7 +17,7 @@ export default function SharedMoleculePatterns() {
         </p>
         <PatternExamples>
           <PatternExample details="basic frame">
-            <div className="frame">This is in a frame.</div>
+            <div className="hyp-frame">This is in a frame.</div>
           </PatternExample>
         </PatternExamples>
       </Pattern>
@@ -29,22 +29,22 @@ export default function SharedMoleculePatterns() {
         </p>
         <PatternExamples>
           <PatternExample details="basic card">
-            <div className="card">This is in a card.</div>
+            <div className="hyp-card">This is in a card.</div>
           </PatternExample>
           <PatternExample details="a card with multiple child elements, showing default vertical rhythm">
-            <div className="card">
-              <div className="u-border">Child content in a card.</div>
-              <div className="u-border">Child content in a card.</div>
-              <div className="u-border">Child content in a card.</div>
+            <div className="hyp-card">
+              <div className="hyp-u-border">Child content in a card.</div>
+              <div className="hyp-u-border">Child content in a card.</div>
+              <div className="hyp-u-border">Child content in a card.</div>
             </div>
           </PatternExample>
           <PatternExample details="A card with some actions">
-            <div className="card">
+            <div className="hyp-card">
               <div>
                 This is some text in a card that also contains some available
                 actions.
               </div>
-              <div className="actions">
+              <div className="hyp-actions">
                 <IconButton title="User" icon="profile" />
                 <IconButton title="Edit" icon="edit" />
                 <IconButton title="Delete" icon="trash" />
@@ -61,14 +61,14 @@ export default function SharedMoleculePatterns() {
         </p>
         <PatternExamples>
           <PatternExample details="A set of LabeledButtons">
-            <div className="actions">
+            <div className="hyp-actions">
               <LabeledButton icon="profile">User</LabeledButton>
               <LabeledButton icon="edit">Edit</LabeledButton>
               <LabeledButton icon="trash">Delete</LabeledButton>
             </div>
           </PatternExample>
           <PatternExample details="A set of IconButtons">
-            <div className="actions">
+            <div className="hyp-actions">
               <IconButton title="User" icon="profile" />
               <IconButton title="Edit" icon="edit" />
               <IconButton title="Delete" icon="trash" />

--- a/src/pattern-library/components/patterns/SharedOrganismPatterns.js
+++ b/src/pattern-library/components/patterns/SharedOrganismPatterns.js
@@ -21,7 +21,7 @@ export default function SharedOrganismPatterns() {
             details="Panel with no header"
             style={{ maxWidth: '400px' }}
           >
-            <div className="panel">
+            <div className="hyp-panel">
               This is in a panel that has no header. A header is not required,
               but you are encouraged to use <code>card</code> in that case. Note
               that a <code>panel</code> will currently fill all available space.
@@ -30,9 +30,9 @@ export default function SharedOrganismPatterns() {
             </div>
           </PatternExample>
           <PatternExample details="Panel with title but no close button">
-            <div className="panel">
+            <div className="hyp-panel">
               <header>
-                <h2 className="panel__title">
+                <h2 className="hyp-panel__title">
                   This is a panel title in a panel header
                 </h2>
               </header>
@@ -44,12 +44,12 @@ export default function SharedOrganismPatterns() {
           </PatternExample>
 
           <PatternExample details="Closeable panel (using IconButton): preferred">
-            <div className="panel panel--closeable">
+            <div className="hyp-panel hyp-panel--closeable">
               <header>
-                <h2 className="panel__title">
+                <h2 className="hyp-panel__title">
                   Panel title on a closeable panel
                 </h2>
-                <div className="panel__close">
+                <div className="hyp-panel__close">
                   <IconButton icon="cancel" title="Close" />
                 </div>
               </header>
@@ -61,10 +61,10 @@ export default function SharedOrganismPatterns() {
           </PatternExample>
 
           <PatternExample details="Panel with actions">
-            <div className="panel panel--closeable">
+            <div className="hyp-panel hyp-panel--closeable">
               <header>
-                <h2 className="panel__title">Panel title</h2>
-                <div className="panel__close">
+                <h2 className="hyp-panel__title">Panel title</h2>
+                <div className="hyp-panel__close">
                   <IconButton icon="cancel" title="Close" />
                 </div>
               </header>
@@ -72,7 +72,7 @@ export default function SharedOrganismPatterns() {
                 This is panel content in a panel that also has some available
                 actions.
               </div>
-              <div className="actions">
+              <div className="hyp-actions">
                 <LabeledButton title="Cancel">Cancel</LabeledButton>
                 <LabeledButton title="Try again" variant="primary">
                   Try again

--- a/styles/README.md
+++ b/styles/README.md
@@ -73,9 +73,10 @@ Directories whose modules provide styles should contain an entry-point module (`
 We use [BEM (Block Element Modifier)](http://getbem.com/) methodology for class naming.
 
 - `base` modules should use element selectors (no class names).
-- Component class names should use PascalCase, e.g. `.HelpPanel`
-- Atomic-level utility classes should be prefixed with `.u-`, e.g. `.u-border--left`. These are classes that may be used additively to adjust styling on a single element.
-- Composite (molecule, organism) class names do not require prefixes, but should be lower-case, e.g. `.frame`.
+- Component class names should use PascalCase, e.g. `.HelpPanel`. All other classnames require a .`hyp-` prefix.
+- All utility and pattern classnames should be prefixed with `.hyp-`.
+- Atomic-level utility classes should be prefixed with `.hyp-u-`, e.g. `.hyp-u-border--left`. These are classes that may be used additively to adjust styling on a single element.
+- Composite (molecule, organism) class names do not require `u`-prefixes, but should be lower-case, e.g. `.hyp-frame`.
 
 ### Variables
 

--- a/styles/util/_atoms.scss
+++ b/styles/util/_atoms.scss
@@ -1,25 +1,25 @@
 @use '../mixins/atoms';
 
-.u-border {
+.hyp-u-border {
   @include atoms.border;
 }
 
-.u-border--left {
+.hyp-u-border--left {
   @include atoms.border(left);
 }
 
-.u-border--right {
+.hyp-u-border--right {
   @include atoms.border(right);
 }
 
-.u-border--top {
+.hyp-u-border--top {
   @include atoms.border(top);
 }
 
-.u-shadow {
+.hyp-u-shadow {
   @include atoms.shadow;
 }
 
-.u-shadow--active {
+.hyp-u-shadow--active {
   @include atoms.shadow($active: true);
 }

--- a/styles/util/_layout.scss
+++ b/styles/util/_layout.scss
@@ -2,22 +2,22 @@
 
 // Apply vertical rhythm (top/bottom margins between immediate-child elements)
 // at the default rhythm-unit size
-.u-vertical-rhythm {
+.hyp-u-vertical-rhythm {
   @include layout.vertical-rhythm;
 }
 
 // Apply horizontal rhythm (left/right margins between immediate-child elements)
 // at the default horizontal-rhythm size
-.u-horizontal-rhythm {
+.hyp-u-horizontal-rhythm {
   @include layout.horizontal-rhythm;
 }
 
 // Establish a row flex container
-.u-layout-row {
+.hyp-u-layout-row {
   @include layout.row;
 }
 
 // Establish a column flex container
-.u-layout-column {
+.hyp-u-layout-column {
   @include layout.column;
 }

--- a/styles/util/_molecules.scss
+++ b/styles/util/_molecules.scss
@@ -4,14 +4,14 @@
  * Utility classes for molecular mixins
  */
 
-.frame {
+.hyp-frame {
   @include molecules.frame;
 }
 
-.card {
+.hyp-card {
   @include molecules.card;
 }
 
-.actions {
+.hyp-actions {
   @include molecules.actions;
 }

--- a/styles/util/_organisms.scss
+++ b/styles/util/_organisms.scss
@@ -7,22 +7,22 @@
 /**
   * Usage:
   * 1. Panel with title and no close button
-  * <div class="panel">
-  *  <header><h2 class="panel__title">Panel title</h2></header>
+  * <div class="hyp-panel">
+  *  <header><h2 class="hyp-panel__title">Panel title</h2></header>
   *  <div>This panel has no close button</div>
   * </div>
   *
   * 2. Panel with title and close button
-  * <div className="panel panel--closeable">
+  * <div className="hyp-panel hyp-panel--closeable">
   *   <header>
-  *     <h2 class="panel__title">Panel title</h2>
-  *     <div class="panel__close">
+  *     <h2 class="hyp-panel__title">Panel title</h2>
+  *     <div class="hyp-panel__close">
   *       <IconButton icon="cancel" title="Close" />
   *     </div>
   *   </header>
   *   <div>This panel has an icon-only close button</div>
   * </div>
   */
-.panel {
+.hyp-panel {
   @include organisms.panel;
 }


### PR DESCRIPTION
Prefixing utility and pattern classes can help guard against unexpected
conflict with pre-existing classnames in applications that use this
package.

The classnames that are prefixed in these changes are currently used only internally to the package and not part of its CSS API—yet. Once these classes are part of the main SASS styles, these prefixes will aid the project of replacing local application utility classes with these.

Slack thread with some related discussion: https://hypothes-is.slack.com/archives/C1M8NH76X/p1620923544133600 (private to Hypothesis team members).