### PR TITLE
Add Dialog Component

### DIFF
--- a/src/components/Dialog.js
+++ b/src/components/Dialog.js
@@ -1,0 +1,139 @@
+import classnames from 'classnames';
+import { useEffect, useLayoutEffect, useRef, useState } from 'preact/hooks';
+
+import { IconButton, LabeledButton } from '../';
+import { SvgIcon } from './SvgIcon';
+
+let idCounter = 0;
+
+/**
+ * Return an element ID beginning with `prefix` that is unique per component instance.
+ *
+ * This avoids different instances of a component re-using the same ID.
+ *
+ * @param {string} prefix
+ */
+function useUniqueId(prefix) {
+  const [id] = useState(() => {
+    ++idCounter;
+    return `${prefix}-${idCounter}`;
+  });
+  return id;
+}
+
+/**
+ * @typedef {import('preact').ComponentChildren} Children
+ *
+ * @typedef DialogProps
+ * @prop {Children} [buttons] -
+ *   Additional `Button` elements to display at the bottom of the dialog.
+ *   A "Cancel" button is added automatically if the `onCancel` prop is set.
+ * @prop {string} [cancelLabel] - Label for the cancel button
+ * @prop {Children} children
+ * @prop {string} [contentClass] - CSS class to apply to the dialog's content
+ * @prop {string} [icon] - Name of optional icon to render in header
+ * @prop {import("preact/hooks").Ref<HTMLElement>} [initialFocus] -
+ *   Child element to focus when the dialog is rendered.
+ * @prop {() => void} [onCancel] -
+ *   A callback to invoke when the user cancels the dialog. If provided, a
+ *   "Cancel" button will be displayed.
+ * @prop {'dialog'|'alertdialog'} [role] - The aria role for the dialog (defaults to" dialog")
+ * @prop {string} title
+ */
+
+/**
+ * HTML control that can be disabled.
+ *
+ * @typedef {HTMLElement & { disabled: boolean }} InputElement
+ */
+
+/**
+ * Render a "panel"-like interface with a title and optional icon and/or
+ * close button. Grabs focus on initial render, defaulting to the entire
+ * Dialog container element, or `initialFocus` HTMLElement if provided.
+ *
+ * @param {DialogProps} props
+ */
+export function Dialog({
+  buttons,
+  cancelLabel = 'Cancel',
+  children,
+  contentClass,
+  icon,
+  initialFocus,
+  onCancel,
+  role = 'dialog',
+  title,
+}) {
+  const dialogDescriptionId = useUniqueId('dialog-description');
+  const dialogTitleId = useUniqueId('dialog-title');
+
+  const rootEl = useRef(/** @type {HTMLDivElement | null} */ (null));
+
+  useEffect(() => {
+    const focusEl = /** @type {InputElement|undefined} */ (initialFocus?.current);
+    if (focusEl && !focusEl.disabled) {
+      focusEl.focus();
+    } else {
+      // Modern accessibility guidance is to focus the dialog itself rather than
+      // trying to be smart about focusing a particular control within the
+      // dialog. See resources above.
+      rootEl.current.focus();
+    }
+    // We only want to run this effect once when the dialog is mounted.
+    //
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Try to assign the dialog an accessible description, using the content of
+  // the first paragraph of text in it.
+  //
+  // A limitation of this approach is that it doesn't update if the dialog's
+  // content changes after the initial render.
+  useLayoutEffect(() => {
+    const description = rootEl.current.querySelector('p');
+    if (description) {
+      description.id = dialogDescriptionId;
+      rootEl.current.setAttribute('aria-describedby', dialogDescriptionId);
+    }
+  }, [dialogDescriptionId]);
+
+  return (
+    <div
+      aria-labelledby={dialogTitleId}
+      className={classnames(
+        'Dialog',
+        { 'Dialog--closeable': !!onCancel },
+        contentClass
+      )}
+      ref={rootEl}
+      role={role}
+      tabIndex={-1}
+    >
+      <header>
+        {icon && (
+          <div className="Dialog__header-icon">
+            <SvgIcon name={icon} title={title} data-testid="header-icon" />
+          </div>
+        )}
+        <h2 className="Dialog__title" id={dialogTitleId}>
+          {title}
+        </h2>
+        {onCancel && (
+          <div className="Dialog__close">
+            <IconButton icon="cancel" title="Close" onClick={onCancel} />
+          </div>
+        )}
+      </header>
+      <div>{children}</div>
+      <div className="Dialog__actions">
+        {onCancel && (
+          <LabeledButton data-testid="cancel-button" onClick={onCancel}>
+            {cancelLabel}
+          </LabeledButton>
+        )}
+        {buttons}
+      </div>
+    </div>
+  );
+}

--- a/src/components/test/Dialog-test.js
+++ b/src/components/test/Dialog-test.js
@@ -1,0 +1,186 @@
+import { mount } from 'enzyme';
+import { createRef } from 'preact';
+
+import { Dialog } from '../Dialog';
+import { checkAccessibility } from '../../../test/util/accessibility';
+
+describe('Dialog', () => {
+  it('renders content', () => {
+    const wrapper = mount(
+      <Dialog>
+        <span>content</span>
+      </Dialog>
+    );
+    assert.isTrue(wrapper.contains(<span>content</span>));
+  });
+
+  it('adds `contentClass` value to class list', () => {
+    const wrapper = mount(
+      <Dialog title="test" contentClass="foo">
+        <span>content</span>
+      </Dialog>
+    );
+    assert.isTrue(wrapper.find('.Dialog').hasClass('foo'));
+  });
+
+  it('renders buttons', () => {
+    const wrapper = mount(
+      <Dialog
+        title="My dialog"
+        buttons={[
+          <button key="foo" name="foo" />,
+          <button key="bar" name="bar" />,
+        ]}
+      />
+    );
+    assert.isTrue(wrapper.contains(<button key="foo" name="foo" />));
+    assert.isTrue(wrapper.contains(<button key="bar" name="bar" />));
+  });
+
+  it('renders the title', () => {
+    const wrapper = mount(<Dialog title="Test dialog" />);
+    const header = wrapper.find('header');
+    assert.equal(header.text().indexOf('Test dialog'), 0);
+  });
+
+  it('renders an icon', () => {
+    const wrapper = mount(<Dialog title="Test dialog" icon="edit" />);
+    const icon = wrapper.find('SvgIcon[data-testid="header-icon"]');
+    assert.isTrue(icon.exists());
+  });
+
+  it('closes when close button is clicked', () => {
+    const onCancel = sinon.stub();
+    const wrapper = mount(<Dialog title="Test dialog" onCancel={onCancel} />);
+
+    wrapper
+      .find('LabeledButton[data-testid="cancel-button"]')
+      .props()
+      .onClick();
+
+    assert.called(onCancel);
+  });
+
+  it(`defaults cancel button's label to "Cancel"`, () => {
+    const wrapper = mount(<Dialog onCancel={sinon.stub()} />);
+    assert.equal(
+      wrapper.find('LabeledButton[data-testid="cancel-button"]').text().trim(),
+      'Cancel'
+    );
+  });
+
+  it('adds a custom label to the cancel button', () => {
+    const wrapper = mount(
+      <Dialog onCancel={sinon.stub()} cancelLabel="hello" />
+    );
+    assert.equal(
+      wrapper.find('LabeledButton[data-testid="cancel-button"]').text().trim(),
+      'hello'
+    );
+  });
+
+  describe('initial focus', () => {
+    let container;
+
+    beforeEach(() => {
+      container = document.createElement('div');
+      document.body.appendChild(container);
+    });
+
+    afterEach(() => {
+      container.remove();
+    });
+
+    it('focuses the `initialFocus` element', () => {
+      const inputRef = createRef();
+
+      mount(
+        <Dialog initialFocus={inputRef} title="My dialog">
+          <input ref={inputRef} />
+        </Dialog>,
+        { attachTo: container }
+      );
+
+      assert.equal(document.activeElement, inputRef.current);
+    });
+
+    it('focuses the dialog if `initialFocus` prop is missing', () => {
+      const wrapper = mount(
+        <Dialog title="My dialog">
+          <div>Test</div>
+        </Dialog>,
+        { attachTo: container }
+      );
+
+      assert.equal(
+        document.activeElement,
+        wrapper.find('[role="dialog"]').getDOMNode()
+      );
+    });
+
+    it('focuses the dialog if `initialFocus` ref is `null`', () => {
+      const wrapper = mount(
+        <Dialog initialFocus={{ current: null }} title="My dialog">
+          <div>Test</div>
+        </Dialog>,
+        { attachTo: container }
+      );
+
+      assert.equal(
+        document.activeElement,
+        wrapper.find('[role="dialog"]').getDOMNode()
+      );
+    });
+
+    it('focuses the dialog if `initialFocus` element is disabled', () => {
+      const inputRef = createRef();
+
+      const wrapper = mount(
+        <Dialog initialFocus={inputRef} title="My dialog">
+          <button ref={inputRef} disabled={true} />
+        </Dialog>,
+        { attachTo: container }
+      );
+
+      assert.equal(
+        document.activeElement,
+        wrapper.find('[role="dialog"]').getDOMNode()
+      );
+    });
+  });
+
+  it("marks the first `<p>` in the dialog's content as the accessible description", () => {
+    const wrapper = mount(
+      <Dialog title="My dialog">
+        <p>Enter a URL</p>
+      </Dialog>
+    );
+    const content = wrapper.find('[role="dialog"]').getDOMNode();
+    const paragraphEl = wrapper.find('p').getDOMNode();
+
+    assert.ok(content.getAttribute('aria-describedby'));
+    assert.equal(content.getAttribute('aria-describedby'), paragraphEl.id);
+  });
+
+  it("does not set an accessible description if the dialog's content does not have a `<p>`", () => {
+    const wrapper = mount(
+      <Dialog title="My dialog">
+        <button>Click me</button>
+      </Dialog>
+    );
+    const content = wrapper.find('[role="dialog"]').getDOMNode();
+    assert.isNull(content.getAttribute('aria-describedby'));
+  });
+
+  it(
+    'should pass a11y checks',
+    checkAccessibility({
+      // eslint-disable-next-line react/display-name
+      content: () => (
+        <Dialog title="Test dialog">
+          <div>test</div>
+        </Dialog>
+      ),
+    })
+  );
+});

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 // Components
 export { LabeledCheckbox, Checkbox } from './components/Checkbox';
+export { Dialog } from './components/Dialog';
 export { IconButton, LabeledButton, LinkButton } from './components/buttons';
 export { Panel } from './components/Panel';
 export { SvgIcon, registerIcons } from './components/SvgIcon';

--- a/src/pattern-library/components/patterns/DialogPatterns.js
+++ b/src/pattern-library/components/patterns/DialogPatterns.js
@@ -1,0 +1,118 @@
+import { createRef, render } from 'preact';
+import { useState } from 'preact/hooks';
+import { Dialog, LabeledButton } from '../../../';
+
+import { PatternPage, Pattern } from '../PatternPage';
+
+/**
+ * Render a Dialog within the `container`, and invoke
+ * `setDialogIsOpen` as needed to alert caller to state changes. Provides the
+ * ability to open and close a Dialog demo. We don't want to render a Dialog
+ * until it's opened because it will grab focus when it first mounts.
+ *
+ * @param {Object} options
+ *   @prop {HTMLElement} container - Element to render the Dialog inside of
+ *   @prop {(isOpen: boolean) => void} setDialogIsOpen - callback to call when
+ *     the Dialog state changes: opened (true) or closed/removed (false)
+ */
+const showDialog = ({ container, setDialogIsOpen }) => {
+  const initialFocusRef = createRef();
+
+  const close = message => {
+    if (message) {
+      alert(message);
+    }
+    render(null, container);
+    setDialogIsOpen(false);
+  };
+
+  const extraButtons = [
+    <LabeledButton key="maybe" onClick={() => close('You chose maybe!')}>
+      Maybe
+    </LabeledButton>,
+    <LabeledButton
+      key="yep"
+      onClick={() => close('You chose "Do it!"')}
+      variant="primary"
+    >
+      Do it!
+    </LabeledButton>,
+  ];
+
+  render(
+    <Dialog
+      buttons={extraButtons}
+      icon="edit"
+      initialFocus={initialFocusRef}
+      title="Basic dialog with icon"
+      onCancel={() => close()}
+    >
+      <div>
+        <p>This is an example of a dialog.</p>
+        <p>
+          This dialog contains an <code>input</code> which is focused when the
+          dialog is opened.
+        </p>
+        <input
+          className="hyp-u-focus-outline"
+          ref={initialFocusRef}
+          type="text"
+        />
+      </div>
+    </Dialog>,
+    container
+  );
+};
+
+export default function DialogPatterns() {
+  const [dialogIsOpen, setDialogIsOpen] = useState(false);
+  const openDialog = () => {
+    setDialogIsOpen(true);
+    showDialog({
+      container: document.getElementById('#dialog1'),
+      setDialogIsOpen,
+    });
+  };
+  return (
+    <PatternPage title="Dialogs">
+      <Pattern title="Dialog">
+        <div className="Example">
+          <p>
+            A <code>Dialog</code> prompts for user interaction and will take
+            focus when opened.
+          </p>
+          <p>
+            Use a <code>Dialog</code> when you want to route focus. Consider
+            using a <code>Panel</code> for presenting panel-styled content that
+            does not require grabbing focus.
+          </p>
+          <div className="Example__content">
+            <div className="Example__usage">
+              <p>
+                This example shows a dismiss-able <code>Dialog</code> with an
+                explicitly-provided element (<code>ref</code>) that should take
+                initial focus: a text <code>input</code>. The highlighted
+                outline is added here by using <code>.hyp-u-focus-outline</code>{' '}
+                on the <code>input</code> element.
+              </p>
+              <p>
+                <code>Dialogs</code> are styled using the <code>panel</code>{' '}
+                pattern.
+              </p>
+            </div>
+            <div className="Example__demo hyp-frame">
+              <div>
+                <div id="#dialog1" />
+                {!dialogIsOpen && (
+                  <LabeledButton variant="primary" onClick={openDialog}>
+                    Open dialog
+                  </LabeledButton>
+                )}
+              </div>
+            </div>
+          </div>
+        </div>
+      </Pattern>
+    </PatternPage>
+  );
+}

--- a/src/pattern-library/components/patterns/MoleculePatterns.js
+++ b/src/pattern-library/components/patterns/MoleculePatterns.js
@@ -12,30 +12,35 @@ export default function MoleculePatterns() {
     <PatternPage title="Molecules">
       <Pattern title="Frame">
         <p>
-          A <code>frame</code> has a border and a background, but no other
-          layout affordances.
+          A <code>frame</code> has a border, background, padding, and vertical
+          spacing of immediate children.
         </p>
         <PatternExamples>
           <PatternExample details="basic frame">
             <div className="hyp-frame">This is in a frame.</div>
+          </PatternExample>
+          <PatternExample details="child content in frame">
+            <div className="hyp-frame">
+              <div className="hyp-u-border">Child content in a frame.</div>
+              <div className="hyp-u-border">Child content in a frame.</div>
+              <div className="hyp-u-border">Child content in a frame.</div>
+            </div>
           </PatternExample>
         </PatternExamples>
       </Pattern>
 
       <Pattern title="Card">
         <p>
-          A <code>card</code> is a frame with internal margins and padding, and
-          a hover effect.
+          A <code>card</code> is a frame with a shadow and hover-shadow effect
+          that fills available horizontal space.
         </p>
         <PatternExamples>
           <PatternExample details="basic card">
             <div className="hyp-card">This is in a card.</div>
           </PatternExample>
-          <PatternExample details="a card with multiple child elements, showing default vertical rhythm">
-            <div className="hyp-card">
-              <div className="hyp-u-border">Child content in a card.</div>
-              <div className="hyp-u-border">Child content in a card.</div>
-              <div className="hyp-u-border">Child content in a card.</div>
+          <PatternExample details="hover shadow disabled">
+            <div className="hyp-card--no-hover">
+              This is in a card with the hover-shadow effect disabled.
             </div>
           </PatternExample>
           <PatternExample details="A card with some actions">

--- a/src/pattern-library/routes.js
+++ b/src/pattern-library/routes.js
@@ -5,6 +5,7 @@ import MoleculePatterns from './components/patterns/MoleculePatterns';
 import OrganismPatterns from './components/patterns/OrganismPatterns';
 
 import ButtonPatterns from './components/patterns/ButtonPatterns';
+import DialogPatterns from './components/patterns/DialogPatterns';
 import FormPatterns from './components/patterns/FormPatterns';
 import PanelPatterns from './components/patterns/PanelPatterns';
 
@@ -50,6 +51,12 @@ const routes = [
     route: '/components-buttons',
     title: 'Buttons',
     component: ButtonPatterns,
+    group: 'components',
+  },
+  {
+    route: '/components-dialogs',
+    title: 'Dialogs',
+    component: DialogPatterns,
     group: 'components',
   },
   {

--- a/styles/components/Dialog.scss
+++ b/styles/components/Dialog.scss
@@ -1,0 +1,5 @@
+@use '../mixins/organisms';
+
+.Dialog {
+  @include organisms.panel;
+}

--- a/styles/index.scss
+++ b/styles/index.scss
@@ -3,6 +3,7 @@
 // e.g.
 // @use '@hypothesis/frontend-shared/styles'
 
+@use './components/Dialog';
 @use './components/Panel';
 @use './components/SvgIcon';
 @use './components/buttons/styles';

--- a/styles/mixins/_molecules.scss
+++ b/styles/mixins/_molecules.scss
@@ -13,36 +13,33 @@ $-space: var.$layout-space;
  */
 
 /**
- * Give an element a border, a background and a shadow. Underpinning for
- * cards and panels.
- *
- * @param {boolean} [$with-hover] - Should this frame have a hover effect?
+ * Give an element a border, background color and internal vertical spacing
  */
 @mixin frame($with-hover: false) {
   @include atoms.border;
-  @include atoms.shadow;
+  @include layout.vertical-rhythm;
 
+  padding: $-space;
   border-radius: $-border-radius;
   background-color: $-color-background;
+}
 
+/**
+ * A frame with a shadow and (optional) shadow hover effect. Fills available
+ * horizontal space.
+ *
+ * @param {boolean} [$with-hover] - Should this frame have a hover effect?
+ */
+@mixin card($with-hover: true) {
+  @include frame;
+  @include atoms.shadow;
   @if $with-hover {
     &:hover,
     &.is-focused {
       @include atoms.shadow($active: true);
     }
   }
-}
-
-/**
- * An element with a frame, shadow, internal vertical rhythm and padding:
- * serves as a container for card- and panel-like patterns.
- */
-@mixin card {
-  @include frame($with-hover: true);
-  @include layout.vertical-rhythm;
-
   width: 100%;
-  padding: $-space;
 
   // TODO: Add clean-theme affordances
 }

--- a/styles/mixins/_organisms.scss
+++ b/styles/mixins/_organisms.scss
@@ -50,4 +50,8 @@ $-space: var.$layout-space;
     font-size: 1.375em;
     margin-right: $-space * -0.75;
   }
+
+  &__actions {
+    @include molecules.actions;
+  }
 }

--- a/styles/pattern-library.scss
+++ b/styles/pattern-library.scss
@@ -179,3 +179,40 @@ body {
     }
   }
 }
+
+// TODO This is prototype styling for a potential new component in the
+// pattern library.
+.Example {
+  margin: 1.5em 0;
+
+  p {
+    margin: 0 0 1em 0;
+  }
+
+  & > p {
+    margin: 0 0 0.5em;
+    font-size: 18px;
+  }
+
+  &__content {
+    margin-top: 2em;
+    display: flex;
+  }
+
+  &__usage {
+    padding-right: 1em;
+    flex-basis: 0;
+    flex-grow: 2;
+    font-size: 15px;
+    line-height: 1.4;
+  }
+
+  &__demo {
+    flex-basis: 0;
+    flex-grow: 3;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background-color: var.$color-grey-1;
+  }
+}

--- a/styles/util/_focus.scss
+++ b/styles/util/_focus.scss
@@ -1,0 +1,9 @@
+@use '../mixins/focus';
+
+.hyp-u-focus-outline {
+  @include focus.outline;
+}
+
+.hyp-u-focus-outline--inset {
+  @include focus.outline($inset: true);
+}

--- a/styles/util/_layout.scss
+++ b/styles/util/_layout.scss
@@ -17,6 +17,16 @@
   @include layout.row;
 }
 
+// Establish a row flex container with items justified and aligned center
+.hyp-u-layout-row--center {
+  @include layout.row($align: center, $justify: center);
+}
+
+// Establish a row flex container with items justified center
+.hyp-u-layout-row--justify-center {
+  @include layout.row($justify: center);
+}
+
 // Establish a column flex container
 .hyp-u-layout-column {
   @include layout.column;

--- a/styles/util/_molecules.scss
+++ b/styles/util/_molecules.scss
@@ -12,6 +12,10 @@
   @include molecules.card;
 }
 
+.hyp-card--no-hover {
+  @include molecules.card($with-hover: false);
+}
+
 .hyp-actions,
 .hyp-actions--row {
   @include molecules.actions;

--- a/styles/util/index.scss
+++ b/styles/util/index.scss
@@ -1,5 +1,6 @@
 @use 'atoms';
 @use 'colors';
+@use 'focus';
 @use 'layout';
 @use 'molecules';
 @use 'organisms';


### PR DESCRIPTION
This PR adds a `Dialog` component and makes some supporting adjustments to patterns and the pattern library:

* Add a `Dialog` component, styles and tests
* Adjust some foundational shared patterns that are used by this component to, well, be a little better—see commit messages, but affected patterns include `card` and `frame`. No visible changes to consumers of the package.
* Add a page to the pattern library to demo `Dialog` components, including some provisional styling for a potential future pattern-library component

A `Dialog` is a panel-like component to use when user interaction is desired. It will route focus when opened, and has `aria-` attributes for a11y.

The `Dialog` component here is very similar to the `Dialog` component in the `client` project, with these differences:

* This version adds an (optional) `icon` prop
* This version uses the `panel` design pattern which increases visual consistency, instead of rolling its own styling
* This `Dialog` does not assume it's modal, and does not provide a backdrop or positioning. That will be supported in a forthcoming `Modal` component.

## To preview

Check out this branch, visit the pattern library, go to the ["Dialogs" page](http://localhost:4001/ui-playground/shared-dialog):

![image](https://user-images.githubusercontent.com/439947/119166965-45117a00-ba2d-11eb-815b-941f4fd7035d.png)