### PR TITLE
Version 3.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v3.2.0] - 2021-06-15
+
+Adds theming support.
+
+- Add basic clean-theme support and update `card`, `frame` patterns [#89](https://github.com/hypothesis/frontend-shared/pull/89)
+
 ## [v3.1.1] - 2021-06-11
 
 Fix typo in Changelog.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hypothesis/frontend-shared",
-  "version": "3.1.1",
+  "version": "3.2.0",
   "description": "Shared components, styles and utilities for Hypothesis projects",
   "license": "BSD-2-Clause",
   "repository": "hypothesis/frontend-shared",


### PR DESCRIPTION
Release v3.2.0. Per discussion in previous PR #96, the changes contained in this version have already been approved, and it's a small version change. I'm going to merge without review.