### PR TITLE
Allow for overflow constraints on content within Modals

### DIFF
--- a/src/components/Dialog.js
+++ b/src/components/Dialog.js
@@ -1,8 +1,14 @@
 import classnames from 'classnames';
 import { useEffect, useLayoutEffect, useRef, useState } from 'preact/hooks';
 
-import { IconButton, LabeledButton } from '../';
-import { SvgIcon } from './SvgIcon';
+import { IconButton, LabeledButton } from './buttons';
+import { registerIcons, SvgIcon } from './SvgIcon';
+
+// Register the checkbox icon for use
+registerIcons({
+  /** @ts-ignore - TS doesn't understand require here */
+  'hyp-cancel': require('../../images/icons/cancel.svg'),
+});
 
 let idCounter = 0;
 
@@ -121,7 +127,7 @@ export function Dialog({
         </h2>
         {onCancel && (
           <div className="Hyp-Dialog__close">
-            <IconButton icon="cancel" title="Close" onClick={onCancel} />
+            <IconButton icon="hyp-cancel" title="Close" onClick={onCancel} />
           </div>
         )}
       </header>

--- a/src/components/Dialog.js
+++ b/src/components/Dialog.js
@@ -131,7 +131,7 @@ export function Dialog({
           </div>
         )}
       </header>
-      <div>{children}</div>
+      {children}
       <div className="Hyp-Dialog__actions">
         {onCancel && (
           <LabeledButton data-testid="cancel-button" onClick={onCancel}>

--- a/src/pattern-library/components/patterns/DialogComponents.js
+++ b/src/pattern-library/components/patterns/DialogComponents.js
@@ -36,14 +36,8 @@ const showDialog = ({ DialogComponent, container, setOpen, props }) => {
     return null;
   }
 
-  return render(
-    <DialogComponent
-      icon="edit"
-      initialFocus={initialFocusRef}
-      title="Basic dialog with icon"
-      onCancel={() => close()}
-      {...props}
-    >
+  if (!props.children) {
+    props.children = (
       <div>
         <p>This is an example of a dialog.</p>
         <p>
@@ -56,7 +50,17 @@ const showDialog = ({ DialogComponent, container, setOpen, props }) => {
           type="text"
         />
       </div>
-    </DialogComponent>,
+    );
+  }
+
+  return render(
+    <DialogComponent
+      icon="edit"
+      initialFocus={initialFocusRef}
+      title="Basic dialog with icon"
+      onCancel={() => close()}
+      {...props}
+    />,
     container
   );
 };
@@ -79,6 +83,7 @@ export default function DialogComponents() {
   // Dialog/Modal state for each of the examples
   const [dialogIsOpen, setDialogIsOpen] = useState(false);
   const [, setModalIsOpen] = useState(false);
+  const [, setLongModalIsOpen] = useState(false);
   const [, setConfirmModalIsOpen] = useState(false);
 
   const openDialog = () => {
@@ -103,6 +108,101 @@ export default function DialogComponents() {
       setOpen: setModalIsOpen,
       props: {
         buttons,
+      },
+    });
+  };
+
+  const openLongModal = () => {
+    const children = (
+      <div style={{ overflow: 'auto' }}>
+        <p>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis a sapien
+          cursus, fringilla diam posuere, varius urna. Phasellus dictum sodales
+          dui, sed scelerisque mauris auctor et. Integer suscipit justo in erat
+          tristique, nec feugiat augue ultrices. Sed accumsan pretium commodo.
+          Orci varius natoque penatibus et magnis dis parturient montes,
+          nascetur ridiculus mus. Ut lobortis tortor metus, sed rutrum risus
+          ultricies non. Maecenas ultricies rutrum diam non feugiat. Nam ut ex
+          ac enim efficitur semper. Integer sed rhoncus eros. Nulla pharetra
+          vulputate faucibus. Vestibulum vestibulum orci non maximus aliquet.
+          Donec id dui ac ipsum pellentesque gravida sit amet non sem.
+          Suspendisse malesuada turpis id erat porta, nec luctus odio mollis.
+          Sed a arcu sed sem venenatis porta. In dictum sapien ut congue
+          facilisis. Curabitur consequat vestibulum ultricies. Vivamus rhoncus
+          vitae sapien id volutpat. Fusce ac nisi dolor. Suspendisse ut
+          venenatis ex. Quisque elementum libero quam, non consectetur lorem
+          faucibus a. Sed eu orci vitae nibh sodales sodales ut at neque. Ut
+          lobortis arcu eu lorem porttitor scelerisque. Aenean euismod est ac
+          enim fermentum, sit amet tristique dui consequat. Phasellus vitae
+          sapien dolor. Nulla iaculis nibh at magna convallis finibus ut vitae
+          ipsum. Maecenas ultricies ultrices diam laoreet lacinia. Nunc commodo
+          eu lorem a bibendum. Sed eu magna rutrum, consectetur orci sit amet,
+          venenatis ex. Aliquam sodales nec odio ac ultricies. In sit amet
+          congue ipsum. Class aptent taciti sociosqu ad litora torquent per
+          conubia nostra, per inceptos himenaeos. Phasellus accumsan justo nec
+          maximus sollicitudin. Aenean eu urna egestas justo dignissim venenatis
+          quis quis massa. Pellentesque convallis posuere elit, eu interdum diam
+          placerat et. Aenean cursus vehicula nibh, in scelerisque nunc feugiat
+          eu. Praesent eleifend ipsum eget urna dictum semper. Nullam dapibus
+          nisl sit amet ultricies lobortis. Vestibulum a velit neque.
+          Suspendisse tincidunt aliquet lorem et consectetur. Phasellus at
+          libero fringilla nulla egestas aliquam. Nullam ut magna risus. Etiam
+          consequat neque sapien, vel ultrices justo vehicula sit amet. Donec
+          semper facilisis odio vel faucibus. Integer eget sagittis justo.
+          Integer sed tincidunt neque. In vulputate fermentum lacus, eget
+          sollicitudin nisi vestibulum vel. Etiam porttitor varius justo, id
+          efficitur tellus congue a. Cras condimentum congue lectus sit amet
+          commodo. Etiam lacus ex, efficitur volutpat enim id, malesuada posuere
+          metus. Mauris convallis convallis arcu, sit amet placerat felis
+          sodales ut. Duis semper a risus ac consequat. Nulla id nibh sem.
+          Aliquam et nulla nec lectus viverra lobortis. Vivamus eros enim,
+          lobortis nec efficitur nec, rhoncus at tortor. Aliquam aliquet
+          bibendum ipsum eu feugiat. Duis iaculis bibendum ligula non ultricies.
+          Curabitur cursus nulla in nisl tincidunt, eget eleifend tellus
+          ultricies. Pellentesque eget mauris nec magna ultrices fringilla id
+          sit amet nulla. Ut nec velit sed augue eleifend pharetra. Aliquam a
+          posuere massa. Nunc vitae tortor ut est cursus vestibulum. In hac
+          habitasse platea dictumst. Nulla eget orci eleifend, elementum turpis
+          vitae, consectetur magna. In in nulla in tellus vestibulum pharetra.
+          Curabitur at rhoncus enim, tempus congue est. Nullam consectetur
+          lobortis nunc, vel feugiat lorem semper a. Ut tellus nulla, tempus id
+          posuere vel, luctus et sem. Nulla nec rhoncus mi. Aenean sit amet
+          mollis nibh. Nam ullamcorper tellus quis arcu aliquam, dignissim
+          ultricies justo efficitur. Cras non ipsum tempor, elementum dui id,
+          pellentesque turpis. Praesent commodo dolor in elit aliquet, sit amet
+          pellentesque sem molestie. In pharetra nisl nec orci pellentesque, ut
+          posuere quam faucibus. Class aptent taciti sociosqu ad litora torquent
+          per conubia nostra, per inceptos himenaeos. Maecenas mollis purus non
+          erat tempor euismod. Vestibulum non leo eget magna vestibulum mattis.
+          Aenean vitae tortor vel mauris pretium tempor. Sed viverra eros
+          tristique, dapibus tellus a, feugiat ipsum. Pellentesque non tellus
+          scelerisque, molestie massa vitae, fermentum ex. Quisque molestie
+          interdum nibh a luctus. Sed aliquet risus ac varius suscipit. Proin
+          eget leo vel lacus finibus posuere vel non nisl. In tristique ligula
+          leo, sed molestie sem sodales nec. Phasellus sed consectetur lectus.
+          In pretium hendrerit eros, a sagittis est faucibus ac. Etiam faucibus
+          felis et eros commodo fringilla. Duis volutpat lobortis suscipit.
+          Maecenas facilisis metus in lorem aliquet efficitur. Duis scelerisque
+          eros scelerisque, rhoncus massa eget, tempor ipsum. Donec id feugiat
+          purus, non condimentum turpis. Sed consequat lorem a odio pharetra
+          pretium. Proin sed turpis ac sapien convallis iaculis a sit amet est.
+          Proin lorem risus, rhoncus non metus at, fringilla commodo erat. Sed
+          quis elit vitae leo ullamcorper interdum non nec ipsum. Etiam
+          ullamcorper lorem ac velit condimentum, eget porttitor odio mollis.
+          Maecenas semper, urna eu cursus placerat, enim neque aliquam orci, ut
+          elementum justo ex id justo. Nunc malesuada egestas dui at vestibulum.
+        </p>
+      </div>
+    );
+    setLongModalIsOpen(true);
+    showDialog({
+      DialogComponent: Modal,
+      container: /** @type {HTMLElement} */ (document.getElementById('modal2')),
+      setOpen: setLongModalIsOpen,
+      props: {
+        title: 'Long Modal',
+        buttons,
+        children,
       },
     });
   };
@@ -182,6 +282,34 @@ export default function DialogComponents() {
                 <div id="modal1" />
                 <LabeledButton variant="primary" onClick={openModal}>
                   Open modal
+                </LabeledButton>
+              </div>
+            </div>
+          </div>
+        </div>
+      </Pattern>
+
+      <Pattern title="Modal with long content">
+        <div className="Example">
+          <p>
+            Modals that may contain a lot of content may need to handle overflow
+            (i.e. make their content scrollable) so that the modal height
+            doesn&apos;t exceed available viewport space.
+          </p>
+          <div className="Example__content">
+            <div className="Example__usage">
+              <p>
+                To make something in a modal scroll-able, apply{' '}
+                <code>overflow: auto</code> to the element you wish to contain.
+                This element needs to be an immediate-child element of the{' '}
+                <code>Modal</code>.
+              </p>
+            </div>
+            <div className="Example__demo hyp-frame">
+              <div>
+                <div id="modal2" />
+                <LabeledButton variant="primary" onClick={openLongModal}>
+                  Open long modal
                 </LabeledButton>
               </div>
             </div>

--- a/styles/mixins/patterns/_molecules.scss
+++ b/styles/mixins/patterns/_molecules.scss
@@ -74,7 +74,32 @@ $-color-background: var.$color-background;
   }
 }
 
-// A responsive sized and positioned container for modal content
+/**
+ * A modal container, with responsive positioning and sizing.
+ *
+ * A modal should contain one immediate-child element; in most cases, an
+ * element that applies the dialog[1] pattern. Content within the dialog
+ * (grandchild elements of modal) can be managed with `overflow` rules so as not
+ * to exceed the size constraints of the modal within the viewport.
+ *
+ * Example structure follows:
+ *
+ * <modal>
+ *   <dialog>
+ *     <div /> <!-- dialog can contain any arbitrary content -->
+ *     <div style="overflow: auto">
+ *       This content will scroll vertically if it is too tall for the
+ *       available space in the modal.
+ *     </div>
+ *     <div />
+ *     ...
+ *   </dialog>
+ * </modal>
+ *
+ * [1]: The modal's immediate child need not specifically apply the dialog
+ *      pattern, but any element that needs to manage overflow within the modal
+ *      must be a grandchild of the modal container element.
+ */
 @mixin modal {
   // The modal container is positioned horizontally- and vertically-centered
   @include layout.fixed-centered;
@@ -98,7 +123,29 @@ $-color-background: var.$color-background;
   // near the top of the viewport.
   @media screen and (min-height: 32rem) {
     top: 10vh;
+    // Provide at least 10vh of space between bottom of modal and bottom of
+    // viewport, or else the modal will look vertically mis-aligned
+    // 100vh - 10vh top - 10vh bottom = 80vh
+    max-height: 80vh;
     transform: translate(-50%, 0);
-    max-height: 80vh; // 10vh space top and bottom
+  }
+
+  // Apply rules to the immediate child (likely a dialog) to allow for overflow
+  // management in modal's grandchild elements.
+  & > * {
+    // A flex layout allows item children to overflow without defining an
+    // absolute container height.
+    // See https://www.codementor.io/@stephenbunch/how-to-make-a-scrollable-container-with-dynamic-height-using-flexbox-bkaunxewg
+    @include layout.column;
+
+    // These height rules are duplicative of the height rules on the modal,
+    // but need to be applied to this element to be able to constrain
+    // overflow in children. Height rules must be on an overflow-constrained
+    // element's immediate parent.
+    max-height: 90vh;
+
+    @media screen and (min-height: 32rem) {
+      max-height: 80vh;
+    }
   }
 }

--- a/styles/mixins/patterns/_organisms.scss
+++ b/styles/mixins/patterns/_organisms.scss
@@ -1,6 +1,7 @@
 @use '../../variables' as var;
 
 @use '../atoms';
+@use '../focus';
 @use '../layout';
 @use '../themes';
 
@@ -14,6 +15,8 @@ $-color-brand: var.$color-brand;
  * modifier.
  */
 @mixin panel {
+  // Prevents focus ring when panel element is focused in Safari
+  @include focus.outline-on-keyboard-focus;
   @include molecules.card;
 
   @include themes.theme('clean') {


### PR DESCRIPTION
This PR updates the modal pattern such that it is possible to constrain content within its contained dialog using `overflow` rules. There is an additional "Long modal" example on the [Pattern Library's "Dialogs" page](http://localhost:4001/ui-playground/components-dialogs).

Problem we're trying to solve here: sometimes modals contain content that is too tall for the modal container, and app devs should be able to apply `overflow` rules to that content to allow it to scroll if it's too tall (versus making the modal container too tall for the viewport). To enable this, it is necessary to apply some additional height and layout rules to the modal container's immediate child element (the immediate parent of the elements that would want overflow control).

In an immediate sense, we need these constraints to be able to use the `Dialog` in the LMS' VitalSource content-picking flow. Here's what that looks like in situ (i.e. with these changes applied). You can see that the content is scrolling correctly:

<img width="802" alt="Screen Shot 2021-06-24 at 8 47 01 AM" src="https://user-images.githubusercontent.com/439947/123266843-5d603300-d4ca-11eb-87b3-ca3c749ba5c3.png">

(_Note_: The shared `Modal` is narrower than the LMS-local variant, but that's a function of the content within the modal—the modal default/preferred width is sensible in most cases. We can manage for width locally if we feel it is too narrow in this particular context).

I found these changes tricky to articulate, and probably re-wrote SASS comments about 15 times. 

This PR also rectifies an oversight in which the `Dialog` component assumed the presence of the `cancel` icon.

Part of https://github.com/hypothesis/lms/issues/2870

More examples below. Note that I am unable to capture the scrollbars themselves as they disappear when I grab screenshots.

Scrollable content on narrow screen:

![image](https://user-images.githubusercontent.com/439947/123267256-cf387c80-d4ca-11eb-807e-708b2634c864.png)

On a larger screen:

![image](https://user-images.githubusercontent.com/439947/123267294-d790b780-d4ca-11eb-8b8e-188b9f4f432c.png)



