### PR TITLE
Add `thumbnail` pattern, `Thumbnail` component

### DIFF
--- a/src/components/Thumbnail.js
+++ b/src/components/Thumbnail.js
@@ -1,0 +1,64 @@
+import classnames from 'classnames';
+import { toChildArray } from 'preact';
+
+import { Spinner } from './Spinner';
+
+/**
+ * @typedef {import('preact').ComponentChildren} Children
+ *
+ * @typedef ThumbnailProps
+ * @prop {Children|null} [children] - Thumbnail content (typically an img)
+ * @prop {string} [classes] - Additional CSS classes to apply
+ * @prop {boolean} [isLoading=false] - Is the thumbnail loading?
+ * @prop {Object} [placeholder='...'] - Optional placeholder to replace default
+ * @prop {'small'|'medium'|'large'} [size='medium'] - Relative size of spinner
+ *   to surrounding content. Typically the `large` size is appropriate, but for
+ *   small thumbnails, `medium` might feel more appropriate.
+ */
+
+/**
+ * Render a container with thumbnail content.
+ *
+ * Thumbnail content (e.g. img) may or may not be present. This component
+ * provides support for three states:
+ *
+ *  - Content not yet loaded or is not available: Show a placeholder
+ *  - Content is loading: Show a loading spinner
+ *  - Content is present: Show the content, unless `isLoading` is `true`
+ *
+ * Thumbnail dimensions will remain constant even when content is not present,
+ * avoiding layout shifts. Applied styling will constrain content to dimensions
+ * of parent container. Apply explicit width and height rules to the parent
+ * container of this component to dictate sizing.
+ *
+ * Examples:
+ *
+ * <Thumbnail><img src="http://placekitten.com/200/300" alt="kitty" /></Thumbnail>
+ * <Thumbnail /> // -> Empty, shows placeholder
+ * <Thumbnail isLoading /> // -> Empty, shows loading spinner
+ *
+ * TODO: There is an implied sub-pattern/-component here to do with rendering
+ * embedded media within constraints, preventing layout shift, and handling
+ * loading states. See https://github.com/hypothesis/frontend-shared/issues/134
+ *
+ * @param {ThumbnailProps} props
+ */
+export function Thumbnail({
+  children,
+  classes = '',
+  isLoading = false,
+  placeholder = '...',
+  size = 'medium',
+}) {
+  // If there are no `children`, render a placeholder (unless loading)
+  const content = toChildArray(children).length ? children : placeholder;
+
+  return (
+    <div className={classnames('Hyp-Thumbnail', classes)}>
+      <div className="Hyp-Thumbnail__content">
+        {isLoading && <Spinner size={size} />}
+        {!isLoading && content}
+      </div>
+    </div>
+  );
+}

--- a/src/components/test/Thumbnail-test.js
+++ b/src/components/test/Thumbnail-test.js
@@ -1,0 +1,69 @@
+import { mount } from 'enzyme';
+
+import { Thumbnail } from '../Thumbnail';
+
+import { checkAccessibility } from '../../../test/util/accessibility';
+
+describe('Thumbnail', () => {
+  const createComponent = (props = {}) =>
+    mount(
+      <Thumbnail {...props}>
+        <img src="http://placekitten.com/200/300" alt="kitty" />
+      </Thumbnail>
+    );
+
+  const createEmptyComponent = (props = {}) => mount(<Thumbnail {...props} />);
+
+  it('renders', () => {
+    const wrapper = createComponent();
+
+    assert.isTrue(wrapper.find('div.Hyp-Thumbnail').exists());
+  });
+
+  it('applies additional classes', () => {
+    const wrapper = createComponent({ classes: 'foo bar' });
+    assert.isTrue(wrapper.find('div.Hyp-Thumbnail.foo.bar').exists());
+  });
+
+  context('when in loading state', () => {
+    it('renders a loading spinner', () => {
+      const wrapper = createComponent({ isLoading: true });
+      assert.exists(wrapper.find('SvgIcon[name="spinner"]'));
+    });
+
+    it('does not render content', () => {
+      const wrapper = createComponent({ isLoading: true });
+      assert.isFalse(wrapper.find('img').exists());
+    });
+
+    it('applies size to loading spinner', () => {
+      const wrapper = createComponent({ isLoading: true, size: 'large' });
+      const spinner = wrapper.find('Spinner');
+      assert.equal(spinner.props().size, 'large');
+    });
+  });
+
+  context('when empty', () => {
+    it('renders default placeholder', () => {
+      const wrapper = createEmptyComponent();
+      assert.equal(wrapper.text(), '...');
+    });
+
+    it('renders the provided placeholder', () => {
+      const wrapper = createEmptyComponent({ placeholder: '!' });
+      assert.equal(wrapper.text(), '!');
+    });
+
+    it('does not render a placeholder when in loading state', () => {
+      const wrapper = createComponent({ isLoading: true, placeholder: '!' });
+      assert.notInclude(wrapper.text(), '!');
+    });
+  });
+
+  it(
+    'should pass a11y checks',
+    checkAccessibility({
+      content: () => createComponent(),
+    })
+  );
+});

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@ export { Panel } from './components/Panel';
 export { Spinner } from './components/Spinner';
 export { SvgIcon, registerIcons } from './components/SvgIcon';
 export { TextInput, TextInputWithButton } from './components/TextInput';
+export { Thumbnail } from './components/Thumbnail';
 
 // Hooks
 export { useElementShouldClose } from './hooks/use-element-should-close';

--- a/src/pattern-library/components/patterns/ThumbnailComponents.js
+++ b/src/pattern-library/components/patterns/ThumbnailComponents.js
@@ -1,0 +1,83 @@
+import { Thumbnail } from '../../..';
+
+import {
+  PatternPage,
+  Pattern,
+  PatternExamples,
+  PatternExample,
+} from '../PatternPage';
+
+export default function ThumbnailComponents() {
+  return (
+    <PatternPage title="Thumbnail">
+      <Pattern title="Thumbnail">
+        <p>
+          The <code>Thumbnail</code> component handles rendering a thumbnail or
+          other image, and provides a loading state and an empty (placeholder)
+          state. If <code>Thumbnail</code> has no content, it will render a
+          placeholder. If its <code>isLoading</code> prop is set to{' '}
+          <code>true</code>, it will render a loading state.
+        </p>
+        <p>
+          The following examples are rendered within a parent container sized to
+          250x175px. The Thumbnail will fill, but not exceed, the available
+          space.
+        </p>
+        <PatternExamples>
+          <PatternExample details="Empty thumbnail with default placeholder">
+            <div style="height: 250px; width:175px">
+              <Thumbnail />
+            </div>
+          </PatternExample>
+          <PatternExample details="Thumbnail with image content">
+            <div style="height: 250px; width:175px">
+              <Thumbnail>
+                <img src="http://placekitten.com/200/300" alt="kitty" />
+              </Thumbnail>
+            </div>
+          </PatternExample>
+          <PatternExample details="Empty thumbnail in loading state">
+            <div style="height: 250px; width:175px">
+              <Thumbnail isLoading />
+            </div>
+          </PatternExample>
+          <PatternExample details="Thumbnail in loading state (ignores content)">
+            <div style="height: 250px; width:175px">
+              <Thumbnail isLoading>
+                <img src="http://placekitten.com/200/300" alt="kitty" />
+              </Thumbnail>
+            </div>
+          </PatternExample>
+          <PatternExample details="Empty thumbnail with custom placeholder (placeholder can be any valid JSX)">
+            <div style="height: 250px; width:175px">
+              <Thumbnail placeholder="!" />
+            </div>
+          </PatternExample>
+        </PatternExamples>
+      </Pattern>
+
+      <Pattern title="Thumbnail (smaller)">
+        <p>These examples are within a 100x150px parent.</p>
+        <PatternExamples>
+          <PatternExample details="smaller loading spinner">
+            <div style="width:150px; height:100px">
+              <Thumbnail isLoading size="small" />
+            </div>
+          </PatternExample>
+          <PatternExample details="constrained image proportions">
+            <div style="width:150px; height:100px">
+              <Thumbnail size="small">
+                <img src="http://placekitten.com/200/300" alt="kitty" />
+              </Thumbnail>
+            </div>
+          </PatternExample>
+          <PatternExample details="constrained image proportions">
+            <div style="width:150px; height:100px">
+              <Thumbnail size="small" />
+            </div>
+          </PatternExample>
+        </PatternExamples>
+      </Pattern>
+    </PatternPage>
+  );
+}

--- a/src/pattern-library/components/patterns/ThumbnailPatterns.js
+++ b/src/pattern-library/components/patterns/ThumbnailPatterns.js
@@ -1,0 +1,113 @@
+import {
+  PatternExample,
+  PatternExamples,
+  PatternPage,
+  Pattern,
+} from '../PatternPage';
+
+import { SvgIcon } from '../../..';
+
+export default function ThumbnailPatterns() {
+  return (
+    <PatternPage title="Thumbnails">
+      <p>
+        The thumbnail pattern is for displaying thumbnail or other images in a
+        frame of constrained size. It provides a variant for displaying a
+        placeholder (when there is no image to render) or a loading state.
+      </p>
+      <p>
+        The thumbnail will fill the available space in the parent (100%), but
+        will constrain the image dimensions within that space, retaining aspect
+        ratio. It will retain its dimensions even when empty or in loading
+        state.
+      </p>
+      <Pattern title="Thumbnail">
+        <p>
+          These examples show a thumbnail that is contained within a parent
+          container sized to 250x175px.
+        </p>
+        <PatternExamples>
+          <PatternExample details="thumbnail with content">
+            <div style="height: 250px; width: 175px">
+              <div className="hyp-thumbnail">
+                <div className="hyp-thumbnail__content">
+                  <img src="http://placekitten.com/200/300" alt="kitty" />
+                </div>
+              </div>
+            </div>
+          </PatternExample>
+
+          <PatternExample details="thumbnail with placeholder">
+            <div style="height: 250px; width: 175px">
+              <div className="hyp-thumbnail">
+                <div className="hyp-thumbnail__content">
+                  <div className="hyp-thumbnail__placeholder">...</div>
+                </div>
+              </div>
+            </div>
+          </PatternExample>
+
+          <PatternExample details="thumbnail in loading state">
+            <div style="height: 250px; width: 175px">
+              <div className="hyp-thumbnail">
+                <div className="hyp-thumbnail__content">
+                  <SvgIcon name="hyp-spinner" className="hyp-spinner" />
+                </div>
+              </div>
+            </div>
+          </PatternExample>
+        </PatternExamples>
+      </Pattern>
+      <Pattern title="Thumbnail in smaller dimensions">
+        <p>
+          These examples show all three states of a thumnbail in a smaller
+          space: 150x100px.
+        </p>
+        <PatternExamples>
+          <PatternExample details="all three states shown">
+            <div style="width: 100px; height: 150px">
+              <div className="hyp-thumbnail">
+                <div className="hyp-thumbnail__content">
+                  <img src="http://placekitten.com/100/150" alt="kitty" />
+                </div>
+              </div>
+            </div>
+
+            <div style="width: 100px; height: 150px">
+              <div className="hyp-thumbnail">
+                <div className="hyp-thumbnail__content">
+                  <span className="hyp-thumbnail__placeholder">...</span>
+                </div>
+              </div>
+            </div>
+
+            <div style="width: 100px; height: 150px">
+              <div className="hyp-thumbnail">
+                <div className="hyp-thumbnail__content">
+                  <SvgIcon name="hyp-spinner" className="hyp-spinner" />
+                </div>
+              </div>
+            </div>
+          </PatternExample>
+        </PatternExamples>
+      </Pattern>
+      <Pattern title="Thumbnails: aspect ratio">
+        <p>
+          An image in a thumnbail is constrained to the available space, and
+          retains aspect ratio.
+        </p>
+        <PatternExamples>
+          <PatternExample details="thumbnail showing retention of image aspect ratio">
+            <div style="width: 175px; height: 250px">
+              <div className="hyp-thumbnail">
+                <div className="hyp-thumbnail__content">
+                  <img src="http://placekitten.com/350/250" alt="kitty" />
+                </div>
+              </div>
+            </div>
+          </PatternExample>
+        </PatternExamples>
+      </Pattern>
+    </PatternPage>
+  );
+}

--- a/src/pattern-library/routes.js
+++ b/src/pattern-library/routes.js
@@ -7,6 +7,7 @@ import FormPatterns from './components/patterns/FormPatterns';
 import ContainerPatterns from './components/patterns/ContainerPatterns';
 import PanelPatterns from './components/patterns/PanelPatterns';
 import SpinnerPatterns from './components/patterns/SpinnerPatterns';
+import ThumbnailPatterns from './components/patterns/ThumbnailPatterns';
 
 import ButtonComponents from './components/patterns/ButtonComponents';
 import ContainerComponents from './components/patterns/ContainerComponents';
@@ -14,6 +15,7 @@ import DialogComponents from './components/patterns/DialogComponents';
 import FormComponents from './components/patterns/FormComponents';
 import PanelComponents from './components/patterns/PanelComponents';
 import SpinnerComponents from './components/patterns/SpinnerComponents';
+import ThumbnailComponents from './components/patterns/ThumbnailComponents';
 
 /**
  * @typedef {'home'|'foundations'|'patterns'|'components'} PlaygroundRouteGroup
@@ -72,6 +74,12 @@ const routes = [
     group: 'patterns',
   },
   {
+    route: '/patterns-thumbnails',
+    title: 'Thumbnails',
+    component: ThumbnailPatterns,
+    group: 'patterns',
+  },
+  {
     route: '/components-buttons',
     title: 'Buttons',
     component: ButtonComponents,
@@ -105,6 +113,12 @@ const routes = [
     route: '/components-spinner',
     title: 'Spinner',
     component: SpinnerComponents,
+    group: 'components',
+  },
+  {
+    route: '/components-thumbnail',
+    title: 'Thumbnail',
+    component: ThumbnailComponents,
     group: 'components',
   },
 ];

--- a/styles/components/Thumbnail.scss
+++ b/styles/components/Thumbnail.scss
@@ -1,0 +1,5 @@
+@use '../mixins/patterns/thumbnails';
+
+.Hyp-Thumbnail {
+  @include thumbnails.thumbnail;
+}

--- a/styles/index.scss
+++ b/styles/index.scss
@@ -11,4 +11,5 @@
 @use './components/Spinner';
 @use './components/SvgIcon';
 @use './components/TextInput';
+@use './components/Thumbnail';
 @use './components/buttons/styles';

--- a/styles/mixins/patterns/_spinners.scss
+++ b/styles/mixins/patterns/_spinners.scss
@@ -2,7 +2,7 @@
 
 // Style an SVG as a loading spinner
 @mixin spinner($size: 2em) {
-  color: var.$color-grey-6;
+  color: var.$color-grey-5;
   // Assure that the spinner SVG is sized proportinally to local font-size
   width: $size;
   height: $size;

--- a/styles/mixins/patterns/_thumbnails.scss
+++ b/styles/mixins/patterns/_thumbnails.scss
@@ -1,0 +1,46 @@
+@use '../../variables' as var;
+
+@use '../atoms';
+@use '../focus';
+@use '../layout';
+@use '../themes';
+
+@use 'containers';
+
+$-color-thumbnail-frame: var.$color-grey-1;
+$-color-thumbnail-background: var.$color-white;
+$-color-thumbnail: var.$color-grey-5;
+
+// A container for thumbnail content. Constrains to parent width and height.
+@mixin thumbnail {
+  // Outer container.
+  // Provides a thick light-grey "frame" around the thumbnail content
+  @include layout.padding(4);
+  background-color: $-color-thumbnail-frame;
+
+  // Fill the entire available space, but do not exceed it
+  width: 100%;
+  height: 100%;
+
+  &__content {
+    // Flex column for constraining the content to the container's dimensions
+    @include layout.column($justify: center, $align: center);
+
+    // Font size and color for placeholder
+    // TODO After font foundations are in place, this could use some nuance
+    // for smaller sizes.
+    font-size: 2em;
+    color: $-color-thumbnail;
+
+    // Apply white background, since the parent is grey
+    background-color: $-color-thumbnail-background;
+
+    width: 100%;
+    height: 100%;
+    & > img {
+      width: 100%;
+      height: 100%;
+      object-fit: contain;
+    }
+  }
+}

--- a/styles/patterns/_thumbnails.scss
+++ b/styles/patterns/_thumbnails.scss
@@ -1,0 +1,5 @@
+@use '../mixins/patterns/thumbnails';
+
+.hyp-thumbnail {
+  @include thumbnails.thumbnail;
+}

--- a/styles/patterns/index.scss
+++ b/styles/patterns/index.scss
@@ -2,3 +2,4 @@
 @use 'forms';
 @use 'panels';
 @use 'spinners';
+@use 'thumbnails';


### PR DESCRIPTION
Depends on #132 

This PR introduces a new pattern and component for thumbnails.

Problems I'm trying to solve/motivation:

* Immediate: create a pattern for a piece of the VS assignment-configuration workflow, with a consistent loading-state styling to other LMS interfaces
* Longer-term: We face a design challenge not infrequently in which we need to have a container for some dynamic content, and we don't want that container to jump around or resize when the content in it updates. Added to that is the need to constrain the dimensions of the content, reliably, to not exceed the bounds of its parent. While this approaches this problem from the perspective of a more composite pattern, we can later extract the content-constraining sub-pattern into a more generalized basis for other patterns, as needed.

The pattern and component here:

* Provide a styled layout for "thumbnail"-like content, currently matching wireframes for the VS paste-a-link workflow (book cover image).
* Provides a placeholder if the thumbnail is empty.
* Provides a loading state, using the Spinner introduced in #132 
* Provides relative sizing

It also makes the Spinner color one tick lighter, as it looked more harmonious that way in-situ.

## Try it out

On this branch, `make dev` and view the [Thumbnail Patterns](http://localhost:4001/ui-playground/patterns-thumbnails) and [Thumbnail Components](http://localhost:4001/ui-playground/components-thumbnail) pages in the pattern library.

## User-facing impacts

These changes are additive. The `Spinner` has a color change, but that `Spinner` hasn't even landed yet and is not used by any outside parties at present.

Screen shot from patterns page, showing the three states—with content, empty and loading—supported by this pattern. Does not capture the animation of the loading spinner:

![image](https://user-images.githubusercontent.com/439947/123975377-48344a00-d98b-11eb-8447-c673cba04c11.png)
