### PR TITLE
Refine structure and naming of Pattern-library components and sections

### DIFF
--- a/src/pattern-library/components/PlaygroundApp.js
+++ b/src/pattern-library/components/PlaygroundApp.js
@@ -41,6 +41,7 @@ export default function PlaygroundApp({
 
   const routeGroups = [
     { title: 'Foundations', routes: getRoutes('foundations') },
+    { title: 'Patterns', routes: getRoutes('patterns') },
     { title: 'Common Components', routes: getRoutes('components') },
   ];
 

--- a/src/pattern-library/components/patterns/ButtonComponents.js
+++ b/src/pattern-library/components/patterns/ButtonComponents.js
@@ -7,7 +7,7 @@ import {
   PatternExample,
 } from '../PatternPage';
 
-export default function ButtonPatterns() {
+export default function ButtonComponents() {
   return (
     <PatternPage title="Buttons">
       <Pattern title="IconButton">

--- a/src/pattern-library/components/patterns/ColorFoundations.js
+++ b/src/pattern-library/components/patterns/ColorFoundations.js
@@ -39,7 +39,7 @@ const backgroundExamples = [
   );
 });
 
-export default function ColorPatterns() {
+export default function ColorFoundations() {
   return (
     <PatternPage title="Colors">
       <Pattern title="Color swatches">

--- a/src/pattern-library/components/patterns/DialogComponents.js
+++ b/src/pattern-library/components/patterns/DialogComponents.js
@@ -61,7 +61,7 @@ const showDialog = ({ DialogComponent, container, setOpen, props }) => {
   );
 };
 
-export default function DialogPatterns() {
+export default function DialogComponents() {
   // Extra buttons to use in Dialog, Modal examples
   const buttons = [
     <LabeledButton key="maybe" onClick={() => alert('You chose maybe')}>

--- a/src/pattern-library/components/patterns/FormComponents.js
+++ b/src/pattern-library/components/patterns/FormComponents.js
@@ -9,7 +9,7 @@ import {
   PatternExample,
 } from '../PatternPage';
 
-export default function FormPatterns() {
+export default function FormComponents() {
   const [wantSandwich, setWantSandwich] = useState(true);
   const [wantWatermelon, setWantWatermelon] = useState(false);
   return (

--- a/src/pattern-library/components/patterns/LayoutFoundations.js
+++ b/src/pattern-library/components/patterns/LayoutFoundations.js
@@ -61,7 +61,7 @@ function SpacingDemo({ direction, size, defaultSize = false }) {
   );
 }
 
-export default function LayoutPatterns() {
+export default function LayoutFoundations() {
   const [showExample1, setShowExample1] = useState(false);
   const [showExample2, setShowExample2] = useState(false);
   const [showExample3, setShowExample3] = useState(false);

--- a/src/pattern-library/components/patterns/PanelComponents.js
+++ b/src/pattern-library/components/patterns/PanelComponents.js
@@ -7,7 +7,7 @@ import {
   PatternExample,
 } from '../PatternPage';
 
-export default function SharedPanelPatterns() {
+export default function PanelComponents() {
   return (
     <PatternPage title="Panel">
       <Pattern title="Panel">

--- a/src/pattern-library/routes.js
+++ b/src/pattern-library/routes.js
@@ -1,17 +1,18 @@
 import PlaygroundHome from './components/PlaygroundHome';
 
-import ColorPatterns from './components/patterns/ColorPatterns';
-import LayoutPatterns from './components/patterns/LayoutPatterns';
+import ColorFoundations from './components/patterns/ColorFoundations';
+import LayoutFoundations from './components/patterns/LayoutFoundations';
+
 import MoleculePatterns from './components/patterns/MoleculePatterns';
 import OrganismPatterns from './components/patterns/OrganismPatterns';
 
-import ButtonPatterns from './components/patterns/ButtonPatterns';
-import DialogPatterns from './components/patterns/DialogPatterns';
-import FormPatterns from './components/patterns/FormPatterns';
-import PanelPatterns from './components/patterns/PanelPatterns';
+import ButtonComponents from './components/patterns/ButtonComponents';
+import DialogComponents from './components/patterns/DialogComponents';
+import FormComponents from './components/patterns/FormComponents';
+import PanelComponents from './components/patterns/PanelComponents';
 
 /**
- * @typedef {'home'|'foundations'|'components'} PlaygroundRouteGroup
+ * @typedef {'home'|'foundations'|'patterns'|'components'} PlaygroundRouteGroup
  *
  * @typedef PlaygroundRoute - Route "handler" that provides a component (function)
  *   that should be rendered for the indicated route
@@ -33,49 +34,49 @@ const routes = [
   {
     route: '/foundations-colors',
     title: 'Colors',
-    component: ColorPatterns,
+    component: ColorFoundations,
     group: 'foundations',
   },
   {
     route: '/foundations-layout',
     title: 'Layout',
-    component: LayoutPatterns,
+    component: LayoutFoundations,
     group: 'foundations',
   },
   {
-    route: '/foundations-molecules',
+    route: '/patterns-molecules',
     title: 'Molecules',
     component: MoleculePatterns,
-    group: 'foundations',
+    group: 'patterns',
   },
   {
-    route: '/foundations-organisms',
+    route: '/patterns-organisms',
     title: 'Organisms',
     component: OrganismPatterns,
-    group: 'foundations',
+    group: 'patterns',
   },
   {
     route: '/components-buttons',
     title: 'Buttons',
-    component: ButtonPatterns,
+    component: ButtonComponents,
     group: 'components',
   },
   {
     route: '/components-dialogs',
     title: 'Dialogs',
-    component: DialogPatterns,
+    component: DialogComponents,
     group: 'components',
   },
   {
     route: '/components-forms',
     title: 'Forms',
-    component: FormPatterns,
+    component: FormComponents,
     group: 'components',
   },
   {
     route: '/components-panel',
     title: 'Panel',
-    component: PanelPatterns,
+    component: PanelComponents,
     group: 'components',
   },
 ];


### PR DESCRIPTION
This PR consolidates the components used for the Pattern Library pages and adds a new "group" of pages to the Pattern Library. 

The motivation for this change is that I'm working on some input and input-with-button design patterns and there is a component naming conflict: `FormPatterns` was "already taken." This PR's changes moves the former `FormPatterns` to `FormComponents` so that I can use `FormPatterns` for actual, well, form patterns.

There are here three types of pattern-library page components:

* `Foundations`, naming convention for components `*Foundations` — These are the atomic building blocks of the design system, expressed in utility CSS classes prefixed `hyp-u`(note: These utility classes are still private to the package for the moment). Note that the existing `*Foundations` pattern-library pages do not provide examples for all of the existing atoms (yet). But it's a start, so far.
* `Patterns`, naming convention for components `*Patterns` — These are composite design patterns built by combining atomic patterns. These are expressed in CSS class names prefixed with `hyp-` (no `u`). These classes are still private to the package. We're moving in a direction that most, if not all, patterns will have a corresponding component. Patterns here are referred to using lower-case: `modal`, `panel`, etc.
* `Components`, naming convention for components `*Components` — These are, duh, component examples. Typically each component implements a design pattern, e.g. `Panel` is built on `panel`. 

There are no actual changes to any content or anything; just adjusting how these examples are organized within the Pattern Library.

This PR currently depends on #112 for purely convenience/ergonomic reasons, but could be made independent if that PR gets mired.

Pattern Library sections after these changes:

![image](https://user-images.githubusercontent.com/439947/123295293-91941d80-d4e3-11eb-8eea-c9ab4efb2317.png)
