### PR TITLE
Introduce spacing-unit scale and spacing patterns

### DIFF
--- a/src/pattern-library/components/patterns/LayoutPatterns.js
+++ b/src/pattern-library/components/patterns/LayoutPatterns.js
@@ -1,3 +1,4 @@
+import classnames from 'classnames';
 import { useState } from 'preact/hooks';
 
 import { LabeledButton } from '../../../';
@@ -9,12 +10,153 @@ import {
   PatternExample,
 } from '../PatternPage';
 
+function SquareBlock() {
+  return (
+    <div
+      className="hyp-u-bg-color--grey-4"
+      style={{ width: '2rem', height: '2rem' }}
+    />
+  );
+}
+
+/**
+ * Render an example of vertical or horizontal spacing between elements.
+ *
+ * @param {Object} options
+ *   @param {'horizontal'|'vertical'} options.direction
+ *   @param {number} options.size - Spacing unit size, 0 - 9
+ *   @param {boolean} [options.defaultSize] - Is this the "default" spacing for
+ *     this orientation?
+ */
+function SpacingDemo({ direction, size, defaultSize = false }) {
+  const layoutClass =
+    direction === 'vertical' ? 'hyp-u-layout-column' : 'hyp-u-layout-row';
+  const baseClass =
+    direction === 'vertical'
+      ? 'hyp-u-vertical-spacing'
+      : 'hyp-u-horizontal-spacing';
+  const sizeClass = `${baseClass}--${size}`;
+  return (
+    <div className={classnames(layoutClass, baseClass)}>
+      {defaultSize ? (
+        <div>
+          <strong>{size}*</strong>
+        </div>
+      ) : (
+        <div>{size}</div>
+      )}
+      <div className={classnames(layoutClass, sizeClass, 'hyp-u-border')}>
+        <SquareBlock />
+        <SquareBlock />
+        <SquareBlock />
+        <SquareBlock />
+        <SquareBlock />
+      </div>
+      {direction === 'horizontal' && (
+        <div>
+          <code>.{sizeClass}</code>
+        </div>
+      )}
+    </div>
+  );
+}
+
 export default function LayoutPatterns() {
   const [showExample1, setShowExample1] = useState(false);
   const [showExample2, setShowExample2] = useState(false);
   const [showExample3, setShowExample3] = useState(false);
+  const scaleUnits = [
+    '0',
+    '0.125rem',
+    '0.25rem',
+    '0.5rem',
+    '0.75rem',
+    '1rem (default unit)',
+    '1.5rem',
+    '2rem',
+    '4rem',
+    '8rem',
+  ];
   return (
     <PatternPage title="Layout">
+      <Pattern title="Spacing Units">
+        <p>
+          Spacing units provide a way to apply predefined, consistent spacing
+          dimensions between (margins) and around (padding) elements. Our
+          spacing is based on a <code>1rem</code> foundational unit.
+        </p>
+        <div className="hyp-u-vertical-spacing">
+          {scaleUnits.map((unitLength, idx) => (
+            <div
+              key={idx}
+              className={`hyp-u-layout-row hyp-u-bg-color--grey-5 hyp-u-horizontal-spacing--${idx}`}
+            >
+              <div
+                className="hyp-u-bg-color--white"
+                style={{ paddingRight: '1rem' }}
+              >
+                <strong>{idx}</strong>
+              </div>
+              <div
+                className="hyp-u-bg-color--white hyp-u-stretch"
+                style={{ paddingLeft: '1rem' }}
+              >
+                <code>{unitLength}</code>
+              </div>
+            </div>
+          ))}
+        </div>
+      </Pattern>
+      <Pattern title="Horizontal spacing">
+        <p>
+          Sometimes you may need to apply or adjust horizontal spacing between
+          an element&apos;s immediate children.
+        </p>
+
+        <p>
+          The default spacing unit used by{' '}
+          <code>.hyp-u-horizontal-spacing</code> and mixins is 3, marked with an
+          asterisk below.
+        </p>
+
+        <div className="hyp-u-vertical-spacing">
+          <div className="hyp-u-layout-column hyp-u-vertical-spacing">
+            <SpacingDemo direction="horizontal" size={0} />
+            <SpacingDemo direction="horizontal" size={1} />
+            <SpacingDemo direction="horizontal" size={2} />
+            <SpacingDemo direction="horizontal" size={3} defaultSize />
+            <SpacingDemo direction="horizontal" size={4} />
+            <SpacingDemo direction="horizontal" size={5} />
+            <SpacingDemo direction="horizontal" size={6} />
+            <SpacingDemo direction="horizontal" size={7} />
+            <SpacingDemo direction="horizontal" size={8} />
+            <SpacingDemo direction="horizontal" size={9} />
+          </div>
+        </div>
+      </Pattern>
+      <Pattern title="Vertical spacing">
+        <p>
+          Sometimes you may need to apply or adjust vertical spacing between an
+          element&apos;s immediate children.
+        </p>
+
+        <p>
+          The default spacing unit used by <code>.hyp-u-vertical-spacing</code>{' '}
+          and mixins is 5, marked with an asterisk below.
+        </p>
+        <div className="hyp-u-layout-row hyp-u-horizontal-spacing--7">
+          <SpacingDemo direction="vertical" size={0} />
+          <SpacingDemo direction="vertical" size={1} />
+          <SpacingDemo direction="vertical" size={2} />
+          <SpacingDemo direction="vertical" size={3} />
+          <SpacingDemo direction="vertical" size={4} />
+          <SpacingDemo direction="vertical" size={5} defaultSize />
+          <SpacingDemo direction="vertical" size={6} />
+          <SpacingDemo direction="vertical" size={7} />
+          <SpacingDemo direction="vertical" size={8} />
+          <SpacingDemo direction="vertical" size={9} />
+        </div>
+      </Pattern>
       <Pattern title="Fixed-Centered Positioning">
         <p>
           The <code>fixed-centered</code> layout pattern centers an element both

--- a/styles/README.md
+++ b/styles/README.md
@@ -57,14 +57,14 @@ Mixins in `mixins` and utility styles in `util` loosely apply [Atomic Design](ht
 
 The directory that a SASS module lives in dictates what it should provide (styles, mixins, variables, etc.) and what kind of dependencies it is allowed:
 
-| Directory    | Description                                                 | Provides  | Dependencies          |
-| ------------ | ----------------------------------------------------------- | --------- | --------------------- |
-| `base`       | Reset and element styles. Used only by the pattern library. | styles    | mixins, variables[^1] |
-| `components` | Styles for shared components                                | styles    | any                   |
-| `mixins`     | Mixins                                                      | mixins    | mixins[^2], variables |
-| `patterns`   | Pattern styles                                              | styles    | mixins                |
-| `util`       | Utility styles                                              | styles    | mixins                |
-| `variables`  | Variables                                                   | variables | none                  |
+| Directory    | Description                                                   | Provides             | Dependencies          |
+| ------------ | ------------------------------------------------------------- | -------------------- | --------------------- |
+| `base`       | Reset and element styles. Used only by the pattern library.   | styles               | mixins, variables[^1] |
+| `components` | Styles for shared components                                  | styles               | any                   |
+| `mixins`     | Mixins                                                        | mixins               | mixins[^2], variables |
+| `patterns`   | Pattern styles                                                | styles               | mixins                |
+| `util`       | Utility styles                                                | styles               | mixins                |
+| `variables`  | Variables and functions that return values based on variables | variables, functions | none                  |
 
 ## CSS Output and Ordering
 

--- a/styles/mixins/_layout.scss
+++ b/styles/mixins/_layout.scss
@@ -1,6 +1,5 @@
 @use '../variables' as var;
 
-$-space: var.$layout-space;
 $-color-overlay: var.$color-overlay;
 
 /**
@@ -48,39 +47,24 @@ $-color-overlay: var.$color-overlay;
 }
 
 /**
- * Establish a vertical (margin) rhythm for this element's immediate
- * children (i.e. put equal space between children).
+ * Put `$size` of vertical space between all immediate children.
  *
- * This mixin uses `!important` such that it can compete with specificity
- * of reset rules that set some of our element's margins to 0. That allows
- * these rules—which are applied to a parent element—to be able to assert
- * margins, as it should be able to do.
- *
- * This mixin uses a "lobotomized owl" selector.
- * See https://css-tricks.com/lobotomized-owls/
- *
- * @param $size [$-space]: Spacing size (padding)
+ * @param {length} [$size] - Relative size of spacing, 0 - 9. Default 5
  */
-@mixin vertical-rhythm($size: $-space) {
-  & > * + * {
-    margin-top: $size !important;
+@mixin vertical-spacing($size: 5) {
+  & > :not(:first-child) {
+    margin-top: var.space($size);
   }
 }
 
 /**
- * Establish a horizontal (margin) rhythm for this element's immediate
- * children (i.e. put equal space between children).
+ * Put `$size` of horizontal space between all immediate children.
  *
- * This mixin uses `!important` such that it can compete with specificity
- * of reset rules that set some of our element's margins to 0. That allows
- * these rules—which are applied to a parent element—to be able to assert
- * margins, as it should be able to do.
- *
- * @param $size [$-space * 0.5] - Size of horizontal margin between child elements
+ * @param {length} [$size] - Relative size of spacing, 0 - 9. Default 3
  */
-@mixin horizontal-rhythm($size: $-space * 0.5) {
-  & > * + * {
-    margin-left: $size !important;
+@mixin horizontal-spacing($size: 3) {
+  & > :not(:first-child) {
+    margin-left: var.space($size);
   }
 }
 
@@ -106,4 +90,10 @@ $-color-overlay: var.$color-overlay;
   bottom: 0;
   right: 0;
   background-color: $-color-overlay;
+}
+
+// A content block, with default padding and vertical spacing between elements
+@mixin block {
+  padding: var.space(); // TODO: padding and mixins
+  @include vertical-spacing;
 }

--- a/styles/mixins/patterns/_molecules.scss
+++ b/styles/mixins/patterns/_molecules.scss
@@ -5,7 +5,6 @@
 
 $-border-radius: var.$border-radius;
 $-color-background: var.$color-background;
-$-space: var.$layout-space;
 
 /**
  * Patterns that are composites of multiple atomic utilities, but
@@ -16,10 +15,8 @@ $-space: var.$layout-space;
  * Give an element a border, background color and internal vertical spacing
  */
 @mixin frame($with-hover: false) {
+  @include layout.block;
   @include atoms.border;
-  @include layout.vertical-rhythm;
-
-  padding: $-space;
   border-radius: $-border-radius;
   background-color: $-color-background;
 }
@@ -53,10 +50,10 @@ $-space: var.$layout-space;
 @mixin actions($direction: row) {
   @if $direction == row {
     @include layout.row(right);
-    @include layout.horizontal-rhythm($-space * 0.75);
+    @include layout.horizontal-spacing($size: 4);
   } @else {
     @include layout.column;
-    @include layout.vertical-rhythm($-space * 0.5);
+    @include layout.vertical-spacing($size: 3);
   }
 }
 

--- a/styles/mixins/patterns/_organisms.scss
+++ b/styles/mixins/patterns/_organisms.scss
@@ -6,7 +6,6 @@
 @use 'molecules';
 
 $-color-brand: var.$color-brand;
-$-space: var.$layout-space;
 
 /**
  * A panel is a card that adds an optional header and/or close button positioning.
@@ -19,9 +18,9 @@ $-space: var.$layout-space;
   & > header,
   &__header {
     @include layout.row($align: center);
+    @include layout.horizontal-spacing;
     @include atoms.border(bottom);
-    @include layout.horizontal-rhythm($-space);
-    padding-bottom: $-space;
+    padding-bottom: var.space();
   }
 
   &__title {
@@ -38,8 +37,8 @@ $-space: var.$layout-space;
   // effect of making the vertical space around the header look more even.
   &--closeable > header,
   &--closeable &__header {
-    padding-bottom: $-space * 0.25;
-    margin-top: $-space * -0.5;
+    padding-bottom: var.space(2);
+    margin-top: -1 * var.space(3);
   }
 
   &--closeable > header &__close,
@@ -49,7 +48,7 @@ $-space: var.$layout-space;
     // This also right-aligns the edge of the close icon with the right edge
     // of the bottom border using a negative right margin.
     font-size: 1.375em;
-    margin-right: $-space * -0.75;
+    margin-right: -1 * var.space(4);
   }
 
   &__actions {

--- a/styles/pattern-library.scss
+++ b/styles/pattern-library.scss
@@ -101,10 +101,7 @@ pre {
   p {
     margin: 1em;
     margin-left: 0;
-  }
-
-  & > p:first-of-type {
-    font-size: 125%;
+    font-size: 1.25rem;
   }
 
   & > h2 {

--- a/styles/util/_colors.scss
+++ b/styles/util/_colors.scss
@@ -4,6 +4,7 @@
 
 // This mapping is necessary due to limitations in SASS interpolation
 $all-colors: (
+  'white': white,
   'grey-0': colors.$grey-0,
   'grey-1': colors.$grey-1,
   'grey-2': colors.$grey-2,

--- a/styles/util/_layout.scss
+++ b/styles/util/_layout.scss
@@ -1,17 +1,5 @@
 @use '../mixins/layout';
 
-// Apply vertical rhythm (top/bottom margins between immediate-child elements)
-// at the default rhythm-unit size
-.hyp-u-vertical-rhythm {
-  @include layout.vertical-rhythm;
-}
-
-// Apply horizontal rhythm (left/right margins between immediate-child elements)
-// at the default horizontal-rhythm size
-.hyp-u-horizontal-rhythm {
-  @include layout.horizontal-rhythm;
-}
-
 // Establish a row flex container
 .hyp-u-layout-row {
   @include layout.row;
@@ -32,6 +20,10 @@
   @include layout.column;
 }
 
+.hyp-u-stretch {
+  flex-grow: 1;
+}
+
 // Position the element centered vertically and horizontally in the entire viewport
 .hyp-u-fixed-centered {
   @include layout.fixed-centered;
@@ -40,4 +32,28 @@
 // A full-viewport-width and -height semi-opaque backdrop overlay
 .hyp-u-overlay {
   @include layout.overlay;
+}
+
+// Apply default horizontal spacing
+.hyp-u-horizontal-spacing {
+  @include layout.horizontal-spacing;
+}
+
+// Apply default vertical spacing
+.hyp-u-vertical-spacing {
+  @include layout.vertical-spacing;
+}
+
+// Generate horizontal-spacing utility classes, 0-9
+@for $space-unit from 0 through 9 {
+  .hyp-u-horizontal-spacing--#{$space-unit} {
+    @include layout.horizontal-spacing($size: $space-unit);
+  }
+}
+
+// Generate vertical-spacing utility classes, 0-9
+@for $space-unit from 0 through 9 {
+  .hyp-u-vertical-spacing--#{$space-unit} {
+    @include layout.vertical-spacing($size: $space-unit);
+  }
 }

--- a/styles/variables/_index.scss
+++ b/styles/variables/_index.scss
@@ -1,8 +1,40 @@
 @forward 'colors' as color-*;
-@forward 'layout' as layout-*;
+
+@use 'sass:list';
 
 $border-radius: 2px;
 
 // Minimum recommended size for tap targets on mobile.
 // This value originated from Apple's Human Interface Guidelines.
 $touch-target-size: 44px;
+
+/**
+ * Return a length value for use in spacing between (margin) or around
+ * (padding) elements.
+ *
+ * @param {number} [$space-unit] - The relative size of the space desired,
+ *   from 0 (no space) to 9 (lots of space). Default 5.
+ */
+@function space($space-unit: 5) {
+  $-default: 1rem;
+  $-spaces-0: /* 0 */ 0;
+  $-spaces: (
+    // NB: SASS lists are 1-indexed
+    /* 1 */ 0.125rem,
+    /* 2 */ 0.25rem,
+    /* 3 */ 0.5rem,
+    /* 4 */ 0.75rem,
+    /* 5 */ $-default,
+    /* 6 */ 1.5rem,
+    /* 7 */ 2rem,
+    /* 8 */ 4rem,
+    /* 9 */ 8rem
+  );
+  @if $space-unit == 0 {
+    // The non-space space
+    @return $-spaces-0;
+  } @else {
+    // This will throw an error if index is out of bounds
+    @return list.nth($-spaces, $space-unit);
+  }
+}

--- a/styles/variables/_layout.scss
+++ b/styles/variables/_layout.scss
@@ -1,2 +1,0 @@
-// Base rhythm units for layout and spacing (margins, padding)
-$space: 1rem;


### PR DESCRIPTION
This PR:

* Defines a `rem`-based “spacing” system that can be used to apply space around and between elements, based on a scale from 0 to 9. 
* Replaces the existing “t-shirt-sizing”-like system in the client. Provides a `space` function (in the `variables` module) that returns an appropriate spacing value, versus individual SASS variables for each size.
* Disentangles void-space units (defined here) from future sizing units (font sizing, content/element sizing). These are somewhat conflated in the client’s existing design system.
* Replaces  `horizontal-rhythm` and `vertical-rhythm` mixins and utility classes with `horizontal-spacing` and `vertical-spacing` mixins and utility classes. These new variants obviate the need for the `!important` rule by leveraging specificity instead, have less clever naming, and don’t use a lobotomized owl selector anymore.
* Adds spacing examples to the Layout pattern-library page.
* Provides some foundational underpinnings for immediately-needed work, such as the `Checkbox` component layout and grid layouts needed for LMS.

There are no user-visible changes as a result of this PR, nor any changes to the public API.

Part of https://github.com/hypothesis/frontend-shared/issues/68

### Pattern Library examples

Here are a few screen shots from the [Pattern Library layout page](http://localhost:4001/ui-playground/foundations-layout).

NB: These examples are functional, if not elegant. I didn't want to put too much time in making them really pretty for now.

<img width="1064" alt="Screen Shot 2021-06-09 at 9 56 10 AM" src="https://user-images.githubusercontent.com/439947/121368915-6c12eb80-c909-11eb-8e05-cac139f42978.png">

<img width="1093" alt="Screen Shot 2021-06-09 at 9 56 41 AM" src="https://user-images.githubusercontent.com/439947/121368953-7339f980-c909-11eb-979a-dfd289b0252a.png">

<img width="1078" alt="Screen Shot 2021-06-09 at 9 56 32 AM" src="https://user-images.githubusercontent.com/439947/121368937-703f0900-c909-11eb-98f6-a62b397d80db.png">


### Background

This system bases spacing on a `1rem` base unit. In almost all cases, `1rem` = `16px`, but in the rare cases when a user has adjusted their browser’s base font size (through preferences, typically), our spacing will scale accordingly.

However, `rem`-based units give us more predictability than the previously-used `em`-based units, which could be fiddly to figure out in practice (we tend to have a lot of local `font-size` changes, e.g., in our apps). `rem`-based fonts and spacing are recommended for a11y, because of their proportional reaction to zooming.

By encapsulating the spacing scale within a  `space` function and spacing mixins, we give ourselves the opportunity to potentially overlay a responsive scale later (i.e. different space-unit values based on breakpoints), and developers don’t have to worry about variable naming or exact values—they can twiddle with the space units from 0 - 9 until they get something that looks right (or rely on the defaults for vertical and horizontal spacing).

### What's not included

To keep this PR changeset from being overwhelming, these tasks are left for future PRs:

* Padding classes, mixins, pattern-library examples—these changes contain margin-related spacing only
* Pattern-library font and other visual cleanup (it’s still fairly fugly, acknowledged, but getting a few more foundations in place will make it easier to address)
* Additional utility classes for margins (i.e. for applying margin to an element itself instead of these spacing classes, which apply margins to children)

The spacing system is entirely private to the package at present. The previous internal spacing was based on `1rem` also (i.e. this doesn’t represent a switch internally from `em`s to `rem`s), so there should be no user-visible changes to the pattern and component layout generated by this package. That makes the risks of trying it out a little lower than if we were exposing it. If it feels cumbersome, we can abort!

### Sources

I took the biggest inspirations from the GOV.uk design system and BBC Gel. 

* [Spacing – GOV.UK Design System](https://design-system.service.gov.uk/styles/spacing/) — 0 - 9 scale, but uses `px` units
* [BBC GEL | Spacing Units](https://www.bbc.co.uk/gel/guidelines/spacing-units) - explains the distinction between void spacing and sizing; uses `rem`
* * [Pattern Lab](https://boltdesignsystem.com/pattern-lab/?p=visual-styles-spacing-system) (Bolt) - Didn’t use this, but example of varying scales horizontally and vertically. This felt a little too complex.
* https://designsystem.gov.au/components/core/#spacing has some interesting API ideas about a spacing mixin
* [VTEX Styleguide](https://styleguide.vtex.com/#!/Spacing) - Sort of similar idea
* [Hudl Uniform](https://uniform.hudl.com/guidelines/layout/space/design) - Another argument for basing on `rem`
* [Bulb Design System](https://design.bulb.co.uk/styles/spacing) - A little cleverness in naming; they have something analogous to our spacing pattern: [Bulb Design System](https://design.bulb.co.uk/styles/spacing#vspace)
* [Spacing | Skyline, Benevity’s Design System.](https://skyline.benevity.org/design-language/spacing/)

And a comprehensive explanation of `rem` vs `em` vs `px` in scalability:

* [Pixels vs. Relative Units in CSS: why it’s still a big deal - 24 Accessibility](https://www.24a11y.com/2019/pixels-vs-relative-units-in-css-why-its-still-a-big-deal/)