### PR TITLE
Refine pattern-library navigation

### DIFF
--- a/src/pattern-library/components/PlaygroundApp.js
+++ b/src/pattern-library/components/PlaygroundApp.js
@@ -1,3 +1,5 @@
+import classnames from 'classnames';
+
 import { SvgIcon } from '../../components/SvgIcon';
 
 // Design patterns
@@ -97,15 +99,24 @@ export default function PlaygroundApp({
   extraRoutes = [],
 }) {
   const allRoutes = routes.concat(extraRoutes);
-  const [route, navigate] = useRoute(baseURL, allRoutes);
-  const content = route ? (
-    <route.component />
+  const [activeRoute, navigate] = useRoute(baseURL, allRoutes);
+  const content = activeRoute ? (
+    <activeRoute.component />
   ) : (
     <>
       <h1 className="heading">:(</h1>
       <p>Page not found.</p>
     </>
   );
+
+  const routeGroups = [
+    { title: 'Foundations', routes: patternRoutes },
+    { title: 'Common Components', routes: componentRoutes },
+  ];
+
+  if (extraRoutes.length) {
+    routeGroups.push({ title: 'Application Patterns', routes: extraRoutes });
+  }
 
   return (
     <main className="PlaygroundApp">
@@ -115,42 +126,16 @@ export default function PlaygroundApp({
             <SvgIcon name="logo" />
           </a>
         </div>
-        <h2>Foundations</h2>
-        <ul className="PlaygroundApp__nav-list">
-          {patternRoutes.map(({ route, title }) => (
-            <li className="PlaygroundApp__nav-item" key={route}>
-              <a
-                key={route}
-                href={`${route}`}
-                onClick={e => navigate(e, route)}
-              >
-                {title}
-              </a>
-            </li>
-          ))}
-        </ul>
-        <h2>Common Components</h2>
-        <ul className="PlaygroundApp__nav-list">
-          {componentRoutes.map(({ route, title }) => (
-            <li className="PlaygroundApp__nav-item" key={route}>
-              <a
-                key={route}
-                href={`${route}`}
-                onClick={e => navigate(e, route)}
-              >
-                {title}
-              </a>
-            </li>
-          ))}
-        </ul>
-        {extraRoutes.length > 0 && (
-          <>
-            <h2>Application Patterns</h2>
-            <ul className="PlaygroundApp__nav-list">
-              {extraRoutes.map(({ route, title }) => (
-                <li className="PlaygroundApp__nav-item" key={route}>
+        {routeGroups.map(rGroup => (
+          <div key={rGroup.title}>
+            <h2>{rGroup.title}</h2>
+            <ul>
+              {rGroup.routes.map(({ route, title }) => (
+                <li key={title}>
                   <a
-                    key={route}
+                    className={classnames('PlaygroundApp__nav-item', {
+                      'is-active': activeRoute.route === route,
+                    })}
                     href={`${route}`}
                     onClick={e => navigate(e, route)}
                   >
@@ -159,8 +144,8 @@ export default function PlaygroundApp({
                 </li>
               ))}
             </ul>
-          </>
-        )}
+          </div>
+        ))}
       </div>
       <div className="PlaygroundApp__content">{content}</div>
     </main>

--- a/styles/pattern-library.scss
+++ b/styles/pattern-library.scss
@@ -17,6 +17,7 @@ body {
 
 .PlaygroundApp__sidebar h2,
 .Pattern > h2 {
+  margin: 0.5em 0;
   font-size: 1.25em;
   width: 100%;
   border-left: 6px solid var.$color-brand;
@@ -74,14 +75,15 @@ pre {
   }
 }
 
-.PlaygroundApp__nav-list {
-  margin: 0.5em;
-}
-
 .PlaygroundApp__nav-item {
-  padding: 1em;
+  width: 100%;
+  padding: 1em 2em;
   font-size: 16px; // TODO: variable later
   &:hover {
+    background-color: var.$color-grey-3;
+  }
+
+  &.is-active {
     background-color: var.$color-grey-3;
   }
 }


### PR DESCRIPTION
~~Currently depends on #70 for convenience reasons and to save me some rebase/merge time, but it doesn't need to if that becomes cumbersome.~~

Per dev feedback and obvious TODOs:

- Make entire nav item clickable
- Add navigation "on" state to show which page you're on
- DRY out route iteration for navigation rendering

After, showing navigation "on" state:

![image](https://user-images.githubusercontent.com/439947/118822760-6d12a900-b886-11eb-9ad9-b6e326d5a45c.png)

TODO later:

Routes could be better organized in general.