### PR TITLE
Change `error` prop to `isError`

### DIFF
--- a/src/components/TextInput.js
+++ b/src/components/TextInput.js
@@ -7,7 +7,7 @@ import classnames from 'classnames';
  * @prop {string} [classes] - Additional CSS classes to apply
  * @prop {import('preact').Ref<HTMLInputElement>} [inputRef] - Optional ref for
  *   the rendered `input` element.
- * @prop {boolean} [isError] - There is an error associated with this input. Will
+ * @prop {boolean} [hasError] - There is an error associated with this input. Will
  *   set some error styling.
  */
 
@@ -32,12 +32,16 @@ import classnames from 'classnames';
 export function TextInput({
   classes = '',
   inputRef,
-  isError = false,
+  hasError = false,
   ...restProps
 }) {
   return (
     <input
-      className={classnames('Hyp-TextInput', { 'is-error': isError }, classes)}
+      className={classnames(
+        'Hyp-TextInput',
+        { 'has-error': hasError },
+        classes
+      )}
       {...restProps}
       ref={inputRef}
       type="text"

--- a/src/components/TextInput.js
+++ b/src/components/TextInput.js
@@ -5,10 +5,10 @@ import classnames from 'classnames';
  *
  * @typedef TextInputBaseProps
  * @prop {string} [classes] - Additional CSS classes to apply
- * @prop {boolean} [error] - There is an error associated with this input. Will
- *   set some error styling.
  * @prop {import('preact').Ref<HTMLInputElement>} [inputRef] - Optional ref for
  *   the rendered `input` element.
+ * @prop {boolean} [isError] - There is an error associated with this input. Will
+ *   set some error styling.
  */
 
 /**
@@ -29,10 +29,15 @@ import classnames from 'classnames';
  *
  * @param {TextInputProps} props
  */
-export function TextInput({ classes = '', error, inputRef, ...restProps }) {
+export function TextInput({
+  classes = '',
+  inputRef,
+  isError = false,
+  ...restProps
+}) {
   return (
     <input
-      className={classnames('Hyp-TextInput', { 'is-error': error }, classes)}
+      className={classnames('Hyp-TextInput', { 'is-error': isError }, classes)}
       {...restProps}
       ref={inputRef}
       type="text"

--- a/src/components/test/TextInput-test.js
+++ b/src/components/test/TextInput-test.js
@@ -10,7 +10,7 @@ describe('TextInput', () => {
     const wrapper = createComponent();
 
     assert.isTrue(wrapper.find('input').hasClass('Hyp-TextInput'));
-    assert.isFalse(wrapper.find('input').hasClass('is-error'));
+    assert.isFalse(wrapper.find('input').hasClass('has-error'));
   });
 
   it('ignores `type` property and sets `type` to `text`', () => {
@@ -20,9 +20,9 @@ describe('TextInput', () => {
   });
 
   it('applies an error class when in error', () => {
-    const wrapper = createComponent({ isError: true });
+    const wrapper = createComponent({ hasError: true });
 
-    assert.isTrue(wrapper.find('input').hasClass('is-error'));
+    assert.isTrue(wrapper.find('input').hasClass('has-error'));
   });
 
   it('passes along a `ref` to the input element through `inputRef`', () => {

--- a/src/components/test/TextInput-test.js
+++ b/src/components/test/TextInput-test.js
@@ -20,7 +20,7 @@ describe('TextInput', () => {
   });
 
   it('applies an error class when in error', () => {
-    const wrapper = createComponent({ error: true });
+    const wrapper = createComponent({ isError: true });
 
     assert.isTrue(wrapper.find('input').hasClass('is-error'));
   });

--- a/src/pattern-library/components/patterns/FormComponents.js
+++ b/src/pattern-library/components/patterns/FormComponents.js
@@ -14,6 +14,7 @@ import {
 export default function FormComponents() {
   const [wantSandwich, setWantSandwich] = useState(true);
   const [wantWatermelon, setWantWatermelon] = useState(false);
+  const [textInputIsError, setTextInputIsError] = useState(true);
   return (
     <PatternPage title="Forms">
       <Pattern title="Checkbox">
@@ -81,10 +82,15 @@ export default function FormComponents() {
             </TextInputWithButton>
           </PatternExample>
 
-          <PatternExample details="text input field in an error state">
+          <PatternExample details="text input field in an error state; click button to toggle error state">
             <TextInputWithButton>
-              <TextInput name="my-input" isError />
-              <IconButton icon="arrow-right" variant="dark" title="go" />
+              <TextInput name="my-input" isError={textInputIsError} />
+              <IconButton
+                icon="arrow-right"
+                variant="dark"
+                title="go"
+                onClick={() => setTextInputIsError(!textInputIsError)}
+              />
             </TextInputWithButton>
           </PatternExample>
         </PatternExamples>

--- a/src/pattern-library/components/patterns/FormComponents.js
+++ b/src/pattern-library/components/patterns/FormComponents.js
@@ -58,7 +58,7 @@ export default function FormComponents() {
           </PatternExample>
 
           <PatternExample details="text input field in an error state">
-            <TextInput name="my-input" error />
+            <TextInput name="my-input" isError />
           </PatternExample>
         </PatternExamples>
       </Pattern>
@@ -83,7 +83,7 @@ export default function FormComponents() {
 
           <PatternExample details="text input field in an error state">
             <TextInputWithButton>
-              <TextInput name="my-input" error />
+              <TextInput name="my-input" isError />
               <IconButton icon="arrow-right" variant="dark" title="go" />
             </TextInputWithButton>
           </PatternExample>

--- a/src/pattern-library/components/patterns/FormComponents.js
+++ b/src/pattern-library/components/patterns/FormComponents.js
@@ -14,7 +14,7 @@ import {
 export default function FormComponents() {
   const [wantSandwich, setWantSandwich] = useState(true);
   const [wantWatermelon, setWantWatermelon] = useState(false);
-  const [textInputIsError, setTextInputIsError] = useState(true);
+  const [textInputHasError, setTextInputHasError] = useState(true);
   return (
     <PatternPage title="Forms">
       <Pattern title="Checkbox">
@@ -59,7 +59,7 @@ export default function FormComponents() {
           </PatternExample>
 
           <PatternExample details="text input field in an error state">
-            <TextInput name="my-input" isError />
+            <TextInput name="my-input" hasError />
           </PatternExample>
         </PatternExamples>
       </Pattern>
@@ -84,12 +84,12 @@ export default function FormComponents() {
 
           <PatternExample details="text input field in an error state; click button to toggle error state">
             <TextInputWithButton>
-              <TextInput name="my-input" isError={textInputIsError} />
+              <TextInput name="my-input" hasError={textInputHasError} />
               <IconButton
                 icon="arrow-right"
                 variant="dark"
                 title="go"
-                onClick={() => setTextInputIsError(!textInputIsError)}
+                onClick={() => setTextInputHasError(!textInputHasError)}
               />
             </TextInputWithButton>
           </PatternExample>

--- a/src/pattern-library/components/patterns/FormPatterns.js
+++ b/src/pattern-library/components/patterns/FormPatterns.js
@@ -24,7 +24,7 @@ export default function FormPatterns() {
           </PatternExample>
           <PatternExample details="text input in an error state">
             <input
-              className="hyp-text-input is-error"
+              className="hyp-text-input has-error"
               type="text"
               placeholder="http://www.example.com"
             />
@@ -55,7 +55,7 @@ export default function FormPatterns() {
               <input
                 type="text"
                 placeholder="http://www.example.com"
-                className="is-error"
+                className="has-error"
               />
               <IconButton icon="arrow-right" title="go" variant="dark" />
             </div>

--- a/styles/mixins/patterns/_forms.scss
+++ b/styles/mixins/patterns/_forms.scss
@@ -34,6 +34,7 @@ $-color-text--disabled: var.$color-text--disabled;
 @mixin text-input {
   @include input;
 
+  &.has-error,
   &.is-error {
     // Apply an error-colored inset outline.
     outline: none;

--- a/styles/mixins/patterns/_forms.scss
+++ b/styles/mixins/patterns/_forms.scss
@@ -36,10 +36,7 @@ $-color-text--disabled: var.$color-text--disabled;
 
   &.is-error {
     // Apply an error-colored inset outline.
-    // Remove any outlines or borders to make sure the input element doesn't
-    // change dimensions when applying the inset outline
     outline: none;
-    border: none;
     @include focus.outline-rule($inset: true, $color: $-color-error);
   }
 


### PR DESCRIPTION
This PR contains two commits, both related to `TextInput`/`text-input`:

* The naming of the `error` prop on `TextInput` was ambiguous. ~~`isError`~~ `hasError` communicates
its boolean-ness better and doesn't masquerade as a native HTML element
attribute. It also better matches the applied stateful classname: ~~`.is-error`~~ `.has-error`
* Don't remove `border` when styling a text input in an error state. The error outline is inset, so should be independent of borders. Removing these borders here caused a tiny, tiny layout wiggle when `TextInput` was used on `lms`. Adds a pattern-library example that allows toggling between error and non-error states to demonstrate that there is no layout wiggle.

Screen grab of updated `TextInput` example in pattern library:

![image](https://user-images.githubusercontent.com/439947/125121002-4839f580-e0c1-11eb-8c76-a66ede755b87.png)

The prop name change is a _breaking change_. The only known use of this component is in one component in `lms`. I'll handle this manually, if that's OK (bump the package and update the component usage in one go).

Fixes #136
Fixes #138