### PR TITLE
Add `spinner` pattern and `Spinner` component

### DIFF
--- a/images/icons/spinner.svg
+++ b/images/icons/spinner.svg
@@ -1,0 +1,36 @@
+<!--
+By Sam Herbert (@sherb), for everyone. More @ http://goo.gl/7AJzbL
+
+From https://raw.githubusercontent.com/SamHerbert/SVG-Loaders/master/svg-loaders/tail-spin.svg
+-->
+<svg width="38" height="38" viewBox="0 0 38 38" xmlns="http://www.w3.org/2000/svg">
+    <defs>
+        <linearGradient x1="8.042%" y1="0%" x2="65.682%" y2="23.865%" id="a">
+            <stop stop-color="#222" stop-opacity="0" offset="0%"/>
+            <stop stop-color="#222" stop-opacity=".631" offset="63.146%"/>
+            <stop stop-color="#222" offset="100%"/>
+        </linearGradient>
+    </defs>
+    <g fill="none" fill-rule="evenodd">
+        <g transform="translate(1 1)">
+            <path d="M36 18c0-9.94-8.06-18-18-18" id="Oval-2" stroke="currentColor" stroke-width="2">
+                <animateTransform
+                    attributeName="transform"
+                    type="rotate"
+                    from="0 18 18"
+                    to="360 18 18"
+                    dur="0.9s"
+                    repeatCount="indefinite" />
+            </path>
+            <circle fill="#fff" cx="36" cy="18" r="1">
+                <animateTransform
+                    attributeName="transform"
+                    type="rotate"
+                    from="0 18 18"
+                    to="360 18 18"
+                    dur="0.9s"
+                    repeatCount="indefinite" />
+            </circle>
+        </g>
+    </g>
+</svg>

--- a/src/components/Spinner.js
+++ b/src/components/Spinner.js
@@ -11,6 +11,8 @@ registerIcons({
 /**
  * @typedef SpinnerProps
  * @prop {string} [classes] - Additional CSS classes to apply
+ * @prop {'small'|'medium'|'large'} [size='medium'] - Relative size of spinner
+ *   to surrounding content
  */
 
 /**
@@ -18,8 +20,7 @@ registerIcons({
  *
  * @param {SpinnerProps} props
  */
-export function Spinner({ classes = '' }) {
-  return (
-    <SvgIcon name="spinner" className={classnames('Hyp-Spinner', classes)} />
-  );
+export function Spinner({ classes = '', size = 'medium' }) {
+  const baseClass = `Hyp-Spinner--${size}`;
+  return <SvgIcon name="spinner" className={classnames(baseClass, classes)} />;
 }

--- a/src/components/Spinner.js
+++ b/src/components/Spinner.js
@@ -1,0 +1,25 @@
+import classnames from 'classnames';
+
+import { registerIcons, SvgIcon } from './SvgIcon';
+
+// Register the spinner icon for use
+registerIcons({
+  /** @ts-ignore - TS doesn't understand require here */
+  'hyp-spinner': require('../../images/icons/spinner.svg'),
+});
+
+/**
+ * @typedef SpinnerProps
+ * @prop {string} [classes] - Additional CSS classes to apply
+ */
+
+/**
+ * Loading indicator.
+ *
+ * @param {SpinnerProps} props
+ */
+export function Spinner({ classes = '' }) {
+  return (
+    <SvgIcon name="spinner" className={classnames('Hyp-Spinner', classes)} />
+  );
+}

--- a/src/components/test/Spinner-test.js
+++ b/src/components/test/Spinner-test.js
@@ -9,12 +9,17 @@ describe('Spinner', () => {
 
   it('renders', () => {
     createSpinner();
-    assert.exists('span.Hyp-Spinner');
+    assert.exists('span.Hyp-Spinner--medium');
   });
 
   it('applies additional classes', () => {
     createSpinner({ classes: 'foo bar' });
-    assert.exists('span.Hyp-Spinner.foo.bar');
+    assert.exists('span.Hyp-Spinner--medium.foo.bar');
+  });
+
+  it('sets indicated size', () => {
+    createSpinner({ size: 'xlarge' });
+    assert.exists('span.Hyp-Spinner--large.foo.bar');
   });
 
   it(

--- a/src/components/test/Spinner-test.js
+++ b/src/components/test/Spinner-test.js
@@ -1,0 +1,26 @@
+import { mount } from 'enzyme';
+
+import { Spinner } from '../Spinner';
+
+import { checkAccessibility } from '../../../test/util/accessibility';
+
+describe('Spinner', () => {
+  const createSpinner = (props = {}) => mount(<Spinner {...props} />);
+
+  it('renders', () => {
+    createSpinner();
+    assert.exists('span.Hyp-Spinner');
+  });
+
+  it('applies additional classes', () => {
+    createSpinner({ classes: 'foo bar' });
+    assert.exists('span.Hyp-Spinner.foo.bar');
+  });
+
+  it(
+    'should pass a11y checks',
+    checkAccessibility({
+      content: () => createSpinner(),
+    })
+  );
+});

--- a/src/icons.js
+++ b/src/icons.js
@@ -10,5 +10,6 @@ export default {
   edit: require('../images/icons/edit.svg'),
   logo: require('../images/icons/logo.svg'),
   profile: require('../images/icons/profile.svg'),
+  spinner: require('../images/icons/spinner.svg'),
   trash: require('../images/icons/trash.svg'),
 };

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ export { Frame, Card, Actions } from './components/containers';
 export { Dialog } from './components/Dialog';
 export { Modal, ConfirmModal } from './components/Modal';
 export { Panel } from './components/Panel';
+export { Spinner } from './components/Spinner';
 export { SvgIcon, registerIcons } from './components/SvgIcon';
 export { TextInput, TextInputWithButton } from './components/TextInput';
 

--- a/src/pattern-library/components/patterns/SpinnerComponents.js
+++ b/src/pattern-library/components/patterns/SpinnerComponents.js
@@ -1,0 +1,22 @@
+import { Spinner } from '../../..';
+
+import {
+  PatternPage,
+  Pattern,
+  PatternExamples,
+  PatternExample,
+} from '../PatternPage';
+
+export default function SpinnerComponents() {
+  return (
+    <PatternPage title="Spinner">
+      <Pattern title="Spinner">
+        <PatternExamples>
+          <PatternExample details="basic loading spinner">
+            <Spinner />
+          </PatternExample>
+        </PatternExamples>
+      </Pattern>
+    </PatternPage>
+  );
+}

--- a/src/pattern-library/components/patterns/SpinnerComponents.js
+++ b/src/pattern-library/components/patterns/SpinnerComponents.js
@@ -15,6 +15,12 @@ export default function SpinnerComponents() {
           <PatternExample details="basic loading spinner">
             <Spinner />
           </PatternExample>
+          <PatternExample details="loading spinner, large">
+            <Spinner size="large" />
+          </PatternExample>
+          <PatternExample details="loading spinner, small">
+            <Spinner size="small" />
+          </PatternExample>
         </PatternExamples>
       </Pattern>
     </PatternPage>

--- a/src/pattern-library/components/patterns/SpinnerPatterns.js
+++ b/src/pattern-library/components/patterns/SpinnerPatterns.js
@@ -17,17 +17,18 @@ export default function SpinnerPatterns() {
       <Pattern title="Spinner">
         <p>
           The spinner is <code>em-sized</code>; it renders at <code>1em</code>{' '}
-          square. To adjust size, adjust the local font size.
+          square, by default. Other relative sizes are available as follows. For
+          manual sizing control, adjust the font-size of a parent element.
         </p>
         <PatternExamples>
           <PatternExample details="basic spinner">
             <SvgIcon name="spinner" className="hyp-spinner" />
           </PatternExample>
-          <PatternExample
-            details="spinner with local font-size at 3rem"
-            style={{ fontSize: '3rem' }}
-          >
-            <SvgIcon name="spinner" className="hyp-spinner" />
+          <PatternExample details="spinner, large size">
+            <SvgIcon name="spinner" className="hyp-spinner--large" />
+          </PatternExample>
+          <PatternExample details="spinner, small size">
+            <SvgIcon name="spinner" className="hyp-spinner--small" />
           </PatternExample>
         </PatternExamples>
       </Pattern>

--- a/src/pattern-library/components/patterns/SpinnerPatterns.js
+++ b/src/pattern-library/components/patterns/SpinnerPatterns.js
@@ -1,0 +1,36 @@
+import {
+  PatternExample,
+  PatternExamples,
+  PatternPage,
+  Pattern,
+} from '../PatternPage';
+
+import { SvgIcon } from '../../..';
+
+export default function SpinnerPatterns() {
+  return (
+    <PatternPage title="Spinners">
+      <p>
+        The <code>spinner</code> pattern can be used to show loading states. It
+        is an animated SVG.
+      </p>
+      <Pattern title="Spinner">
+        <p>
+          The spinner is <code>em-sized</code>; it renders at <code>1em</code>{' '}
+          square. To adjust size, adjust the local font size.
+        </p>
+        <PatternExamples>
+          <PatternExample details="basic spinner">
+            <SvgIcon name="spinner" className="hyp-spinner" />
+          </PatternExample>
+          <PatternExample
+            details="spinner with local font-size at 3rem"
+            style={{ fontSize: '3rem' }}
+          >
+            <SvgIcon name="spinner" className="hyp-spinner" />
+          </PatternExample>
+        </PatternExamples>
+      </Pattern>
+    </PatternPage>
+  );
+}

--- a/src/pattern-library/routes.js
+++ b/src/pattern-library/routes.js
@@ -6,12 +6,14 @@ import LayoutFoundations from './components/patterns/LayoutFoundations';
 import FormPatterns from './components/patterns/FormPatterns';
 import ContainerPatterns from './components/patterns/ContainerPatterns';
 import PanelPatterns from './components/patterns/PanelPatterns';
+import SpinnerPatterns from './components/patterns/SpinnerPatterns';
 
 import ButtonComponents from './components/patterns/ButtonComponents';
 import ContainerComponents from './components/patterns/ContainerComponents';
 import DialogComponents from './components/patterns/DialogComponents';
 import FormComponents from './components/patterns/FormComponents';
 import PanelComponents from './components/patterns/PanelComponents';
+import SpinnerComponents from './components/patterns/SpinnerComponents';
 
 /**
  * @typedef {'home'|'foundations'|'patterns'|'components'} PlaygroundRouteGroup
@@ -64,6 +66,12 @@ const routes = [
     group: 'patterns',
   },
   {
+    route: '/patterns-spinners',
+    title: 'Spinners',
+    component: SpinnerPatterns,
+    group: 'patterns',
+  },
+  {
     route: '/components-buttons',
     title: 'Buttons',
     component: ButtonComponents,
@@ -91,6 +99,12 @@ const routes = [
     route: '/components-panel',
     title: 'Panel',
     component: PanelComponents,
+    group: 'components',
+  },
+  {
+    route: '/components-spinner',
+    title: 'Spinner',
+    component: SpinnerComponents,
     group: 'components',
   },
 ];

--- a/styles/components/Spinner.scss
+++ b/styles/components/Spinner.scss
@@ -1,0 +1,5 @@
+@use '../mixins/patterns/spinners';
+
+.Hyp-Spinner {
+  @include spinners.spinner;
+}

--- a/styles/components/Spinner.scss
+++ b/styles/components/Spinner.scss
@@ -1,5 +1,14 @@
 @use '../mixins/patterns/spinners';
 
-.Hyp-Spinner {
-  @include spinners.spinner;
+.Hyp-Spinner--small {
+  @include spinners.spinner($size: 1em);
+}
+
+.Hyp-Spinner,
+.Hyp-Spinner--medium {
+  @include spinners.spinner($size: 2em);
+}
+
+.Hyp-Spinner--large {
+  @include spinners.spinner($size: 3em);
 }

--- a/styles/index.scss
+++ b/styles/index.scss
@@ -8,6 +8,7 @@
 @use './components/Dialog';
 @use './components/Modal';
 @use './components/Panel';
+@use './components/Spinner';
 @use './components/SvgIcon';
 @use './components/TextInput';
 @use './components/buttons/styles';

--- a/styles/mixins/patterns/_spinners.scss
+++ b/styles/mixins/patterns/_spinners.scss
@@ -1,9 +1,9 @@
 @use '../../variables' as var;
 
 // Style an SVG as a loading spinner
-@mixin spinner {
+@mixin spinner($size: 2em) {
   color: var.$color-grey-6;
   // Assure that the spinner SVG is sized proportinally to local font-size
-  width: 1em;
-  height: 1em;
+  width: $size;
+  height: $size;
 }

--- a/styles/mixins/patterns/_spinners.scss
+++ b/styles/mixins/patterns/_spinners.scss
@@ -1,0 +1,9 @@
+@use '../../variables' as var;
+
+// Style an SVG as a loading spinner
+@mixin spinner {
+  color: var.$color-grey-6;
+  // Assure that the spinner SVG is sized proportinally to local font-size
+  width: 1em;
+  height: 1em;
+}

--- a/styles/patterns/_spinners.scss
+++ b/styles/patterns/_spinners.scss
@@ -1,0 +1,5 @@
+@use '../mixins/patterns/spinners';
+
+.hyp-spinner {
+  @include spinners.spinner;
+}

--- a/styles/patterns/_spinners.scss
+++ b/styles/patterns/_spinners.scss
@@ -1,5 +1,14 @@
 @use '../mixins/patterns/spinners';
 
-.hyp-spinner {
-  @include spinners.spinner;
+.hyp-spinner--small {
+  @include spinners.spinner($size: 1em);
+}
+
+.hyp-spinner,
+.hyp-spinner--medium {
+  @include spinners.spinner($size: 2em);
+}
+
+.hyp-spinner--large {
+  @include spinners.spinner($size: 3em);
 }

--- a/styles/patterns/index.scss
+++ b/styles/patterns/index.scss
@@ -1,3 +1,4 @@
 @use 'containers';
 @use 'forms';
 @use 'panels';
+@use 'spinners';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1255,18 +1255,10 @@ anymatch@^2.0.0:
     micromatch "^3.1.4"
     normalize-path "^2.1.1"
 
-anymatch@^3.1.0:
+anymatch@^3.1.0, anymatch@~3.1.1, anymatch@~3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-3.1.2.tgz#c0557c096af32f106198f4f4e2a383537e378716"
   integrity sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==
-  dependencies:
-    normalize-path "^3.0.0"
-    picomatch "^2.0.4"
-
-anymatch@~3.1.1:
-  version "3.1.1"
-  resolved "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz"
-  integrity sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==
   dependencies:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
@@ -1600,7 +1592,7 @@ binary-extensions@^1.0.0:
 
 binary-extensions@^2.0.0:
   version "2.2.0"
-  resolved "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz"
+  resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.2.0.tgz#75f502eeaf9ffde42fc98829645be4ea76bd9e2d"
   integrity sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==
 
 bindings@^1.5.0:
@@ -1676,7 +1668,7 @@ braces@^2.3.1, braces@^2.3.2:
 
 braces@^3.0.2, braces@~3.0.2:
   version "3.0.2"
-  resolved "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz"
+  resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.2.tgz#3454e1a462ee8d599e236df336cd9ea4f8afe107"
   integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
   dependencies:
     fill-range "^7.0.1"
@@ -2024,20 +2016,20 @@ chokidar@3.4.3:
   optionalDependencies:
     fsevents "~2.1.2"
 
-"chokidar@>=3.0.0 <4.0.0", chokidar@^3.4.0, chokidar@^3.4.2:
-  version "3.5.1"
-  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.1.tgz"
-  integrity sha512-9+s+Od+W0VJJzawDma/gvBNQqkTiqYTWLuZoyAsivsI4AaWTCzHG06/TMjsf1cYe9Cb97UCEhjz7HvnPk2p/tw==
+"chokidar@>=3.0.0 <4.0.0":
+  version "3.5.2"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.2.tgz#dba3976fcadb016f66fd365021d91600d01c1e75"
+  integrity sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==
   dependencies:
-    anymatch "~3.1.1"
+    anymatch "~3.1.2"
     braces "~3.0.2"
-    glob-parent "~5.1.0"
+    glob-parent "~5.1.2"
     is-binary-path "~2.1.0"
     is-glob "~4.0.1"
     normalize-path "~3.0.0"
-    readdirp "~3.5.0"
+    readdirp "~3.6.0"
   optionalDependencies:
-    fsevents "~2.3.1"
+    fsevents "~2.3.2"
 
 chokidar@^2.0.0:
   version "2.1.8"
@@ -2057,6 +2049,21 @@ chokidar@^2.0.0:
     upath "^1.1.1"
   optionalDependencies:
     fsevents "^1.2.7"
+
+chokidar@^3.4.0, chokidar@^3.4.2:
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.1.tgz"
+  integrity sha512-9+s+Od+W0VJJzawDma/gvBNQqkTiqYTWLuZoyAsivsI4AaWTCzHG06/TMjsf1cYe9Cb97UCEhjz7HvnPk2p/tw==
+  dependencies:
+    anymatch "~3.1.1"
+    braces "~3.0.2"
+    glob-parent "~5.1.0"
+    is-binary-path "~2.1.0"
+    is-glob "~4.0.1"
+    normalize-path "~3.0.0"
+    readdirp "~3.5.0"
+  optionalDependencies:
+    fsevents "~2.3.1"
 
 chownr@^1.1.1:
   version "1.1.4"
@@ -3332,7 +3339,7 @@ fill-range@^4.0.0:
 
 fill-range@^7.0.1:
   version "7.0.1"
-  resolved "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz"
+  resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-7.0.1.tgz#1919a6a7c75fe38b2c7c77e5198535da9acdda40"
   integrity sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==
   dependencies:
     to-regex-range "^5.0.1"
@@ -3537,9 +3544,9 @@ fsevents@~2.1.2:
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.1.3.tgz#fb738703ae8d2f9fe900c33836ddebee8b97f23e"
   integrity sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==
 
-fsevents@~2.3.1:
+fsevents@~2.3.1, fsevents@~2.3.2:
   version "2.3.2"
-  resolved "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
   integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
 
 function-bind@^1.1.1:
@@ -3626,10 +3633,17 @@ glob-parent@^3.1.0:
     is-glob "^3.1.0"
     path-dirname "^1.0.0"
 
-glob-parent@^5.0.0, glob-parent@~5.1.0:
+glob-parent@^5.0.0:
   version "5.1.1"
   resolved "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz"
   integrity sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==
+  dependencies:
+    is-glob "^4.0.1"
+
+glob-parent@~5.1.0, glob-parent@~5.1.2:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.2.tgz#869832c58034fe68a4093c17dc15e8340d8401c4"
+  integrity sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==
   dependencies:
     is-glob "^4.0.1"
 
@@ -4138,7 +4152,7 @@ is-binary-path@^1.0.0:
 
 is-binary-path@~2.1.0:
   version "2.1.0"
-  resolved "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz"
+  resolved "https://registry.yarnpkg.com/is-binary-path/-/is-binary-path-2.1.0.tgz#ea1f7f3b80f064236e83470f86c09c254fb45b09"
   integrity sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==
   dependencies:
     binary-extensions "^2.0.0"
@@ -4286,7 +4300,7 @@ is-number@^4.0.0:
 
 is-number@^7.0.0:
   version "7.0.0"
-  resolved "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz"
+  resolved "https://registry.yarnpkg.com/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
   integrity sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
 
 is-plain-obj@^2.1.0:
@@ -5220,7 +5234,7 @@ normalize-path@^2.1.1:
 
 normalize-path@^3.0.0, normalize-path@~3.0.0:
   version "3.0.0"
-  resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-3.0.0.tgz"
+  resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-3.0.0.tgz#0dcd69ff23a1c9b11fd0978316644a0388216a65"
   integrity sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==
 
 normalize-range@^0.1.2:
@@ -5674,9 +5688,9 @@ performance-now@^2.1.0:
   integrity sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
 
 picomatch@^2.0.4, picomatch@^2.2.1:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.2.tgz"
-  integrity sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.0.tgz#f1f061de8f6a4bf022892e2d128234fb98302972"
+  integrity sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==
 
 pify@^2.0.0:
   version "2.3.0"
@@ -5990,8 +6004,15 @@ readdirp@^2.2.1:
 
 readdirp@~3.5.0:
   version "3.5.0"
-  resolved "https://registry.npmjs.org/readdirp/-/readdirp-3.5.0.tgz"
+  resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-3.5.0.tgz#9ba74c019b15d365278d2e91bb8c48d7b4d42c9e"
   integrity sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==
+  dependencies:
+    picomatch "^2.2.1"
+
+readdirp@~3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-3.6.0.tgz#74a370bd857116e245b29cc97340cd431a02a6c7"
+  integrity sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==
   dependencies:
     picomatch "^2.2.1"
 
@@ -6248,9 +6269,9 @@ safe-regex@^1.1.0:
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
 sass@^1.32.11:
-  version "1.32.11"
-  resolved "https://registry.yarnpkg.com/sass/-/sass-1.32.11.tgz#b236b3ea55c76602c2ef2bd0445f0db581baa218"
-  integrity sha512-O9tRcob/fegUVSIV1ihLLZcftIOh0AF1VpKgusUfLqnb2jQ0GLDwI5ivv1FYWivGv8eZ/AwntTyTzjcHu0c/qw==
+  version "1.35.1"
+  resolved "https://registry.yarnpkg.com/sass/-/sass-1.35.1.tgz#90ecf774dfe68f07b6193077e3b42fb154b9e1cd"
+  integrity sha512-oCisuQJstxMcacOPmxLNiLlj4cUyN2+8xJnG7VanRoh2GOLr9RqkvI4AxA4a6LHVg/rsu+PmxXeGhrdSF9jCiQ==
   dependencies:
     chokidar ">=3.0.0 <4.0.0"
 
@@ -6930,7 +6951,7 @@ to-regex-range@^2.1.0:
 
 to-regex-range@^5.0.1:
   version "5.0.1"
-  resolved "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz"
+  resolved "https://registry.yarnpkg.com/to-regex-range/-/to-regex-range-5.0.1.tgz#1648c44aae7c8d988a326018ed72f5b4dd0392e4"
   integrity sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==
   dependencies:
     is-number "^7.0.0"


### PR DESCRIPTION
This PR adds a shared `spinner` pattern and corresponding `Spinner` component. 

Motivation: The spinners are styled differently in our applications, and their usage within a single application is also inconsistent. In the immediate term, I'd like to use a loading spinner within a component on LMS, so this feels like the right time to drop this in.

~~This implementation is copied over from the `client`, with a little bit of simplification, and I made the `Spinner` component take a `classes` prop for better developer control.~~

This implementation is a variant of the `lms` `Spinner`, using an animated SVG.

~~To implement this, I had to update the `sass` dependency in this package. Needed the `math.div` function. The version here is in line with what the `client` and `lms` have.~~

The above is no longer the case, since the implementation is SVG-based, but there's no harm in bumping SASS.

~~This PR currently depends on #131 for my own convenience, but it doesn't strictly need to if that one gets mired.~~

## Try it out

On this branch, run `make dev` and visit the Pattern Library's [spinner pattern](http://localhost:4001/ui-playground/patterns-spinners) and [Spinner components](http://localhost:4001/ui-playground/components-spinner) pages.

Screen shot (doesn't show animation):

![image](https://user-images.githubusercontent.com/439947/123956815-1ca86400-d979-11eb-9cd5-3ac7332ea04c.png)

