### PR TITLE
Add styling for `dark` variant of `IconButton`

### DIFF
--- a/src/pattern-library/components/patterns/ButtonPatterns.js
+++ b/src/pattern-library/components/patterns/ButtonPatterns.js
@@ -81,6 +81,48 @@ export default function ButtonPatterns() {
           </PatternExample>
         </PatternExamples>
 
+        <h3>Dark variant</h3>
+        <p>
+          This variant is for use on darker (light grey vs. white) backgrounds.
+          Note that this button, unlike other <code>IconButton</code>s, has a
+          background color. This is to allow for a use case in which the dark{' '}
+          <code>IconButton</code> is initially fixed on a grey background but
+          floats on top of content when scrolled.
+        </p>
+
+        <PatternExamples>
+          <PatternExample
+            details="Basic usage"
+            style={{ backgroundColor: '#ececec' }}
+          >
+            <IconButton icon="cancel" title="Close" variant="dark" />
+          </PatternExample>
+          <PatternExample
+            details="Note that the button has a background color"
+            style={{ backgroundColor: '#ffffff' }}
+          >
+            <IconButton icon="cancel" title="Close" variant="dark" />
+          </PatternExample>
+          <PatternExample
+            details="Pressed"
+            style={{ backgroundColor: '#ececec' }}
+          >
+            <IconButton icon="cancel" title="Close" variant="dark" pressed />
+          </PatternExample>
+          <PatternExample
+            details="Expanded"
+            style={{ backgroundColor: '#ececec' }}
+          >
+            <IconButton icon="cancel" title="Close" variant="dark" expanded />
+          </PatternExample>
+          <PatternExample
+            details="Disabled"
+            style={{ backgroundColor: '#ececec' }}
+          >
+            <IconButton icon="cancel" title="Close" variant="dark" disabled />
+          </PatternExample>
+        </PatternExamples>
+
         <h3>Light variant</h3>
         <p>
           This variant should only be used for non-critical icons on white

--- a/styles/components/buttons/_config.scss
+++ b/styles/components/buttons/_config.scss
@@ -4,6 +4,7 @@
 // Map variables to local tokens
 $touch-target-size: var.$touch-target-size !default;
 
+$color-g0: var.$color-grey-0 !default;
 $color-g1: var.$color-grey-1 !default;
 $color-g2: var.$color-grey-2 !default;
 $color-g3: var.$color-grey-3 !default;
@@ -75,8 +76,15 @@ $IconButton-colors--primary: (
   'disabled-foreground': $color-g7,
 );
 
-// Variant currently unused
-$IconButton-colors--dark: $IconButton-colors;
+$IconButton-colors--dark: (
+  'foreground': $color-g7,
+  'background': $color-g2,
+  'hover-foreground': $color-g9,
+  'hover-background': $color-g3,
+  'active-foreground': $color-g9,
+  'active-background': $color-g3,
+  'disabled-foreground': $color-g5,
+);
 
 // Colors for buttons styled as "links"
 $LinkButton-colors: (


### PR DESCRIPTION
This PR adds colors (styling) for the `dark` variant of `IconButton`. We didn't have a use case for this variant until now, when it could be of use as a close button for the Notebook.

## To review

Check out this branch, `make dev` and go to the [Buttons page of your Pattern Library](http://localhost:4001/ui-playground/components-buttons).

Screen shot:

![image](https://user-images.githubusercontent.com/439947/119659817-8ecadd80-bdfc-11eb-9ef1-95807bde4e6a.png)
