### PR TITLE
Add icons to package

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -9,5 +9,8 @@ export { SvgIcon, registerIcons } from './components/SvgIcon';
 // Hooks
 export { useElementShouldClose } from './hooks/use-element-should-close';
 
+// Shared icons
+export { default as icons } from './icons';
+
 // Utilities
 export { normalizeKeyName } from './browser-compatibility-utils';


### PR DESCRIPTION
This PR makes a map of this package's icons available to applications that use the package, similar to the structure of `icons` modules in the individual applications (a map of `iconName` to a `require`'d icon source).

Changes to package: `icons` is available from package entrypoint/exports.

Problem: If this package adds or updates a component that uses `SvgIcon`, the icon for that `SvgIcon` needs to be guaranteed-available-and-registered with the consuming applications, or applications can break. I ran into this while implementing a `Checkbox` feature that used a "checkbox" SVG to style the checkbox input. This package registers that SVG image, but when I tested the package against the `lms` project, everything asploded because the `lms` app doesn't know about `checkbox` (SVG).

We need some sort of fix ASAP to ensure that updates to this package won't _break_ consuming apps.

The `lms` app's current `icons` module looks like this:

```
export default {
  // LMS icons
  'caret-down': require('../../images/caret-down.svg'),
  check: require('../../images/check.svg'),
  spinner: require('../../images/spinner.svg'),

  // Shared icons
  'arrow-left': require('@hypothesis/frontend-shared/images/icons/arrow-left.svg'),
  'arrow-right': require('@hypothesis/frontend-shared/images/icons/arrow-right.svg'),
};
```

That means that this `icons` registry would need to be updated in lockstep with this package, and needs to know about the asset structure (SVG paths) in this package. 

Instead, I propose an app's `icons` module could be structured like so:

```
import { icons as sharedIcons } from '@hypothesis/frontend-shared';

const appIcons = {
  'caret-down': require('../../images/caret-down.svg'),
  check: require('../../images/check.svg'),
  spinner: require('../../images/spinner.svg'),
}

export default {...sharedIcons, ...appIcons};
```

I've tested this strategy in the sidebar's `icons` module and it seems to work as expected.

This isn't a perfect solution in that:

* It will register _all_ shared icons, even if this app doesn't make use of all of them. Probably not too big of a deal.
* It's something that will need to be integrated into each `icons` module in our apps. A one-time task and, again, not a big deal, but it represents an "extra step" to get this package to work that I'm not entirely comfortable with. At the very least, it will need to be documented and commented.
* It "handles" icon-naming collisions in that it allows apps to override shared icons. However, this could cause unexpected results if an app developer were unaware that a shared icon of the same name already existed. I'm not sure how rampant this problem would be, or how we might prevent it. 
