### PR TITLE
Remove alignment rule from buttons; add columnar `actions` pattern

### DIFF
--- a/src/pattern-library/components/patterns/SharedMoleculePatterns.js
+++ b/src/pattern-library/components/patterns/SharedMoleculePatterns.js
@@ -57,7 +57,8 @@ export default function SharedMoleculePatterns() {
       <Pattern title="Actions">
         <p>
           The <code>actions</code> pattern presents a collection of actions
-          (typically buttons) spaced out in a row, aligned right.
+          (typically buttons). By default, these are laid out in a row, aligned
+          right, but can also be laid out in a column.
         </p>
         <PatternExamples>
           <PatternExample details="A set of LabeledButtons">
@@ -72,6 +73,22 @@ export default function SharedMoleculePatterns() {
               <IconButton title="User" icon="profile" />
               <IconButton title="Edit" icon="edit" />
               <IconButton title="Delete" icon="trash" />
+            </div>
+          </PatternExample>
+          <PatternExample details="Columnar layout">
+            <div className="hyp-actions--column">
+              <LabeledButton>User</LabeledButton>
+              <LabeledButton>Edit</LabeledButton>
+              <LabeledButton>Delete</LabeledButton>
+            </div>
+          </PatternExample>
+          <PatternExample details="Columnar layout: buttons stretching to fill space">
+            <div style="width:300px">
+              <div className="hyp-actions--column">
+                <LabeledButton variant="primary">Do this</LabeledButton>
+                <LabeledButton variant="primary">No, this!</LabeledButton>
+                <LabeledButton variant="primary">Maybe this?</LabeledButton>
+              </div>
             </div>
           </PatternExample>
         </PatternExamples>

--- a/styles/components/buttons/_base.scss
+++ b/styles/components/buttons/_base.scss
@@ -78,7 +78,6 @@
     display: inline;
   } @else {
     display: flex;
-    justify-content: center;
     align-items: center;
   }
 

--- a/styles/mixins/_molecules.scss
+++ b/styles/mixins/_molecules.scss
@@ -48,9 +48,17 @@ $-space: var.$layout-space;
 }
 
 /**
- * A container that lays out a collection of actions—typically buttons—in a single row.
+ * A container that lays out a collection of actions—typically buttons. Default
+ * to a row layout, but also available as `column`.
+ *
+ * @param {'row'|'column'} [$direction]
  */
-@mixin actions {
-  @include layout.row(right);
-  @include layout.horizontal-rhythm($-space * 0.75);
+@mixin actions($direction: row) {
+  @if $direction == row {
+    @include layout.row(right);
+    @include layout.horizontal-rhythm($-space * 0.75);
+  } @else {
+    @include layout.column;
+    @include layout.vertical-rhythm($-space * 0.5);
+  }
 }

--- a/styles/util/_molecules.scss
+++ b/styles/util/_molecules.scss
@@ -12,6 +12,11 @@
   @include molecules.card;
 }
 
-.hyp-actions {
+.hyp-actions,
+.hyp-actions--row {
   @include molecules.actions;
+}
+
+.hyp-actions--column {
+  @include molecules.actions($direction: column);
 }


### PR DESCRIPTION
This PR removes an unnecessary `justify-content` alignment rule from buttons styling to allow for left alignment of button text in cases where buttons are "stretched" wider than their content-sized width.

The removal of the rule has no effect on existing button patterns, as it didn't "do" anything for buttons that are content-sized.

This PR also adds a variant of the `actions` pattern, `actions--column`, to capture this usage of buttons stacked on top of each other. It can be viewed on the "Molecules" pattern-library page.

Fixes #63 

Screenshots from pattern library:

Existing labeled buttons unaffected:

<img src="https://user-images.githubusercontent.com/439947/118670093-5015a180-b7c4-11eb-9cba-a4bca07a9cce.png" width="300" />

New columnar `actions` pattern showing stretched buttons:

![image](https://user-images.githubusercontent.com/439947/118669980-37a58700-b7c4-11eb-9e1b-d364472b0a0c.png)
