### PR TITLE
Fix `IconButton` horizontal icon alignment on narrow screens

### DIFF
--- a/styles/components/buttons/_mixins.scss
+++ b/styles/components/buttons/_mixins.scss
@@ -94,6 +94,10 @@
         &--large {
           min-width: c.$touch-target-size;
           min-height: c.$touch-target-size;
+          // The forced min-size means that we need to explicitly horizontally
+          // center or the icon could appear off-center.
+          // (vertical centering is already applied via an `align-items` rule)
+          justify-content: center;
         }
       }
     }


### PR DESCRIPTION
There is a media-query that will enforce a minimum width and height on
`IconButton`s to ensure a minimum tap-target size. Before these changes,
icons within `IconButton`s on narrow screens could appear off-center
horizontally.

The icon image is already vertically centered.
Add a horizontal-alignment rule here to ensure that the icon image
always appears in the center of the entire button.

Before, [Pattern-Library buttons page](http://localhost:4001/ui-playground/components-buttons) in narrow viewport:

<img width="411" alt="Screen Shot 2021-06-16 at 1 41 16 PM" src="https://user-images.githubusercontent.com/439947/122267264-adc30980-cea8-11eb-961c-2740b1f6c6e6.png">

After:

<img width="361" alt="Screen Shot 2021-06-16 at 1 40 55 PM" src="https://user-images.githubusercontent.com/439947/122267275-af8ccd00-cea8-11eb-99e5-771edf324c35.png">
