### PR TITLE
Remediate broken tests using `assert.exists`

### DIFF
--- a/src/components/test/Spinner-test.js
+++ b/src/components/test/Spinner-test.js
@@ -8,18 +8,18 @@ describe('Spinner', () => {
   const createSpinner = (props = {}) => mount(<Spinner {...props} />);
 
   it('renders', () => {
-    createSpinner();
-    assert.exists('span.Hyp-Spinner--medium');
+    const wrapper = createSpinner();
+    assert.isTrue(wrapper.find('SvgIcon.Hyp-Spinner--medium').exists());
   });
 
   it('applies additional classes', () => {
-    createSpinner({ classes: 'foo bar' });
-    assert.exists('span.Hyp-Spinner--medium.foo.bar');
+    const wrapper = createSpinner({ classes: 'foo bar' });
+    assert.isTrue(wrapper.find('SvgIcon.Hyp-Spinner--medium.foo.bar').exists());
   });
 
   it('sets indicated size', () => {
-    createSpinner({ size: 'xlarge' });
-    assert.exists('span.Hyp-Spinner--large.foo.bar');
+    const wrapper = createSpinner({ size: 'large' });
+    assert.isTrue(wrapper.find('SvgIcon.Hyp-Spinner--large').exists());
   });
 
   it(

--- a/src/components/test/TextInput-test.js
+++ b/src/components/test/TextInput-test.js
@@ -33,9 +33,9 @@ describe('TextInput', () => {
   });
 
   it('applies extra classes', () => {
-    createComponent({ classes: 'foo bar' });
+    const wrapper = createComponent({ classes: 'foo bar' });
 
-    assert.exists('div.Hyp-TextInput.foo.bar');
+    assert.isTrue(wrapper.find('.Hyp-TextInput.foo.bar').exists());
   });
 });
 
@@ -49,14 +49,14 @@ describe('TextInputWithButton', () => {
     );
 
   it('wraps children in a container element with appropriate className', () => {
-    createComponent();
+    const wrapper = createComponent();
 
-    assert.exists('div.Hyp-TextInputWithButton');
+    assert.isTrue(wrapper.find('.Hyp-TextInputWithButton').exists());
   });
 
   it('applies extra classes', () => {
-    createComponent({ classes: 'foo bar' });
+    const wrapper = createComponent({ classes: 'foo bar' });
 
-    assert.exists('div.Hyp-TextInputWithButton.foo.bar');
+    assert.isTrue(wrapper.find('.Hyp-TextInputWithButton.foo.bar').exists());
   });
 });

--- a/src/components/test/Thumbnail-test.js
+++ b/src/components/test/Thumbnail-test.js
@@ -28,7 +28,7 @@ describe('Thumbnail', () => {
   context('when in loading state', () => {
     it('renders a loading spinner', () => {
       const wrapper = createComponent({ isLoading: true });
-      assert.exists(wrapper.find('SvgIcon[name="spinner"]'));
+      assert.isTrue(wrapper.find('SvgIcon[name="spinner"]').exists());
     });
 
     it('does not render content', () => {

--- a/src/components/test/containers-test.js
+++ b/src/components/test/containers-test.js
@@ -17,9 +17,9 @@ describe('Frame', () => {
   });
 
   it('applies extra classes', () => {
-    createComponent({ classes: 'foo bar' });
+    const wrapper = createComponent({ classes: 'foo bar' });
 
-    assert.exists('div.Hyp-Frame.foo.bar');
+    assert.isTrue(wrapper.find('div.Hyp-Frame.foo.bar').exists());
   });
 });
 
@@ -38,9 +38,9 @@ describe('Card', () => {
   });
 
   it('applies extra classes', () => {
-    createComponent({ classes: 'foo bar' });
+    const wrapper = createComponent({ classes: 'foo bar' });
 
-    assert.exists('div.Hyp-Card.foo.bar');
+    assert.isTrue(wrapper.find('div.Hyp-Card.foo.bar').exists());
   });
 });
 
@@ -59,14 +59,14 @@ describe('Actions', () => {
   });
 
   it('applies extra classes', () => {
-    createComponent({ classes: 'foo bar' });
+    const wrapper = createComponent({ classes: 'foo bar' });
 
-    assert.exists('div.Hyp-Actions--row.foo.bar');
+    assert.isTrue(wrapper.find('div.Hyp-Actions--row.foo.bar').exists());
   });
 
   it('applies columnar layout if `direction` is `column`', () => {
-    createComponent({ direction: 'column' });
+    const wrapper = createComponent({ direction: 'column' });
 
-    assert.exists('div.Hyp-Actions--column');
+    assert.isTrue(wrapper.find('div.Hyp-Actions--column').exists());
   });
 });


### PR DESCRIPTION
This assertion does not do what I thought it did. Blush.

[`assert.exists`](https://www.chaijs.com/api/assert/#method_exists) asserts that something is neither `null` nor `undefined`. I don't even know how I got into a place of thinking these tests would do what I thought they would, which is checking to make sure a DOM element/React Wrapper corresponding to the given selector exists. Sheesh.

Fixes #137