### PR TITLE
Establish basic color patterns

### DIFF
--- a/src/pattern-library/components/PlaygroundApp.js
+++ b/src/pattern-library/components/PlaygroundApp.js
@@ -1,6 +1,7 @@
 import { SvgIcon } from '../../components/SvgIcon';
 
 // Design patterns
+import SharedColorPatterns from './patterns/SharedColorPatterns';
 import SharedMoleculePatterns from './patterns/SharedMoleculePatterns';
 import SharedOrganismPatterns from './patterns/SharedOrganismPatterns';
 
@@ -38,6 +39,11 @@ const homeRoute = {
 
 /** @type {PlaygroundRoute[]} */
 const patternRoutes = [
+  {
+    route: '/shared-colors',
+    title: 'Colors',
+    component: SharedColorPatterns,
+  },
   {
     route: '/shared-molecules',
     title: 'Molecules',
@@ -109,7 +115,7 @@ export default function PlaygroundApp({
             <SvgIcon name="logo" />
           </a>
         </div>
-        <h2>Common Patterns</h2>
+        <h2>Foundations</h2>
         <ul className="PlaygroundApp__nav-list">
           {patternRoutes.map(({ route, title }) => (
             <li className="PlaygroundApp__nav-item" key={route}>

--- a/src/pattern-library/components/patterns/SharedColorPatterns.js
+++ b/src/pattern-library/components/patterns/SharedColorPatterns.js
@@ -1,0 +1,75 @@
+import {
+  PatternPage,
+  Pattern,
+  PatternExamples,
+  PatternExample,
+} from '../PatternPage';
+
+// TODO:
+// - color descriptions and guidance
+// - hex and other metadata about colors
+// - more sophisticated "swatches"
+// - foreground color examples
+// - more examples of overriding with `!` classes
+// - valid contrast combinations
+
+const backgroundExamples = [
+  'brand',
+  'grey-0',
+  'grey-1',
+  'grey-2',
+  'grey-3',
+  'grey-4',
+  'grey-5',
+  'grey-6',
+  'grey-7',
+  'grey-8',
+  'grey-9',
+].map(colorName => {
+  return (
+    <PatternExample details={`${colorName}`} key={`bg-${colorName}`}>
+      <div
+        key={colorName}
+        className={`PatternSwatch hyp-u-bg-color--${colorName}`}
+      />
+    </PatternExample>
+  );
+});
+
+export default function SharedFormPatterns() {
+  return (
+    <PatternPage title="Colors">
+      <Pattern title="Color swatches">
+        <PatternExamples>{backgroundExamples}</PatternExamples>
+      </Pattern>
+
+      <Pattern title="Overriding background colors: example">
+        <PatternExamples>
+          <PatternExample details="Background utility class without override: panel specificity wins">
+            <div className="hyp-panel hyp-u-bg-color--grey-2">
+              <p>
+                This is a <code>panel</code> with an applied utility class
+                <code>.hyp-u-bg-color--grey-2</code>.
+              </p>
+              <p>
+                It is superseded by a background-color rule from the{' '}
+                <code>panel</code> (it is &quot;ignored&quot;).
+              </p>
+            </div>
+          </PatternExample>
+          <PatternExample details="Background utility class with override: background class wins">
+            <div className="hyp-panel hyp-!-u-bg-color--grey-2">
+              <p>
+                This is a <code>panel</code> with an applied utility class
+                <code>.hyp-!-u-bg-color--grey-2</code>.
+              </p>
+              <p>
+                It contains an <code>!important</code> rule.
+              </p>
+            </div>
+          </PatternExample>
+        </PatternExamples>
+      </Pattern>
+    </PatternPage>
+  );
+}

--- a/styles/base/_elements.scss
+++ b/styles/base/_elements.scss
@@ -3,7 +3,7 @@
 
 $-border-radius: var.$border-radius;
 $-color-link: var.$color-link;
-$-color-link-hover: var.$color-link-hover;
+$-color-link--hover: var.$color-link--hover;
 
 // basic standard styling for elements
 // TODO: Evaluate if dependencies on variables can be reduced or eliminated
@@ -24,7 +24,7 @@ a:focus {
 
 a:hover {
   text-decoration: none;
-  color: $-color-link-hover;
+  color: $-color-link--hover;
 }
 
 p {

--- a/styles/components/buttons/_config.scss
+++ b/styles/components/buttons/_config.scss
@@ -8,21 +8,21 @@ $color-g1: var.$color-grey-1 !default;
 $color-g2: var.$color-grey-2 !default;
 $color-g3: var.$color-grey-3 !default;
 $color-g4: var.$color-grey-4 !default;
-$color-g6: var.$color-grey-6 !default;
+$color-g5: var.$color-grey-5 !default;
 $color-g7: var.$color-grey-7 !default;
-$color-gsemi: var.$color-grey-semi !default;
-$color-gmid: var.$color-grey-mid !default;
+$color-g8: var.$color-grey-8 !default;
+$color-g9: var.$color-grey-9 !default;
 $color-brand: var.$color-brand !default;
 $color-link-hover: var.$color-link-hover !default;
 
 // Colors for labeled buttons
 $LabeledButton-colors: (
-  'foreground': $color-gmid,
+  'foreground': $color-g7,
   'background': $color-g1,
-  'hover-foreground': $color-g7,
+  'hover-foreground': $color-g9,
   'hover-background': $color-g2,
-  'active-foreground': $color-g7,
-  'disabled-foreground': $color-gmid,
+  'active-foreground': $color-g9,
+  'disabled-foreground': $color-g7,
 );
 
 // Variant currently unused
@@ -30,40 +30,40 @@ $LabeledButton-colors--light: $LabeledButton-colors;
 
 $LabeledButton-colors--primary: (
   'foreground': $color-g1,
-  'background': $color-gmid,
+  'background': $color-g7,
   'hover-foreground': $color-g1,
-  'hover-background': $color-g6,
+  'hover-background': $color-g8,
   'active-foreground': $color-g1,
   'disabled-foreground': $color-g4,
 );
 
 $LabeledButton-colors--dark: (
-  'foreground': $color-gmid,
+  'foreground': $color-g7,
   'background': transparent,
-  'hover-foreground': $color-g7,
+  'hover-foreground': $color-g9,
   'hover-background': $color-g3,
-  'active-foreground': $color-gmid,
+  'active-foreground': $color-g7,
   'active-background': $color-g3,
-  'disabled-foreground': $color-gmid,
+  'disabled-foreground': $color-g7,
 );
 
 // Colors for icon-only buttons
 $IconButton-colors: (
-  'foreground': $color-gmid,
+  'foreground': $color-g7,
   'background': transparent,
-  'hover-foreground': $color-g7,
+  'hover-foreground': $color-g9,
   'hover-background': transparent,
   'active-foreground': $color-brand,
-  'disabled-foreground': $color-gmid,
+  'disabled-foreground': $color-g7,
 );
 
 $IconButton-colors--light: (
-  'foreground': $color-gsemi,
+  'foreground': $color-g5,
   'background': transparent,
-  'hover-foreground': $color-g6,
+  'hover-foreground': $color-g8,
   'hover-background': transparent,
-  'active-foreground': $color-gsemi,
-  'disabled-foreground': $color-gsemi,
+  'active-foreground': $color-g5,
+  'disabled-foreground': $color-g5,
 );
 
 $IconButton-colors--primary: (
@@ -72,7 +72,7 @@ $IconButton-colors--primary: (
   'hover-foreground': $color-brand,
   'hover-background': transparent,
   'active-foreground': $color-brand,
-  'disabled-foreground': $color-gmid,
+  'disabled-foreground': $color-g7,
 );
 
 // Variant currently unused
@@ -80,12 +80,12 @@ $IconButton-colors--dark: $IconButton-colors;
 
 // Colors for buttons styled as "links"
 $LinkButton-colors: (
-  'foreground': $color-gmid,
+  'foreground': $color-g7,
   'background': transparent,
   'hover-foreground': $color-link-hover,
   'hover-background': transparent,
-  'active-foreground': $color-g7,
-  'disabled-foreground': $color-gmid,
+  'active-foreground': $color-g9,
+  'disabled-foreground': $color-g7,
 );
 
 // Variant currently unused
@@ -97,16 +97,16 @@ $LinkButton-colors--primary: (
   'hover-foreground': $color-brand,
   'hover-background': transparent,
   'active-foreground': $color-brand,
-  'disabled-foreground': $color-gmid,
+  'disabled-foreground': $color-g7,
 );
 
 $LinkButton-colors--dark: (
-  'foreground': $color-g7,
+  'foreground': $color-g9,
   'background': transparent,
   'hover-foreground': $color-link-hover,
   'hover-background': transparent,
-  'active-foreground': $color-g7,
-  'disabled-foreground': $color-gmid,
+  'active-foreground': $color-g9,
+  'disabled-foreground': $color-g7,
 );
 
 $-IconButton: (

--- a/styles/components/buttons/_config.scss
+++ b/styles/components/buttons/_config.scss
@@ -13,7 +13,7 @@ $color-g7: var.$color-grey-7 !default;
 $color-g8: var.$color-grey-8 !default;
 $color-g9: var.$color-grey-9 !default;
 $color-brand: var.$color-brand !default;
-$color-link-hover: var.$color-link-hover !default;
+$color-link--hover: var.$color-link--hover !default;
 
 // Colors for labeled buttons
 $LabeledButton-colors: (
@@ -82,7 +82,7 @@ $IconButton-colors--dark: $IconButton-colors;
 $LinkButton-colors: (
   'foreground': $color-g7,
   'background': transparent,
-  'hover-foreground': $color-link-hover,
+  'hover-foreground': $color-link--hover,
   'hover-background': transparent,
   'active-foreground': $color-g9,
   'disabled-foreground': $color-g7,
@@ -103,7 +103,7 @@ $LinkButton-colors--primary: (
 $LinkButton-colors--dark: (
   'foreground': $color-g9,
   'background': transparent,
-  'hover-foreground': $color-link-hover,
+  'hover-foreground': $color-link--hover,
   'hover-background': transparent,
   'active-foreground': $color-g9,
   'disabled-foreground': $color-g7,

--- a/styles/pattern-library.scss
+++ b/styles/pattern-library.scss
@@ -138,7 +138,7 @@ pre {
   }
 
   code {
-    color: var.$color-grey-mid;
+    color: var.$color-grey-7;
   }
 }
 

--- a/styles/pattern-library.scss
+++ b/styles/pattern-library.scss
@@ -152,6 +152,14 @@ pre {
   }
 }
 
+.PatternSwatch {
+  width: 100px;
+  height: 100px;
+  display: flex;
+  align-items: center;
+  justify-items: center;
+}
+
 // Element styles
 body {
   font-family: sans-serif;

--- a/styles/util/_colors.scss
+++ b/styles/util/_colors.scss
@@ -1,0 +1,45 @@
+@use 'sass:map';
+
+@use '../variables/colors' as colors;
+
+// This mapping is necessary due to limitations in SASS interpolation
+$all-colors: (
+  'grey-0': colors.$grey-0,
+  'grey-1': colors.$grey-1,
+  'grey-2': colors.$grey-2,
+  'grey-3': colors.$grey-3,
+  'grey-4': colors.$grey-4,
+  'grey-5': colors.$grey-5,
+  'grey-6': colors.$grey-6,
+  'grey-7': colors.$grey-7,
+  'grey-8': colors.$grey-8,
+  'grey-9': colors.$grey-9,
+  'brand': colors.$brand,
+  'selection': colors.$selection,
+);
+
+// Generate a foreground-color utility class for each color
+// and an override foreground-color class for same, e.g.
+// `.hyp-u-color--grey-0` and `.hyp-!-u-color--grey-0`
+@each $color-name, $color-value in $all-colors {
+  .hyp-u-color--#{$color-name} {
+    color: $color-value;
+  }
+
+  .hyp-\!-u-color--#{$color-name} {
+    color: $color-value !important;
+  }
+}
+
+// Generate a background-color utility class for each color
+// and an override class for same, e.g.
+// `.hyp-u-bg-color--grey-0` and `.hyp-!-u-bg-color--grey-0`
+@each $color-name, $color-value in $all-colors {
+  .hyp-u-bg-color--#{$color-name} {
+    background-color: $color-value;
+  }
+
+  .hyp-\!-u-bg-color--#{$color-name} {
+    background-color: $color-value !important;
+  }
+}

--- a/styles/util/index.scss
+++ b/styles/util/index.scss
@@ -1,4 +1,5 @@
 @use 'atoms';
+@use 'colors';
 @use 'layout';
 @use 'molecules';
 @use 'organisms';

--- a/styles/variables/_colors.scss
+++ b/styles/variables/_colors.scss
@@ -1,40 +1,21 @@
-// Greys (layout colors)
-// These may be used for non-textual styling of components and elements
-$white: #fff !default;
+$brand: #bd1c2b;
 
-// Interim color variable for migration purposes.
-// Used as very-subtle background color for form fields. $grey-1 is too dark.
+// Grayscale
+$white: white;
 $grey-0: #fafafa;
-
 $grey-1: #f2f2f2;
 $grey-2: #ececec;
-
 $grey-3: #dbdbdb;
-
 $grey-4: #a6a6a6;
+$grey-5: #9c9c9c;
+$grey-6: #737373;
+$grey-7: #595959;
+$grey-8: #3f3f3f;
+$grey-9: #202020;
+$black: black;
 
-// Interim color variable for migration purposes, as the step between `$grey-4`
-// and `$grey-5` is large. Represents `base-semi` in proposed future palette,
-// minus blue tint.
-$grey-semi: #9c9c9c;
+$shadow: $black;
 
-// This is the lightest grey admissible on a white, $grey-0 or $grey-1
-// background to meet WCAG-AA text contrast requirements.
-$grey-5: #737373;
-
-// Interim color variable for migration purposes, as the step between `$grey-5`
-// and `$grey-6` is large. Represents `base-mid` in proposed future palette,
-// minus blue tint.
-// This is the lightest grey admissible on $grey-2, $grey-3
-$grey-mid: #595959;
-
-$grey-6: #3f3f3f;
-
-$grey-7: #202020;
-
-$shadow: black;
-
-$brand: #bd1c2b;
 $link: $brand !default;
 
 // Legacy

--- a/styles/variables/_colors.scss
+++ b/styles/variables/_colors.scss
@@ -1,4 +1,7 @@
 $brand: #bd1c2b;
+$brand--dark: #84141e;
+
+$selection: #59a7e8;
 
 // Grayscale
 $white: white;
@@ -14,15 +17,12 @@ $grey-8: #3f3f3f;
 $grey-9: #202020;
 $black: black;
 
-$shadow: $black;
-
-$link: $brand !default;
-
-// Legacy
-// TODO: This should be $link--hover
-$link-hover: #84141e !default;
-$focus-outline: #51a7e8;
-
 // Tokenizing colors to their use
 $background: $white;
 $border: $grey-3;
+$focus-outline: $selection;
+
+$link: $brand;
+$link--hover: $brand--dark;
+
+$shadow: $black;


### PR DESCRIPTION
This PR establishes some very basic structure around managing colors within this package's internal SASS. This is part of ongoing work to start to establish some foundational bits and bobs of our design system—not creating a new system, but describing the existing one.

Changes relevant to package users: additional page visible in the pattern library (Colors) with some basic color swatches, and a  sub-heading changed from _Common Patterns_ to _Foundations_. No externally-consumable SASS or CSS is affected by these changes.

These changes are internal to the package:

* Establishes a 0 - 9 greyscale from existing color values. Internally some variable names changed, but no colors changed—just their references. Previously we had a 0-7 greyscale range, with some intermediate `grey-mid` and `grey-semi` values. One had to remember (or forget, every time) whether `grey-semi` was lighter or darker than `grey-4`. No longer. Values are lightest at 0 and darkest at 9.
* Standardizes naming for color variables
* Generates utility classes for foreground and background colors

There's a lot more to do here, but I wanted to keep things as simple as possible. These changes were motivated by some needs for `Dialog`—it felt like the right time to do this.

Screenshot from new pattern-library page:

![image](https://user-images.githubusercontent.com/439947/118715929-3ab76c00-b7f2-11eb-9095-cf534007b8f6.png)

There's a lot to do here (I left myself some TODOs, even), but it's a start.