### PR TITLE
Add additional utility mixins and classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,18 +14,12 @@ Your project must have Preact installed as a dependency.
 $ npm install @hypothesis/frontend-shared --save
 ```
 
-### In SASS modules
+### SASS
 
-To import default styling of frontend-shared components, include this line in the main project's SASS.
+To add styles for all shared components to your project's SASS:
 
 ```scss
 @use '@hypothesis/frontend-shared/styles';
-```
-
-Mixins can be imported directly
-
-```scss
-@use "@hypothesis/frontend-shared/styles/mixins" as mixins;
 ```
 
 ### In JS

--- a/styles/mixins/_layout.scss
+++ b/styles/mixins/_layout.scss
@@ -3,6 +3,36 @@
 $-color-overlay: var.$color-overlay;
 
 /**
+ * Apply a margin to all sides (default) or designated `$side` in specified
+ * `$size` (default: spacing-unit 5)
+ *
+ * @param {number} [$size] - spacing-unit 0-9, default 5
+ * @param {'left'|'right'|'top'|'bottom'} [$side]
+ */
+@mixin margin($size: 5, $side: null) {
+  @if ($side) {
+    margin-#{$side}: var.space($size);
+  } @else {
+    margin: var.space($size);
+  }
+}
+
+/**
+ * Apply padding to all sides (default) or designated `$side` in specified
+ * `$size` (default: spacing-unit 3)
+ *
+ * @param {number} [$size] - spacing-unit 0-9, default 3
+ * @param {'left'|'right'|'top'|'bottom'} [$side]
+ */
+@mixin padding($size: 3, $side: null) {
+  @if ($side) {
+    padding-#{$side}: var.space($size);
+  } @else {
+    padding: var.space($size);
+  }
+}
+
+/**
  * Abstract mixin for establishing basic flex container. External users should
  * use `row` or `column` as needed. Default values here reflect default CSS
  * values for flex rules.

--- a/styles/util/_atoms.scss
+++ b/styles/util/_atoms.scss
@@ -16,6 +16,10 @@
   @include atoms.border(top);
 }
 
+.hyp-u-border--bottom {
+  @include atoms.border(bottom);
+}
+
 .hyp-u-shadow {
   @include atoms.shadow;
 }

--- a/styles/util/_layout.scss
+++ b/styles/util/_layout.scss
@@ -1,38 +1,9 @@
 @use '../mixins/layout';
 
-// Establish a row flex container
-.hyp-u-layout-row {
-  @include layout.row;
-}
+/* Spacing classes */
 
-// Establish a row flex container with items justified and aligned center
-.hyp-u-layout-row--center {
-  @include layout.row($align: center, $justify: center);
-}
-
-// Establish a row flex container with items justified center
-.hyp-u-layout-row--justify-center {
-  @include layout.row($justify: center);
-}
-
-// Establish a column flex container
-.hyp-u-layout-column {
-  @include layout.column;
-}
-
-.hyp-u-stretch {
-  flex-grow: 1;
-}
-
-// Position the element centered vertically and horizontally in the entire viewport
-.hyp-u-fixed-centered {
-  @include layout.fixed-centered;
-}
-
-// A full-viewport-width and -height semi-opaque backdrop overlay
-.hyp-u-overlay {
-  @include layout.overlay;
-}
+// These classes are applied to a parent element to establish horizontal
+// or vertical spacing between immediate-child elements.
 
 // Apply default horizontal spacing
 .hyp-u-horizontal-spacing {
@@ -56,4 +27,150 @@
   .hyp-u-vertical-spacing--#{$space-unit} {
     @include layout.vertical-spacing($size: $space-unit);
   }
+}
+
+/* Margin and padding classes */
+
+// These classes are applied to individual elements to override margin or padding
+
+// Default-sized margin classes
+.hyp-u-margin {
+  @include layout.margin;
+}
+
+.hyp-u-margin--left {
+  @include layout.margin($side: 'left');
+}
+
+.hyp-u-margin--right {
+  @include layout.margin($side: 'right');
+}
+
+.hyp-u-margin--top {
+  @include layout.margin($side: 'top');
+}
+
+.hyp-u-margin--bottom {
+  @include layout.margin($side: 'bottom');
+}
+
+// Generate margin utility classes for spacing units 0-9
+@for $space-unit from 0 through 9 {
+  .hyp-u-margin--#{$space-unit} {
+    @include layout.margin($size: $space-unit);
+  }
+
+  .hyp-u-margin--left--#{$space-unit} {
+    @include layout.margin($size: $space-unit, $side: 'left');
+  }
+
+  .hyp-u-margin--right--#{$space-unit} {
+    @include layout.margin($size: $space-unit, $side: 'right');
+  }
+
+  .hyp-u-margin--top--#{$space-unit} {
+    @include layout.margin($size: $space-unit, $side: 'top');
+  }
+
+  .hyp-u-margin--bottom--#{$space-unit} {
+    @include layout.margin($size: $space-unit, $side: 'bottom');
+  }
+}
+
+// Default padding-size classes
+.hyp-u-padding {
+  @include layout.padding;
+}
+
+.hyp-u-padding--left {
+  @include layout.padding($side: 'left');
+}
+
+.hyp-u-padding--right {
+  @include layout.padding($side: 'right');
+}
+
+.hyp-u-padding--top {
+  @include layout.padding($side: 'top');
+}
+
+.hyp-u-padding--bottom {
+  @include layout.padding($side: 'bottom');
+}
+
+// Generate padding utility classes for spacing units 0-9
+@for $space-unit from 0 through 9 {
+  .hyp-u-padding--#{$space-unit} {
+    @include layout.padding($size: $space-unit);
+  }
+
+  .hyp-u-padding--left--#{$space-unit} {
+    @include layout.padding($size: $space-unit, $side: 'left');
+  }
+
+  .hyp-u-padding--right--#{$space-unit} {
+    @include layout.padding($size: $space-unit, $side: 'right');
+  }
+
+  .hyp-u-padding--top--#{$space-unit} {
+    @include layout.padding($size: $space-unit, $side: 'top');
+  }
+
+  .hyp-u-padding--bottom--#{$space-unit} {
+    @include layout.padding($size: $space-unit, $side: 'bottom');
+  }
+}
+
+/* Flex-layout classes */
+
+// Establish a row flex container
+.hyp-u-layout-row {
+  @include layout.row;
+}
+
+// Establish a row flex container with items justified and aligned center
+// (centered on both flex axes)
+.hyp-u-layout-row--center {
+  @include layout.row($align: center, $justify: center);
+}
+
+// Establish a row flex container that aligns its children along the baseline
+.hyp-u-layout-row--align-baseline {
+  @include layout.row($align: baseline);
+}
+
+// Establish a row flex container with items aligned center
+.hyp-u-layout-row--align-center {
+  @include layout.row($align: center);
+}
+
+// Establish a row flex container with items justified center
+.hyp-u-layout-row--justify-center {
+  @include layout.row($justify: center);
+}
+
+// Establish a row flex container with items justified right
+.hyp-u-layout-row--justify-right {
+  @include layout.row($justify: right);
+}
+
+// Establish a column flex container
+.hyp-u-layout-column {
+  @include layout.column;
+}
+
+.hyp-u-stretch {
+  flex-grow: 1;
+}
+
+/* Positioning and overlay classes */
+
+// Position the element centered vertically and horizontally in the entire viewport
+.hyp-u-fixed-centered {
+  @include layout.fixed-centered;
+}
+
+// A full-viewport-width and -height semi-opaque backdrop overlay
+.hyp-u-overlay {
+  @include layout.overlay;
 }


### PR DESCRIPTION
This is a relatively dull PR that fills in some gaps for utility classes and mixins. These are all still private to the package.

This PR also includes a commit that updates the package README, which was embarrassingly out-of-date.

Motivation: fill in any obvious gaps, and reproduce utility classes/mixins that are in use in other applications.

No user-visible changes at all. All of these mixins and utility classes are still private to the package. But we're getting closer to being able to make some utilities public here...

Part of https://github.com/hypothesis/frontend-shared/issues/74