### PR TITLE
Package to v3.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v3.1.1] - 2021-06-11
+
+Fix typo in Changelog.
+
+## [v3.1.0] - 2021-06-11
+
+Updates `Checkbox` to use styled SVG for appearance and introduces an internal
+spacing system.
+
+- Add styling, design pattern for checkbox components [#95](https://github.com/hypothesis/frontend-shared/pull/95)
+- Introduce spacing-unit scale and spacing patterns [#92](https://github.com/hypothesis/frontend-shared/pull/92)
+
 ## [v3.0.0] - 2021-06-08
 
 `Dialog`, `Modal` and `ConfirmModal` components added.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hypothesis/frontend-shared",
-  "version": "3.0.0",
+  "version": "3.1.1",
   "description": "Shared components, styles and utilities for Hypothesis projects",
   "license": "BSD-2-Clause",
   "repository": "hypothesis/frontend-shared",


### PR DESCRIPTION
Version the package.

This started as a version-bump to `3.1.0`, but a typo in the `CHANGELOG` led to `3.1.1` because the `3.0.0` tag had already been pushed.