### PR TITLE
Re-order (intended) CSS output and make SASS source directories reflect this

### DIFF
--- a/src/pattern-library/components/patterns/ColorPatterns.js
+++ b/src/pattern-library/components/patterns/ColorPatterns.js
@@ -45,26 +45,11 @@ export default function ColorPatterns() {
 
       <Pattern title="Overriding background colors: example">
         <PatternExamples>
-          <PatternExample details="Background utility class without override: panel specificity wins">
+          <PatternExample details="Background-color utility class">
             <div className="hyp-panel hyp-u-bg-color--grey-2">
               <p>
                 This is a <code>panel</code> with an applied utility class
                 <code>.hyp-u-bg-color--grey-2</code>.
-              </p>
-              <p>
-                It is superseded by a background-color rule from the{' '}
-                <code>panel</code> (it is &quot;ignored&quot;).
-              </p>
-            </div>
-          </PatternExample>
-          <PatternExample details="Background utility class with override: background class wins">
-            <div className="hyp-panel hyp-!-u-bg-color--grey-2">
-              <p>
-                This is a <code>panel</code> with an applied utility class
-                <code>.hyp-!-u-bg-color--grey-2</code>.
-              </p>
-              <p>
-                It contains an <code>!important</code> rule.
               </p>
             </div>
           </PatternExample>

--- a/styles/README.md
+++ b/styles/README.md
@@ -57,15 +57,29 @@ Mixins in `mixins` and utility styles in `util` loosely apply [Atomic Design](ht
 
 The directory that a SASS module lives in dictates what it should provide (styles, mixins, variables, etc.) and what kind of dependencies it is allowed:
 
-| Directory    | Description                                     | Provides  | Dependencies          |
-| ------------ | ----------------------------------------------- | --------- | --------------------- |
-| `base`       | Global reset styles: element styles, typography | styles    | mixins, variables[^1] |
-| `components` | Styles for shared components                    | styles    | any                   |
-| `mixins`     | Mixins                                          | mixins    | mixins[^2], variables |
-| `util`       | Utility styles                                  | styles    | mixins                |
-| `variables`  | Variables                                       | variables | none                  |
+| Directory    | Description                  | Provides  | Dependencies          |
+| ------------ | ---------------------------- | --------- | --------------------- |
+| `base`       | Reset and element styles     | styles    | mixins, variables[^1] |
+| `components` | Styles for shared components | styles    | any                   |
+| `mixins`     | Mixins                       | mixins    | mixins[^2], variables |
+| `patterns`   | Pattern styles               | styles    | mixins                |
+| `util`       | Utility styles               | styles    | mixins                |
+| `variables`  | Variables                    | variables | none                  |
 
-Directories whose modules provide styles should contain an entry-point module (`index.scss`) for the convenience of consumers.
+## CSS Output and Ordering
+
+The current SASS entry point for the package only generates styles from `components`.
+
+Other CSS output is currently private to the package, and used (only) by the pattern library.
+
+The intended ordering of CSS output—to assure proper cascade/ordering—is:
+
+1. `base`
+2. `components`
+3. `patterns`
+4. `utils`
+
+Note `utils` in last position, to assure these classes override other rules.
 
 ## Conventions
 
@@ -103,5 +117,5 @@ We use [BEM (Block Element Modifier)](http://getbem.com/) methodology for class 
   Modules that output styles may `@use` modules in the order needed for correct cascade, however.
 
 [^1]: Variable dependencies: sparingly. Ideally, not.
-[^2]: Atomic mixin modules build on each other, and as such, `molecules` may depend on `atoms`, etc. Non-atomic mixin modules should not depend on other mixins.
+[^2]: Mixin modules in top-level `mixins` directory should not depend on other `mixins`.
 [^3]: Members prefixed with `-` are considered "private" by SASS

--- a/styles/components/Dialog.scss
+++ b/styles/components/Dialog.scss
@@ -1,4 +1,4 @@
-@use '../mixins/organisms';
+@use '../mixins/patterns/organisms';
 
 .Dialog {
   @include organisms.panel;

--- a/styles/components/Panel.scss
+++ b/styles/components/Panel.scss
@@ -1,4 +1,4 @@
-@use '../mixins/organisms';
+@use '../mixins/patterns/organisms';
 
 .Panel {
   @include organisms.panel;

--- a/styles/mixins/patterns/_molecules.scss
+++ b/styles/mixins/patterns/_molecules.scss
@@ -1,7 +1,7 @@
-@use '../variables' as var;
+@use '../../variables' as var;
 
-@use 'atoms';
-@use 'layout';
+@use '../atoms';
+@use '../layout';
 
 $-border-radius: var.$border-radius;
 $-color-background: var.$color-background;

--- a/styles/mixins/patterns/_organisms.scss
+++ b/styles/mixins/patterns/_organisms.scss
@@ -1,7 +1,8 @@
-@use '../variables' as var;
+@use '../../variables' as var;
 
-@use 'atoms';
-@use 'layout';
+@use '../atoms';
+@use '../layout';
+
 @use 'molecules';
 
 $-color-brand: var.$color-brand;

--- a/styles/pattern-library.scss
+++ b/styles/pattern-library.scss
@@ -1,9 +1,9 @@
 @use 'base';
-@use 'util';
 @use 'variables' as var;
 
-// Include component styles
-@use 'index';
+@use 'index'; // component styles
+@use 'patterns';
+@use 'util';
 
 body {
   font-size: 100%;

--- a/styles/patterns/_molecules.scss
+++ b/styles/patterns/_molecules.scss
@@ -1,4 +1,4 @@
-@use '../mixins/molecules';
+@use '../mixins/patterns/molecules';
 
 /**
  * Utility classes for molecular mixins

--- a/styles/patterns/_organisms.scss
+++ b/styles/patterns/_organisms.scss
@@ -1,4 +1,4 @@
-@use '../mixins/organisms';
+@use '../mixins/patterns/organisms';
 
 /**
  * Utility classes for organism mixins

--- a/styles/patterns/index.scss
+++ b/styles/patterns/index.scss
@@ -1,0 +1,2 @@
+@use 'molecules';
+@use 'organisms';

--- a/styles/util/_colors.scss
+++ b/styles/util/_colors.scss
@@ -25,10 +25,6 @@ $all-colors: (
   .hyp-u-color--#{$color-name} {
     color: $color-value;
   }
-
-  .hyp-\!-u-color--#{$color-name} {
-    color: $color-value !important;
-  }
 }
 
 // Generate a background-color utility class for each color
@@ -37,9 +33,5 @@ $all-colors: (
 @each $color-name, $color-value in $all-colors {
   .hyp-u-bg-color--#{$color-name} {
     background-color: $color-value;
-  }
-
-  .hyp-\!-u-bg-color--#{$color-name} {
-    background-color: $color-value !important;
   }
 }

--- a/styles/util/index.scss
+++ b/styles/util/index.scss
@@ -2,5 +2,3 @@
 @use 'colors';
 @use 'focus';
 @use 'layout';
-@use 'molecules';
-@use 'organisms';


### PR DESCRIPTION
This PR reorders (intended) output of CSS to give some utility classes a fighting chance of applying, without having to resort to `!important` or other weapons. These utility classes are (still) only used within the package itself. Nothing changes within the package's API.

Motivations:

1. Find the minimally-nuclear approach to assuring that utility classes can override as needed.
2. Resolve dependency and ordering differences between "true" utility classes and mixins vs. "patterns"

With regard to the first item, the goal is that authors can do something like: `<div className="hyp-card hyp-u-bg-color--grey-2">` and feel confident that they'll get a card pattern, but with a different background color.

Previous to these changes, I'd taken a more nuclear approach, though I tried to make sure the author meant to "press the button" by creating additional, `!`-named utility classes that included an `!important` rule, e.g. `.hyp-!-u-bg-color--grey-2`. Clever, but let's try to do better.

First stop: simple CSS ordering. This PR updates the pattern-library SASS entry point (the only thing that consumes utility classes at this time) to include `utils` last.

This on its own didn't fix the specific example here: `<div className="hyp-card hyp-u-bg-color--grey-2">` because "molecule" and "organism" CSS styles (which include `hyp-card`) were getting output with utility styles, and by luck of the draw/alphabet, `hyp-card` was getting output after `hyp-u-bg-color--grey-2`.

Stepping back and looking at things: true util classes should be atomic. "Molecules" and "organisms" aren't utils, they're composite pattern styles, which in turn draw on more atomic patterns. This was already reflected in their dependencies (atomic mixins have no other mixin dependencies, but molecules and organisms depend on atomic mixins). Let's get molecules and organisms out of the atomic-utility-class mix, then, by putting them into their own `patterns` directory, which gets included in stylesheet output before `utils`.

Finally, update the README to explain WTH and remove the (now) unneeded color-utility-override classes and example in the pattern library.

There are still instances of `!important` in two layout mixins, which I'll review as part of https://github.com/hypothesis/frontend-shared/issues/74

p.s. We have a few other tricks up our sleeve that are less scorched-earth than `!important`, like leveraging the `:is` pseudo-select, should we run into further specificity wars. The arsenal is not depleted.