### PR TITLE
`Modal`, `ConfirmModal` components and design patterns

### DIFF
--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -1,0 +1,88 @@
+import { useRef } from 'preact/hooks';
+
+import { useElementShouldClose } from '../hooks/use-element-should-close';
+import { Dialog } from './Dialog';
+import { LabeledButton } from './buttons';
+
+/**
+ * @typedef {import('./Dialog').DialogProps} DialogProps
+ */
+
+/**
+ * @typedef ModalBaseProps
+ * @prop {() => void} onCancel - `onCancel` is required for Modals
+ */
+
+/**
+ * @typedef {DialogProps & ModalBaseProps} ModalProps
+ */
+
+/**
+ * A modal dialog. Presents a dialog with an overlay background. Will close
+ * if user clicks/taps outside of it.
+ *
+ * @param {ModalProps} props
+ */
+export function Modal({ children, onCancel, ...restProps }) {
+  const modalContainerRef = useRef(/** @type {HTMLDivElement | null} */ (null));
+
+  useElementShouldClose(modalContainerRef, true /* isOpen */, () => {
+    if (onCancel) {
+      onCancel();
+    }
+  });
+
+  return (
+    <>
+      <div className="Modal__overlay" />
+      <div className="Modal" ref={modalContainerRef}>
+        <Dialog onCancel={onCancel} {...restProps}>
+          {children}
+        </Dialog>
+      </div>
+    </>
+  );
+}
+
+/**
+ * @typedef ConfirmModalBaseProps
+ * @prop {string} message - Main text of the modal message
+ * @prop {string} confirmAction - Label for the "Confirm" button
+ * @prop {() => void} onConfirm - Callback invoked if the user clicks the "Confirm" button
+ * @prop {() => void} onCancel - Callback invoked if the user cancels
+ *
+ * @typedef {Omit<ModalProps, 'buttons' | 'children'> & ConfirmModalBaseProps} ConfirmModalProps
+ */
+
+/**
+ * A modal that emulates a `window.confirm` interface:
+ * request a boolean yes/no confirmation from the user.
+ *
+ * @param {ConfirmModalProps} props
+ */
+export function ConfirmModal({
+  message,
+  confirmAction,
+  onConfirm,
+  onCancel,
+  ...restProps
+}) {
+  return (
+    <Modal
+      onCancel={onCancel}
+      buttons={[
+        <LabeledButton
+          key="ok"
+          onClick={onConfirm}
+          variant="primary"
+          data-testid="confirm-button"
+        >
+          {confirmAction}
+        </LabeledButton>,
+      ]}
+      {...restProps}
+    >
+      <p>{message}</p>
+    </Modal>
+  );
+}

--- a/src/components/test/Modal-test.js
+++ b/src/components/test/Modal-test.js
@@ -1,0 +1,104 @@
+import { mount } from 'enzyme';
+import { act } from 'preact/test-utils';
+
+import { ConfirmModal, Modal } from '../Modal';
+
+describe('Modal', () => {
+  function createComponent(props = {}) {
+    return mount(
+      <Modal title="My modal" onCancel={sinon.stub()} {...props}>
+        This is my modal
+      </Modal>
+    );
+  }
+
+  it('renders a dialog for the modal', () => {
+    const wrapper = createComponent();
+    assert.isTrue(wrapper.find('Dialog').exists());
+    assert.equal(wrapper.find('Dialog').props().title, 'My modal');
+  });
+
+  describe('closing the modal', () => {
+    it('closes when `ESC` pressed', () => {
+      const onCancel = sinon.stub();
+      const container = document.createElement('div');
+      document.body.appendChild(container);
+      mount(
+        <Modal title="Test dialog" onCancel={onCancel}>
+          This is my modal
+        </Modal>,
+        {
+          attachTo: container,
+        }
+      );
+
+      const event = new Event('keydown');
+      event.key = 'Escape';
+      document.body.dispatchEvent(event);
+      assert.called(onCancel);
+      container.remove();
+    });
+
+    it('closes when close button is pressed', () => {
+      const onCancel = sinon.stub();
+      const wrapper = createComponent({ onCancel });
+
+      wrapper
+        .find('LabeledButton[data-testid="cancel-button"]')
+        .props()
+        .onClick();
+      assert.calledOnce(onCancel);
+    });
+  });
+});
+
+describe('Confirm Modal', () => {
+  function createComponent(props = {}) {
+    return mount(
+      <ConfirmModal
+        title="Really?"
+        message="Are you sure you want to do that?"
+        onConfirm={sinon.stub()}
+        confirmAction="Yes"
+        onCancel={sinon.stub()}
+        {...props}
+      />
+    );
+  }
+
+  it('renders a dialog for the modal', () => {
+    const wrapper = createComponent();
+
+    const dialog = wrapper.find('Dialog');
+
+    assert.equal(dialog.props().title, 'Really?');
+    assert.include(
+      dialog.children().text(),
+      'Are you sure you want to do that?'
+    );
+  });
+
+  it('invokes confirm and cancel callbacks when dialog buttons clicked', () => {
+    const onCancel = sinon.stub();
+    const onConfirm = sinon.stub();
+    const wrapper = createComponent({ onCancel, onConfirm });
+
+    const dialog = wrapper.find('Dialog');
+    const cancelButton = dialog.find(
+      'LabeledButton[data-testid="cancel-button"]'
+    );
+    const confirmButton = dialog.find(
+      'LabeledButton[data-testid="confirm-button"]'
+    );
+
+    assert.equal(confirmButton.children().text(), 'Yes');
+    act(() => {
+      confirmButton.props().onClick();
+    });
+    confirmButton.update();
+    assert.calledOnce(onConfirm);
+
+    cancelButton.props().onClick();
+    assert.calledOnce(onCancel);
+  });
+});

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@
 export { LabeledCheckbox, Checkbox } from './components/Checkbox';
 export { Dialog } from './components/Dialog';
 export { IconButton, LabeledButton, LinkButton } from './components/buttons';
+export { Modal, ConfirmModal } from './components/Modal';
 export { Panel } from './components/Panel';
 export { SvgIcon, registerIcons } from './components/SvgIcon';
 

--- a/src/pattern-library/components/patterns/DialogPatterns.js
+++ b/src/pattern-library/components/patterns/DialogPatterns.js
@@ -1,51 +1,48 @@
 import { createRef, render } from 'preact';
 import { useState } from 'preact/hooks';
-import { Dialog, LabeledButton } from '../../../';
+import { ConfirmModal, Dialog, LabeledButton, Modal } from '../../../';
 
 import { PatternPage, Pattern } from '../PatternPage';
 
 /**
- * Render a Dialog within the `container`, and invoke
+ * Render a Dialog or Modal within the `container`, and invoke
  * `setDialogIsOpen` as needed to alert caller to state changes. Provides the
  * ability to open and close a Dialog demo. We don't want to render a Dialog
  * until it's opened because it will grab focus when it first mounts.
  *
  * @param {Object} options
- *   @prop {HTMLElement} container - Element to render the Dialog inside of
- *   @prop {(isOpen: boolean) => void} setDialogIsOpen - callback to call when
+ *   @param {import('preact').FunctionComponent} options.DialogComponent - Which Dialog
+ *   or Dialog-wrapping component (function) to use;
+ *   a reference to `Dialog`, `Modal`, `ConfirmModal`, e.g.
+ *   @param {HTMLElement} options.container - Element to render the Dialog inside of
+ *   @param {(isOpen: boolean) => void} options.setOpen - callback to call when
  *     the Dialog state changes: opened (true) or closed/removed (false)
+ *   @param {Object} [options.props] - Extra prop(s) for Dialog component
  */
-const showDialog = ({ container, setDialogIsOpen }) => {
+const showDialog = ({ DialogComponent, container, setOpen, props }) => {
   const initialFocusRef = createRef();
 
   const close = message => {
     if (message) {
       alert(message);
     }
-    render(null, container);
-    setDialogIsOpen(false);
+    if (container) {
+      render(null, container);
+    }
+    setOpen(false);
   };
 
-  const extraButtons = [
-    <LabeledButton key="maybe" onClick={() => close('You chose maybe!')}>
-      Maybe
-    </LabeledButton>,
-    <LabeledButton
-      key="yep"
-      onClick={() => close('You chose "Do it!"')}
-      variant="primary"
-    >
-      Do it!
-    </LabeledButton>,
-  ];
+  if (!container) {
+    return null;
+  }
 
-  render(
-    <Dialog
-      buttons={extraButtons}
+  return render(
+    <DialogComponent
       icon="edit"
       initialFocus={initialFocusRef}
       title="Basic dialog with icon"
       onCancel={() => close()}
+      {...props}
     >
       <div>
         <p>This is an example of a dialog.</p>
@@ -59,18 +56,71 @@ const showDialog = ({ container, setDialogIsOpen }) => {
           type="text"
         />
       </div>
-    </Dialog>,
+    </DialogComponent>,
     container
   );
 };
 
 export default function DialogPatterns() {
+  // Extra buttons to use in Dialog, Modal examples
+  const buttons = [
+    <LabeledButton key="maybe" onClick={() => alert('You chose maybe')}>
+      Maybe
+    </LabeledButton>,
+    <LabeledButton
+      key="yep"
+      onClick={() => alert('You chose yep')}
+      variant="primary"
+    >
+      Do it!
+    </LabeledButton>,
+  ];
+
+  // Dialog/Modal state for each of the examples
   const [dialogIsOpen, setDialogIsOpen] = useState(false);
+  const [, setModalIsOpen] = useState(false);
+  const [, setConfirmModalIsOpen] = useState(false);
+
   const openDialog = () => {
     setDialogIsOpen(true);
     showDialog({
-      container: document.getElementById('#dialog1'),
-      setDialogIsOpen,
+      DialogComponent: Dialog,
+      container: /** @type {HTMLElement} */ (document.getElementById(
+        'dialog1'
+      )),
+      setOpen: setDialogIsOpen,
+      props: {
+        buttons,
+      },
+    });
+  };
+
+  const openModal = () => {
+    setModalIsOpen(true);
+    showDialog({
+      DialogComponent: Modal,
+      container: /** @type {HTMLElement} */ (document.getElementById('modal1')),
+      setOpen: setModalIsOpen,
+      props: {
+        buttons,
+      },
+    });
+  };
+
+  const openConfirmModal = () => {
+    setConfirmModalIsOpen(true);
+    showDialog({
+      DialogComponent: ConfirmModal,
+      container: /** @type {HTMLElement} */ (document.getElementById(
+        'confirm-modal1'
+      )),
+      setOpen: setConfirmModalIsOpen,
+      props: {
+        confirmAction: 'Sure thing',
+        message: 'Confirm modal content goes right here.',
+        title: 'Confirm Modal Example',
+        onConfirm: () => alert('ok'),
+      },
     });
   };
   return (
@@ -102,12 +152,69 @@ export default function DialogPatterns() {
             </div>
             <div className="Example__demo hyp-frame">
               <div>
-                <div id="#dialog1" />
+                <div id="dialog1" />
                 {!dialogIsOpen && (
                   <LabeledButton variant="primary" onClick={openDialog}>
                     Open dialog
                   </LabeledButton>
                 )}
+              </div>
+            </div>
+          </div>
+        </div>
+      </Pattern>
+
+      <Pattern title="Modal">
+        <div className="Example">
+          <p>
+            A <code>Modal</code> is a type of <code>Dialog</code> that centers
+            on the screen and obscures the background with an overlay.
+          </p>
+          <div className="Example__content">
+            <div className="Example__usage">
+              <p>
+                Close the modal by clicking the close (X) button, the cancel
+                button or clicking anywhere outside of it.
+              </p>
+            </div>
+            <div className="Example__demo hyp-frame">
+              <div>
+                <div id="modal1" />
+                <LabeledButton variant="primary" onClick={openModal}>
+                  Open modal
+                </LabeledButton>
+              </div>
+            </div>
+          </div>
+        </div>
+      </Pattern>
+
+      <Pattern title="Confirm Modal">
+        <div className="Example">
+          <p>
+            <code>ConfirmModal</code> is intended to mirror the functionality of{' '}
+            <code>window.confirm</code>.
+          </p>
+          <div className="Example__content">
+            <div className="Example__usage">
+              <p>
+                <code>ConfirmModal</code> prompts the user for a boolean yes/no
+                input. Close and cancel are considered no.
+              </p>
+              <p>
+                Handlers need to be provided for what to do on yes (
+                <code>onConfirm</code>) and no/cancel (<code>onCancel</code>).
+                Typically, both would (also) close the modal, though in this
+                example, the <code>onConfirm</code> handler does not close the
+                modal.
+              </p>
+            </div>
+            <div className="Example__demo hyp-frame">
+              <div>
+                <div id="confirm-modal1" />
+                <LabeledButton variant="primary" onClick={openConfirmModal}>
+                  Open confirm modal
+                </LabeledButton>
               </div>
             </div>
           </div>

--- a/src/pattern-library/components/patterns/MoleculePatterns.js
+++ b/src/pattern-library/components/patterns/MoleculePatterns.js
@@ -1,3 +1,5 @@
+import { useState } from 'preact/hooks';
+
 import {
   PatternExample,
   PatternExamples,
@@ -8,6 +10,7 @@ import {
 import { IconButton, LabeledButton } from '../../../';
 
 export default function MoleculePatterns() {
+  const [showModalExample, setShowModalExample] = useState(false);
   return (
     <PatternPage title="Molecules">
       <Pattern title="Frame">
@@ -93,6 +96,56 @@ export default function MoleculePatterns() {
                 <LabeledButton variant="primary">Do this</LabeledButton>
                 <LabeledButton variant="primary">No, this!</LabeledButton>
                 <LabeledButton variant="primary">Maybe this?</LabeledButton>
+              </div>
+            </div>
+          </PatternExample>
+        </PatternExamples>
+      </Pattern>
+
+      <Pattern title="Modal container">
+        <p>
+          The <code>modal</code> pattern positions and sizes a modal container
+          appropriately based on viewport size.
+        </p>
+        <PatternExamples>
+          <PatternExample details="Responsive Modal container positioning and sizing">
+            <div>
+              <LabeledButton
+                variant="primary"
+                onClick={() => setShowModalExample(true)}
+              >
+                Show example
+              </LabeledButton>
+              <div
+                className="hyp-u-overlay"
+                style={{ visibility: showModalExample ? 'visible' : 'hidden' }}
+              >
+                <div className="hyp-modal">
+                  <div className="hyp-card">
+                    <div>
+                      <p>
+                        Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+                        Ut congue bibendum ipsum, ut euismod eros. Morbi sit
+                        amet sollicitudin diam. Cras tristique dui at nulla
+                        gravida, non sodales velit tincidunt. Pellentesque
+                        pharetra elit ac risus porta, vel vestibulum odio
+                        consectetur. Aliquam convallis augue ex, vitae aliquet
+                        enim varius id. Integer porttitor erat non nisi posuere,
+                        a tempus felis ultrices. In hac habitasse platea
+                        dictumst. Donec ut justo at odio pharetra laoreet ac
+                        consectetur elit.
+                      </p>
+                    </div>
+                    <div className="hyp-actions">
+                      <LabeledButton
+                        variant="primary"
+                        onClick={() => setShowModalExample(false)}
+                      >
+                        Hide example
+                      </LabeledButton>
+                    </div>
+                  </div>
+                </div>
               </div>
             </div>
           </PatternExample>

--- a/styles/components/Modal.scss
+++ b/styles/components/Modal.scss
@@ -1,0 +1,10 @@
+@use '../mixins/layout';
+@use '../mixins/patterns/molecules';
+
+.Modal__overlay {
+  @include layout.overlay;
+}
+
+.Modal {
+  @include molecules.modal;
+}

--- a/styles/index.scss
+++ b/styles/index.scss
@@ -4,6 +4,7 @@
 // @use '@hypothesis/frontend-shared/styles'
 
 @use './components/Dialog';
+@use './components/Modal';
 @use './components/Panel';
 @use './components/SvgIcon';
 @use './components/buttons/styles';

--- a/styles/mixins/patterns/_molecules.scss
+++ b/styles/mixins/patterns/_molecules.scss
@@ -59,3 +59,32 @@ $-space: var.$layout-space;
     @include layout.vertical-rhythm($-space * 0.5);
   }
 }
+
+// A responsive sized and positioned container for modal content
+@mixin modal {
+  // The modal container is positioned horizontally- and vertically-centered
+  @include layout.fixed-centered;
+
+  // This sizing applies to smaller viewports
+  width: 90vw;
+  max-width: 90vw;
+  max-height: 90vh;
+
+  // For viewports with more horizontal room, adjust width.
+  // Set a reasonable min-width on the modal so it doesn't look too dinky,
+  // and a max-width so it doesn't stretch too wide.
+  @media screen and (min-width: 48rem) {
+    width: auto;
+    min-width: 28rem;
+    max-width: 44rem; // default for older browsers
+    max-width: min(44rem, 90vw);
+  }
+
+  // For viewports with more vertical room, adjust vertical positioning to
+  // near the top of the viewport.
+  @media screen and (min-height: 32rem) {
+    top: 10vh;
+    transform: translate(-50%, 0);
+    max-height: 80vh; // 10vh space top and bottom
+  }
+}

--- a/styles/pattern-library.scss
+++ b/styles/pattern-library.scss
@@ -197,6 +197,11 @@ body {
   &__content {
     margin-top: 2em;
     display: flex;
+    flex-direction: column;
+
+    @media screen and (min-width: 48rem) {
+      flex-direction: row;
+    }
   }
 
   &__usage {

--- a/styles/patterns/_molecules.scss
+++ b/styles/patterns/_molecules.scss
@@ -24,3 +24,7 @@
 .hyp-actions--column {
   @include molecules.actions($direction: column);
 }
+
+.hyp-modal {
+  @include molecules.modal;
+}


### PR DESCRIPTION
This (initially draft) PR contains new `Modal` and `ConfirmModal` components and their corresponding supporting design patterns and pattern-library content.

`Modal` wraps a `Dialog` and adds a background overlay and a close-on-outside-click functionality. `Modal` + `Dialog` here = the `Dialog` component in the `client`. `ConfirmModal` is analogous to `ConfirmDialog` in the `client` and doesn't deviate too much from it.

I've added some responsiveness to the modal positioning and sizing in this variant. See implementation and comments for details (a test to see if the source is self-documenting and commented enough).

### In draft until...

* [x] Feedback gathered about general approach, design
* [x] Tests added (after that)

### To try it out

Check out this branch, run `make dev` and visit the new [Dialogs pattern library page](http://localhost:4001/ui-playground/components-dialogs) in your browser. The modal examples are last on the page.

### Screenshots

Note that the pattern-library examples include all supported Dialog bells and whistles, including an icon in the header, which may not be applicable to modals. But it's helpful to see everything in the mix...

`Modal`, narrow viewport (with initial-focus input):

<img src="https://user-images.githubusercontent.com/439947/120656749-e0551700-c451-11eb-854c-81303da1dea9.png" width="400" />

The same `Modal`, wider viewport:

![image](https://user-images.githubusercontent.com/439947/120656865-f9f65e80-c451-11eb-8d9f-0121ee652a12.png)


`ConfirmModal`, narrow viewport:

<img src="https://user-images.githubusercontent.com/439947/120656429-9b30e500-c451-11eb-87a6-08be792d7f51.png" width="400" />

`ConfirmModal`, narrow viewport, with excessively long content (NB, this example is not included in source):

<img src="https://user-images.githubusercontent.com/439947/120656388-93714080-c451-11eb-877d-4d17aae4d098.png" width="400" />

`ConfirmModal`, wider viewport:

![C1268CBD-4F24-4A0E-A10F-037E7E8C80EA](https://user-images.githubusercontent.com/439947/120656593-be5b9480-c451-11eb-8830-568d87f9ab42.png)


Fixes https://github.com/hypothesis/frontend-shared/issues/86
