### PR TITLE
Add `inputRef` to `TextInput` component

### DIFF
--- a/src/components/TextInput.js
+++ b/src/components/TextInput.js
@@ -7,11 +7,13 @@ import classnames from 'classnames';
  * @prop {string} [classes] - Additional CSS classes to apply
  * @prop {boolean} [error] - There is an error associated with this input. Will
  *   set some error styling.
+ * @prop {import('preact').Ref<HTMLInputElement>} [inputRef] - Optional ref for
+ *   the rendered `input` element.
  */
 
 /**
  * `TextInput` sets the `type` attribute on the `input`, but any other valid
- * attribute should be forwarded.
+ * `input` attribute should be forwarded.
  * @typedef {Omit<import('preact').JSX.HTMLAttributes<HTMLInputElement>, 'type'>} HTMLInputElementProps
  * @typedef {TextInputBaseProps & HTMLInputElementProps} TextInputProps
  */
@@ -27,11 +29,12 @@ import classnames from 'classnames';
  *
  * @param {TextInputProps} props
  */
-export function TextInput({ classes = '', error, ...restProps }) {
+export function TextInput({ classes = '', error, inputRef, ...restProps }) {
   return (
     <input
       className={classnames('Hyp-TextInput', { 'is-error': error }, classes)}
       {...restProps}
+      ref={inputRef}
       type="text"
     />
   );

--- a/src/components/test/TextInput-test.js
+++ b/src/components/test/TextInput-test.js
@@ -1,4 +1,5 @@
 import { mount } from 'enzyme';
+import { createRef } from 'preact';
 
 import { TextInput, TextInputWithButton } from '../TextInput';
 
@@ -22,6 +23,13 @@ describe('TextInput', () => {
     const wrapper = createComponent({ error: true });
 
     assert.isTrue(wrapper.find('input').hasClass('is-error'));
+  });
+
+  it('passes along a `ref` to the input element through `inputRef`', () => {
+    const inputRef = createRef();
+    createComponent({ inputRef: inputRef });
+
+    assert.isTrue(inputRef.current instanceof Node);
   });
 
   it('applies extra classes', () => {


### PR DESCRIPTION
Our newly-established convention is that components that wrap a single HTML element should take a `ref` prop named per the type of element rendered. Update `TextInput` accordingly, following the method that `buttons` components use.