### PR TITLE
Text input patterns and simple components

### DIFF
--- a/src/components/TextInput.js
+++ b/src/components/TextInput.js
@@ -1,0 +1,53 @@
+import classnames from 'classnames';
+
+/**
+ * @typedef {import('preact').ComponentChildren} Children
+ *
+ * @typedef TextInputBaseProps
+ * @prop {boolean} [error] - There is an error associated with this input. Will
+ *   set some error styling.
+ */
+
+/**
+ * `TextInput` sets the `type` attribute on the `input`, but any other valid
+ * attribute should be forwarded.
+ * @typedef {Omit<import('preact').JSX.HTMLAttributes<HTMLInputElement>, 'type'>} HTMLInputElementProps
+ * @typedef {TextInputBaseProps & HTMLInputElementProps} TextInputProps
+ */
+
+/**
+ * @typedef TextInputWithButtonProps
+ * @prop {Children} children
+ */
+
+/**
+ * Wrap a textual `<input>` element with some styles and provide error UI
+ *
+ * @param {TextInputProps} props
+ */
+export function TextInput({ error, ...restProps }) {
+  return (
+    <input
+      className={classnames('Hyp-TextInput', { 'is-error': error })}
+      {...restProps}
+      type="text"
+    />
+  );
+}
+
+/**
+ * A wrapping component for pairing a `TextInput` with an `IconButton` component.
+ * Applies appropriate design pattern. Expected usage:
+ *
+ * <TextInputWithButton>
+ *   <TextInput />
+ *   <IconButton />
+ * </TextInputWithButton>
+ *
+ * Current implementation assumes the input is on the left and button on right.
+ *
+ * @param {TextInputWithButtonProps} props
+ */
+export function TextInputWithButton({ children }) {
+  return <div className="Hyp-TextInputWithButton">{children}</div>;
+}

--- a/src/components/test/TextInput-test.js
+++ b/src/components/test/TextInput-test.js
@@ -1,0 +1,42 @@
+import { mount } from 'enzyme';
+
+import { TextInput, TextInputWithButton } from '../TextInput';
+
+describe('TextInput', () => {
+  const createComponent = (props = {}) => mount(<TextInput {...props} />);
+
+  it('renders an input field with an appropriate className', () => {
+    const wrapper = createComponent();
+
+    assert.isTrue(wrapper.find('input').hasClass('Hyp-TextInput'));
+    assert.isFalse(wrapper.find('input').hasClass('is-error'));
+  });
+
+  it('ignores `type` property and sets `type` to `text`', () => {
+    const wrapper = createComponent({ type: 'checkbox' });
+
+    assert.equal(wrapper.getDOMNode().getAttribute('type'), 'text');
+  });
+
+  it('applies an error class when in error', () => {
+    const wrapper = createComponent({ error: true });
+
+    assert.isTrue(wrapper.find('input').hasClass('is-error'));
+  });
+});
+
+describe('TextInputWithButton', () => {
+  const createComponent = () =>
+    mount(
+      <TextInputWithButton>
+        <TextInput />
+        <button />
+      </TextInputWithButton>
+    );
+
+  it('wraps children in a container element with appropriate className', () => {
+    const wrapper = createComponent();
+
+    assert.isTrue(wrapper.find('div').hasClass('Hyp-TextInputWithButton'));
+  });
+});

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ export { IconButton, LabeledButton, LinkButton } from './components/buttons';
 export { Modal, ConfirmModal } from './components/Modal';
 export { Panel } from './components/Panel';
 export { SvgIcon, registerIcons } from './components/SvgIcon';
+export { TextInput } from './components/TextInput';
 
 // Hooks
 export { useElementShouldClose } from './hooks/use-element-should-close';

--- a/src/pattern-library/components/patterns/FormComponents.js
+++ b/src/pattern-library/components/patterns/FormComponents.js
@@ -1,6 +1,8 @@
 import { useState } from 'preact/hooks';
 
-import { LabeledCheckbox } from '../../../';
+import { IconButton } from '../../../components/buttons';
+import { LabeledCheckbox } from '../../../components/Checkbox';
+import { TextInput, TextInputWithButton } from '../../../components/TextInput';
 
 import {
   PatternPage,
@@ -41,6 +43,49 @@ export default function FormComponents() {
             >
               I want a watermelon
             </LabeledCheckbox>
+          </PatternExample>
+        </PatternExamples>
+      </Pattern>
+
+      <Pattern title="TextInput">
+        <p>
+          <code>TextInput</code> is a basic wrapper around an{' '}
+          <code>input type=&quot;text&quot;</code> field.
+        </p>
+        <PatternExamples>
+          <PatternExample details="basic text input field">
+            <TextInput name="my-input" />
+          </PatternExample>
+
+          <PatternExample details="text input field in an error state">
+            <TextInput name="my-input" error />
+          </PatternExample>
+        </PatternExamples>
+      </Pattern>
+
+      <Pattern title="TextInputWithButton">
+        <p>
+          This component wraps the <code>text-input-with-button</code> pattern:
+          a text input on the left with an associated icon-only button on the
+          right.
+        </p>
+        <p>
+          Current usage favors the <code>dark</code> variant of{' '}
+          <code>IconButton</code>.
+        </p>
+        <PatternExamples>
+          <PatternExample details="basic text input field">
+            <TextInputWithButton>
+              <TextInput name="my-input" />
+              <IconButton icon="arrow-right" variant="dark" title="go" />
+            </TextInputWithButton>
+          </PatternExample>
+
+          <PatternExample details="text input field in an error state">
+            <TextInputWithButton>
+              <TextInput name="my-input" error />
+              <IconButton icon="arrow-right" variant="dark" title="go" />
+            </TextInputWithButton>
           </PatternExample>
         </PatternExamples>
       </Pattern>

--- a/src/pattern-library/components/patterns/FormPatterns.js
+++ b/src/pattern-library/components/patterns/FormPatterns.js
@@ -1,0 +1,67 @@
+import {
+  PatternExample,
+  PatternExamples,
+  PatternPage,
+  Pattern,
+} from '../PatternPage';
+
+import { IconButton } from '../../../components/buttons';
+
+export default function FormPatterns() {
+  return (
+    <PatternPage title="Forms">
+      <Pattern title="Text inputs">
+        <p>
+          A pattern for <code>input type=&quot;text&quot;</code>
+        </p>
+        <PatternExamples>
+          <PatternExample details="basic text input">
+            <input
+              className="hyp-text-input"
+              type="text"
+              placeholder="http://www.example.com"
+            />
+          </PatternExample>
+          <PatternExample details="text input in an error state">
+            <input
+              className="hyp-text-input is-error"
+              type="text"
+              placeholder="http://www.example.com"
+            />
+          </PatternExample>
+        </PatternExamples>
+      </Pattern>
+      <Pattern title="Text input with button">
+        <p>
+          A pattern that pairs a text input field with an icon-only button. Use
+          a dark-variant button to match the standard pattern here.
+        </p>
+        <PatternExamples>
+          <PatternExample
+            style={{ width: '300px' }}
+            details="text input with a dark-variant IconButton"
+          >
+            <div className="hyp-text-input-with-button">
+              <input type="text" placeholder="http://www.example.com" />
+              <IconButton icon="arrow-right" title="go" variant="dark" />
+            </div>
+          </PatternExample>
+
+          <PatternExample
+            style={{ width: '300px' }}
+            details="text input and button in an error state"
+          >
+            <div className="hyp-text-input-with-button">
+              <input
+                type="text"
+                placeholder="http://www.example.com"
+                className="is-error"
+              />
+              <IconButton icon="arrow-right" title="go" variant="dark" />
+            </div>
+          </PatternExample>
+        </PatternExamples>
+      </Pattern>
+    </PatternPage>
+  );
+}

--- a/src/pattern-library/routes.js
+++ b/src/pattern-library/routes.js
@@ -3,6 +3,7 @@ import PlaygroundHome from './components/PlaygroundHome';
 import ColorFoundations from './components/patterns/ColorFoundations';
 import LayoutFoundations from './components/patterns/LayoutFoundations';
 
+import FormPatterns from './components/patterns/FormPatterns';
 import MoleculePatterns from './components/patterns/MoleculePatterns';
 import OrganismPatterns from './components/patterns/OrganismPatterns';
 
@@ -42,6 +43,12 @@ const routes = [
     title: 'Layout',
     component: LayoutFoundations,
     group: 'foundations',
+  },
+  {
+    route: '/patterns-forms',
+    title: 'Forms',
+    component: FormPatterns,
+    group: 'patterns',
   },
   {
     route: '/patterns-molecules',

--- a/styles/components/TextInput.scss
+++ b/styles/components/TextInput.scss
@@ -1,0 +1,9 @@
+@use '../mixins/patterns/forms';
+
+.Hyp-TextInput {
+  @include forms.text-input;
+}
+
+.Hyp-TextInputWithButton {
+  @include forms.text-input-with-button;
+}

--- a/styles/index.scss
+++ b/styles/index.scss
@@ -8,4 +8,5 @@
 @use './components/Modal';
 @use './components/Panel';
 @use './components/SvgIcon';
+@use './components/TextInput';
 @use './components/buttons/styles';

--- a/styles/mixins/_focus.scss
+++ b/styles/mixins/_focus.scss
@@ -2,9 +2,9 @@
 
 $-color-focus-outline: var.$color-focus-outline;
 
-@mixin outline-rule($inset: false) {
+@mixin outline-rule($inset: false, $color: $-color-focus-outline) {
   outline: none;
-  box-shadow: 0 0 0 2px $-color-focus-outline if($inset, inset, null);
+  box-shadow: 0 0 0 2px $color if($inset, inset, null);
 }
 
 /**

--- a/styles/mixins/patterns/_forms.scss
+++ b/styles/mixins/patterns/_forms.scss
@@ -1,0 +1,90 @@
+@use '../../variables' as var;
+
+@use '../atoms';
+@use '../focus';
+@use '../layout';
+
+$-border-radius: var.$border-radius;
+
+$-color-grey-0: var.$color-grey-0;
+$-color-white: var.$color-white;
+
+$-color-error: var.$color-error;
+
+$-color-text: var.$color-text;
+$-color-text--light: var.$color-text--light;
+$-color-text--disabled: var.$color-text--disabled;
+
+/**
+ * General styling for a text-like input
+ */
+@mixin input {
+  @include focus.outline($inset: true);
+  @include atoms.border;
+  @include layout.padding;
+
+  background-color: $-color-grey-0;
+  color: $-color-text;
+  border-radius: $-border-radius;
+}
+
+/**
+ * Styling for <input type="text" />. Includes a state class for errors.
+ */
+@mixin text-input {
+  @include input;
+
+  &.is-error {
+    // Apply an error-colored inset outline.
+    // Remove any outlines or borders to make sure the input element doesn't
+    // change dimensions when applying the inset outline
+    outline: none;
+    border: none;
+    @include focus.outline-rule($inset: true, $color: $-color-error);
+  }
+
+  &::placeholder {
+    color: $-color-text--light;
+  }
+
+  &:focus {
+    background-color: $-color-white;
+
+    &::placeholder {
+      // Note that this won't meet WCAG contrast requirements, so should only
+      // be used when the placeholder is in effect "disabled" by focus
+      color: $-color-text--disabled;
+    }
+  }
+}
+
+/**
+ * A pattern for pairing a text input (left) with an icon-only button (right).
+ *
+ * Removes border radiuses where the two elements touch, and adds a border
+ * to the button to align with the `input`.
+ *
+ * Sample usage:
+ *  <div.hyp-text-input-with-button />
+ *   <input.hyp-text-input />
+ *   <button.hyp-IconButton />
+ *  </div>
+ */
+@mixin text-input-with-button {
+  @include layout.row;
+  // Make the paired input and button fill the available space
+  width: 100%;
+  input {
+    @include text-input;
+    flex-grow: 1;
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
+  }
+
+  button {
+    @include atoms.border;
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
+    border-left: 0;
+  }
+}

--- a/styles/patterns/_forms.scss
+++ b/styles/patterns/_forms.scss
@@ -1,0 +1,9 @@
+@use '../mixins/patterns/forms';
+
+.hyp-text-input {
+  @include forms.text-input;
+}
+
+.hyp-text-input-with-button {
+  @include forms.text-input-with-button;
+}

--- a/styles/patterns/index.scss
+++ b/styles/patterns/index.scss
@@ -1,2 +1,3 @@
+@use 'forms';
 @use 'molecules';
 @use 'organisms';

--- a/styles/variables/_colors.scss
+++ b/styles/variables/_colors.scss
@@ -15,9 +15,9 @@ $grey-1: #f2f2f2;
 $grey-2: #ececec;
 $grey-3: #dbdbdb;
 $grey-4: #a6a6a6;
-$grey-5: #9c9c9c;
-$grey-6: #737373;
-$grey-7: #595959;
+$grey-5: #9c9c9c; // Fails all WCAG contrast tests; do not use for text on white
+$grey-6: #737373; // Passes WCAG AA; Fails WCAG AAA normal/small text contrast
+$grey-7: #595959; // This and higher pass all WCAG AA/AAA contrast checks
 $grey-8: #3f3f3f;
 $grey-9: #202020;
 $black: black;
@@ -25,6 +25,9 @@ $black: black;
 // Typography: TODO refactor when adding typography patterns
 $text: $grey-9;
 $text--light: $grey-6;
+// This does not provide enough contrast on white to meet WCAG AA standards,
+// and should only be used for disabled interfaces.
+$text--disabled: $grey-4;
 
 // Tokenizing colors to their use
 $background: $white;


### PR DESCRIPTION
This PR introduces two patterns: a basic text `input`, as well as a pattern that pairs a text `input` with an icon-only button (`text-input` and `text-input-with-button`, respectively). It also proposes two corresponding (logic-less)[1] components, `TextInput` and `TextInputWithButton` that wrap those patterns.

These patterns are based on existing styling in the client application, and will be used in the VitalSource content picker. See https://github.com/hypothesis/lms/issues/2862

This is the first time this package has proposed providing logic-less components, and I've done my best to make them breathtakingly basic. The `TextInput` component forwards all valid `HTMLInputElement` attributes except `type` (which it sets itself), and `TextInputWithButton` simply wraps its children in an appropriately-classed element.

I'm opening this PR in draft because:

* I'm still looking for thoughts about what to do about testing here. Ostensibly we could test for the `TextInput` applying the `is-error` class correctly. I can't really see much to do testing-wise beyond that.
* The logic-less components here are a new pattern for us, and bear some consideration.

_Edit_: moving out of draft as tests have been added, and some review has happened here.

Here is a screen shot of the pattern library page for the design patterns:

![image](https://user-images.githubusercontent.com/439947/123319133-0411f700-d4fe-11eb-9344-f49a718cd086.png)

And a screen shot of the pattern library page for the components that wrap those patterns (`Checkbox` already existed):

![image](https://user-images.githubusercontent.com/439947/123319157-0f652280-d4fe-11eb-8cda-d274be588d38.png)

You can see here how the correspondence of a design pattern with a component that wraps it continues to feel like an intuitive way to expose stuff.

[1] Technically `TextInput` takes an optional boolean `error` prop and will apply a CSS class when it's `true`, but that's cutting it fine on "logic".

~~This PR is current failing on test coverage, which is no kind of surprise.~~