### PR TITLE
Add `overlay` and `fixed-centered` layout patterns

### DIFF
--- a/src/pattern-library/components/patterns/LayoutPatterns.js
+++ b/src/pattern-library/components/patterns/LayoutPatterns.js
@@ -1,0 +1,132 @@
+import { useState } from 'preact/hooks';
+
+import { LabeledButton } from '../../../';
+
+import {
+  PatternPage,
+  Pattern,
+  PatternExamples,
+  PatternExample,
+} from '../PatternPage';
+
+export default function LayoutPatterns() {
+  const [showExample1, setShowExample1] = useState(false);
+  const [showExample2, setShowExample2] = useState(false);
+  const [showExample3, setShowExample3] = useState(false);
+  return (
+    <PatternPage title="Layout">
+      <Pattern title="Fixed-Centered Positioning">
+        <p>
+          The <code>fixed-centered</code> layout pattern centers an element both
+          horizontally and vertically within the entire viewport.
+        </p>
+        <PatternExamples>
+          <PatternExample details="Centering an element vertically and horizontally within the viewport">
+            <div>
+              <LabeledButton
+                variant="primary"
+                onClick={() => setShowExample1(true)}
+              >
+                Show example
+              </LabeledButton>
+              <div
+                className="hyp-u-fixed-centered"
+                style={`width:450px;${
+                  showExample1 ? 'visibility:visible' : 'visibility:hidden'
+                }`}
+              >
+                <div className="hyp-card">
+                  <p>
+                    This is a card that is centered vertically and horizontally
+                    in the current viewport.
+                  </p>
+                  <div className="hyp-actions">
+                    <LabeledButton
+                      variant="primary"
+                      onClick={() => setShowExample1(false)}
+                    >
+                      Hide example
+                    </LabeledButton>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </PatternExample>
+        </PatternExamples>
+      </Pattern>
+      <Pattern title="Full-screen overlay">
+        <p>
+          The <code>overlay</code> layout pattern provides a full-viewport,
+          semi-opaque overlay that obscures UI interactions in the viewport
+          below. It is intended for use as a backdrop for modals, e.g.
+        </p>
+        <PatternExamples>
+          <PatternExample details="Semi-opaque full-screen overlay">
+            <div>
+              <LabeledButton
+                variant="primary"
+                onClick={() => setShowExample2(true)}
+              >
+                Show example
+              </LabeledButton>
+              <div
+                className="hyp-u-overlay"
+                style={
+                  showExample2 ? 'visibility:visible' : 'visibility:hidden'
+                }
+              >
+                <div className="hyp-u-fixed-centered">
+                  <LabeledButton onClick={() => setShowExample2(false)}>
+                    Hide example
+                  </LabeledButton>
+                </div>
+              </div>
+            </div>
+          </PatternExample>
+        </PatternExamples>
+      </Pattern>
+
+      <Pattern title="Example: Full-screen overlay with fixed-centered content">
+        <p>
+          This shows an example of combining the <code>overlay</code> and{' '}
+          <code>fixed-centered</code> patterns.
+        </p>
+        <PatternExamples>
+          <PatternExample details="Overlay and fixed-centered patterns used together">
+            <div>
+              <LabeledButton
+                variant="primary"
+                onClick={() => setShowExample3(true)}
+              >
+                Show example
+              </LabeledButton>
+              <div
+                className="hyp-u-overlay"
+                style={
+                  showExample3 ? 'visibility:visible' : 'visibility:hidden'
+                }
+              >
+                <div className="hyp-u-fixed-centered">
+                  <div className="hyp-card" style="width:450px">
+                    <div>
+                      This is content in a fixed-centered card of 450px width
+                      over a full-screen overlay.
+                    </div>
+                    <div className="hyp-actions">
+                      <LabeledButton
+                        variant="primary"
+                        onClick={() => setShowExample3(false)}
+                      >
+                        Hide example
+                      </LabeledButton>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </PatternExample>
+        </PatternExamples>
+      </Pattern>
+    </PatternPage>
+  );
+}

--- a/src/pattern-library/routes.js
+++ b/src/pattern-library/routes.js
@@ -1,6 +1,7 @@
 import PlaygroundHome from './components/PlaygroundHome';
 
 import ColorPatterns from './components/patterns/ColorPatterns';
+import LayoutPatterns from './components/patterns/LayoutPatterns';
 import MoleculePatterns from './components/patterns/MoleculePatterns';
 import OrganismPatterns from './components/patterns/OrganismPatterns';
 
@@ -32,6 +33,12 @@ const routes = [
     route: '/foundations-colors',
     title: 'Colors',
     component: ColorPatterns,
+    group: 'foundations',
+  },
+  {
+    route: '/foundations-layout',
+    title: 'Layout',
+    component: LayoutPatterns,
     group: 'foundations',
   },
   {

--- a/styles/mixins/_atoms.scss
+++ b/styles/mixins/_atoms.scss
@@ -1,10 +1,10 @@
-@use 'sass:color';
 @use 'sass:list';
 
 @use '../variables' as var;
 
 $-color-border: var.$color-border;
 $-color-shadow: var.$color-shadow;
+$-color-shadow--dark: var.$color-shadow--dark;
 
 /**
  * Add border styles for all element sides (default) or a specific single side
@@ -29,9 +29,9 @@ $-color-shadow: var.$color-shadow;
 @mixin shadow($active: false) {
   @if $active {
     /* offset-x | offset-y | blur-radius | spread-radius | color */
-    box-shadow: 0px 2px 3px 0px color.scale($-color-shadow, $alpha: -85%);
+    box-shadow: 0px 2px 3px 0px $-color-shadow--dark;
   } @else {
     /* offset-x | offset-y | blur-radius | color */
-    box-shadow: 0px 1px 1px color.scale($-color-shadow, $alpha: -90%);
+    box-shadow: 0px 1px 1px $-color-shadow;
   }
 }

--- a/styles/mixins/_layout.scss
+++ b/styles/mixins/_layout.scss
@@ -1,6 +1,7 @@
 @use '../variables' as var;
 
 $-space: var.$layout-space;
+$-color-overlay: var.$color-overlay;
 
 /**
  * Abstract mixin for establishing basic flex container. External users should
@@ -81,4 +82,28 @@ $-space: var.$layout-space;
   & > * + * {
     margin-left: $size !important;
   }
+}
+
+/**
+ * Position an element vertically and horizontally within the viewport
+ */
+@mixin fixed-centered {
+  z-index: 20;
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+}
+
+/**
+ * Semi-opaque overlay, full-viewport
+ */
+@mixin overlay {
+  z-index: 10;
+  position: fixed;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
+  background-color: $-color-overlay;
 }

--- a/styles/util/_layout.scss
+++ b/styles/util/_layout.scss
@@ -21,3 +21,13 @@
 .hyp-u-layout-column {
   @include layout.column;
 }
+
+// Position the element centered vertically and horizontally in the entire viewport
+.hyp-u-fixed-centered {
+  @include layout.fixed-centered;
+}
+
+// A full-viewport-width and -height semi-opaque backdrop overlay
+.hyp-u-overlay {
+  @include layout.overlay;
+}

--- a/styles/variables/_colors.scss
+++ b/styles/variables/_colors.scss
@@ -1,3 +1,5 @@
+@use 'sass:color';
+
 $brand: #bd1c2b;
 $brand--dark: #84141e;
 
@@ -25,4 +27,6 @@ $focus-outline: $selection;
 $link: $brand;
 $link--hover: $brand--dark;
 
-$shadow: $black;
+$overlay: color.scale($black, $alpha: -50%);
+$shadow: color.scale($black, $alpha: -90%);
+$shadow--dark: color.scale($black, $alpha: -85%);


### PR DESCRIPTION
Part of https://github.com/hypothesis/frontend-shared/issues/53

This is an unexciting PR that adds a couple of layout patterns for:

* Vertically and horizontally centering an element in the viewport
* A full-viewport semi-transparent overlay

A new Layout page is added to the Foundations section of the Pattern Library.

Acknowledgement: The Layout page is fairly fugly, and we're getting to the point where I want to go back and make some improvements, but I also didn't want to distract from moving toward a `Dialog` at this moment.

## To see it in action

Check out this branch, run `make dev`, go to the [Pattern Library's new Layout page](http://localhost:4001/ui-playground/shared-layout).