### PR TITLE
Add ability to opt out of focus control for `Dialog`, `Modal`

### DIFF
--- a/src/components/Dialog.js
+++ b/src/components/Dialog.js
@@ -38,8 +38,10 @@ function useUniqueId(prefix) {
  * @prop {Children} children
  * @prop {string} [contentClass] - CSS class to apply to the dialog's content
  * @prop {string} [icon] - Name of optional icon to render in header
- * @prop {import("preact/hooks").Ref<HTMLElement>} [initialFocus] -
- *   Child element to focus when the dialog is rendered.
+ * @prop {import("preact/hooks").Ref<HTMLElement>|null} [initialFocus] -
+ *   Child element to focus when the dialog is rendered. If not provided,
+ *   the Dialog's container will be automatically focused on opening. Set to
+ *   `null` to opt out of automatic focus control.
  * @prop {() => void} [onCancel] -
  *   A callback to invoke when the user cancels the dialog. If provided, a
  *   "Cancel" button will be displayed.
@@ -77,15 +79,20 @@ export function Dialog({
   const rootEl = useRef(/** @type {HTMLDivElement | null} */ (null));
 
   useEffect(() => {
-    const focusEl = /** @type {InputElement|undefined} */ (initialFocus?.current);
-    if (focusEl && !focusEl.disabled) {
-      focusEl.focus();
-    } else {
-      // Modern accessibility guidance is to focus the dialog itself rather than
-      // trying to be smart about focusing a particular control within the
-      // dialog. See resources above.
-      rootEl.current.focus();
+    // Setting `initialFocus` to `null` opts out of focus handling
+    if (initialFocus !== null) {
+      const focusEl = /** @type {InputElement|null} */ (initialFocus?.current);
+      if (focusEl && !focusEl.disabled) {
+        focusEl.focus();
+      } else {
+        // The `initialFocus` prop has not been set, so use automatic focus handling.
+        // Modern accessibility guidance is to focus the dialog itself rather than
+        // trying to be smart about focusing a particular control within the
+        // dialog.
+        rootEl.current.focus();
+      }
     }
+
     // We only want to run this effect once when the dialog is mounted.
     //
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/components/test/Dialog-test.js
+++ b/src/components/test/Dialog-test.js
@@ -118,18 +118,16 @@ describe('Dialog', () => {
       );
     });
 
-    it('focuses the dialog if `initialFocus` ref is `null`', () => {
-      const wrapper = mount(
-        <Dialog initialFocus={{ current: null }} title="My dialog">
+    it('does not set focus if `initialFocus` is set to `null`', () => {
+      const focusedBefore = document.activeElement;
+      mount(
+        <Dialog initialFocus={null} title="My dialog">
           <div>Test</div>
         </Dialog>,
         { attachTo: container }
       );
 
-      assert.equal(
-        document.activeElement,
-        wrapper.find('[role="dialog"]').getDOMNode()
-      );
+      assert.equal(document.activeElement, focusedBefore);
     });
 
     it('focuses the dialog if `initialFocus` element is disabled', () => {

--- a/src/pattern-library/components/patterns/DialogComponents.js
+++ b/src/pattern-library/components/patterns/DialogComponents.js
@@ -1,6 +1,14 @@
 import { createRef, render } from 'preact';
 import { useState } from 'preact/hooks';
-import { ConfirmModal, Dialog, LabeledButton, Modal } from '../../../';
+import {
+  ConfirmModal,
+  Dialog,
+  LabeledButton,
+  Modal,
+  TextInputWithButton,
+  TextInput,
+  IconButton,
+} from '../../../';
 
 import Library from '../Library';
 
@@ -72,6 +80,8 @@ export default function DialogComponents() {
   const [dialogIsOpen, setDialogIsOpen] = useState(false);
   // Basic Modal example
   const [, setModalIsOpen] = useState(false);
+  // Modal with manual focus control
+  const [, setFocusModalIsOpen] = useState(false);
   // Modal with overflowing content example
   const [, setLongModalIsOpen] = useState(false);
   // ConfirmModal example
@@ -115,6 +125,37 @@ export default function DialogComponents() {
         buttons,
       },
     });
+  };
+
+  const openFocusModal = () => {
+    const inputRef = createRef();
+    const children = (
+      <>
+        <div>
+          The input here is manually focused after the <code>Modal</code> is
+          opened.
+        </div>
+        <TextInputWithButton>
+          <TextInput inputRef={inputRef} />
+          <IconButton icon="edit" title="go" variant="dark" />
+        </TextInputWithButton>
+      </>
+    );
+    setFocusModalIsOpen(true);
+    showDialog({
+      DialogComponent: Modal,
+      container: /** @type {HTMLElement} */ (document.getElementById(
+        'modalFocus'
+      )),
+      setOpen: setFocusModalIsOpen,
+      props: {
+        buttons,
+        children,
+        initialFocus: null,
+      },
+    });
+    // This is possible because the Dialog has not grabbed focus
+    inputRef.current.focus();
   };
 
   const openLongModal = () => {
@@ -279,6 +320,30 @@ export default function DialogComponents() {
             <div>
               <div id="modal1" />
               <LabeledButton variant="primary" onClick={openModal}>
+                Open modal
+              </LabeledButton>
+            </div>
+          </Library.Demo>
+        </Library.Example>
+
+        <Library.Example title="Manual focus control">
+          <p>
+            In some cases, you might need more manual control of focus routing.
+            This might arise if you have nested components within a{' '}
+            <code>Modal</code> or <code>Dialog</code>, or there is complex logic
+            about focus. Setting the <code>initialFocus</code> prop to{' '}
+            <code>null</code> will opt out of automatic focus handling.
+          </p>
+          <p>
+            In this example, automatic focus is disabled. When the{' '}
+            <code>Modal</code> is opened, a contained <code>TextInput</code>{' '}
+            component is manually set to focused.
+          </p>
+
+          <Library.Demo>
+            <div>
+              <div id="modalFocus" />
+              <LabeledButton variant="primary" onClick={openFocusModal}>
                 Open modal
               </LabeledButton>
             </div>

--- a/src/pattern-library/components/patterns/DialogComponents.js
+++ b/src/pattern-library/components/patterns/DialogComponents.js
@@ -2,11 +2,11 @@ import { createRef, render } from 'preact';
 import { useState } from 'preact/hooks';
 import { ConfirmModal, Dialog, LabeledButton, Modal } from '../../../';
 
-import { PatternPage, Pattern } from '../PatternPage';
+import Library from '../Library';
 
 /**
  * Render a Dialog or Modal within the `container`, and invoke
- * `setDialogIsOpen` as needed to alert caller to state changes. Provides the
+ * `setOpen` as needed to alert caller to state changes. Provides the
  * ability to open and close a Dialog demo. We don't want to render a Dialog
  * until it's opened because it will grab focus when it first mounts.
  *
@@ -38,7 +38,7 @@ const showDialog = ({ DialogComponent, container, setOpen, props }) => {
 
   if (!props.children) {
     props.children = (
-      <div>
+      <>
         <p>This is an example of a dialog.</p>
         <p>
           This dialog contains an <code>input</code> which is focused when the
@@ -49,7 +49,7 @@ const showDialog = ({ DialogComponent, container, setOpen, props }) => {
           ref={initialFocusRef}
           type="text"
         />
-      </div>
+      </>
     );
   }
 
@@ -66,6 +66,17 @@ const showDialog = ({ DialogComponent, container, setOpen, props }) => {
 };
 
 export default function DialogComponents() {
+  // Dialog/Modal state for each of the examples
+
+  // Basic Dialog example
+  const [dialogIsOpen, setDialogIsOpen] = useState(false);
+  // Basic Modal example
+  const [, setModalIsOpen] = useState(false);
+  // Modal with overflowing content example
+  const [, setLongModalIsOpen] = useState(false);
+  // ConfirmModal example
+  const [, setConfirmModalIsOpen] = useState(false);
+
   // Extra buttons to use in Dialog, Modal examples
   const buttons = [
     <LabeledButton key="maybe" onClick={() => alert('You chose maybe')}>
@@ -79,12 +90,6 @@ export default function DialogComponents() {
       Do it!
     </LabeledButton>,
   ];
-
-  // Dialog/Modal state for each of the examples
-  const [dialogIsOpen, setDialogIsOpen] = useState(false);
-  const [, setModalIsOpen] = useState(false);
-  const [, setLongModalIsOpen] = useState(false);
-  const [, setConfirmModalIsOpen] = useState(false);
 
   const openDialog = () => {
     setDialogIsOpen(true);
@@ -224,130 +229,112 @@ export default function DialogComponents() {
     });
   };
   return (
-    <PatternPage title="Dialogs">
-      <Pattern title="Dialog">
-        <div className="Example">
+    <Library.Page title="Dialogs">
+      <Library.Pattern title="Dialog">
+        <p>
+          A <code>Dialog</code> prompts for user interaction and will take focus
+          when opened.
+        </p>
+        <p>
+          Use a <code>Dialog</code> when you want to route focus. Consider using
+          a <code>Panel</code> for presenting panel-styled content that does not
+          require grabbing focus.
+        </p>
+        <Library.Example title="Setting initial focus">
           <p>
-            A <code>Dialog</code> prompts for user interaction and will take
-            focus when opened.
+            This example shows a dismiss-able <code>Dialog</code> with an
+            explicitly-provided element (<code>ref</code>) that should take
+            initial focus: a text <code>input</code>. The highlighted outline is
+            added here by using <code>.hyp-u-focus-outline</code> on the{' '}
+            <code>input</code> element.
           </p>
           <p>
-            Use a <code>Dialog</code> when you want to route focus. Consider
-            using a <code>Panel</code> for presenting panel-styled content that
-            does not require grabbing focus.
+            <code>Dialogs</code> are styled using the <code>panel</code>{' '}
+            pattern.
           </p>
-          <div className="Example__content">
-            <div className="Example__usage">
-              <p>
-                This example shows a dismiss-able <code>Dialog</code> with an
-                explicitly-provided element (<code>ref</code>) that should take
-                initial focus: a text <code>input</code>. The highlighted
-                outline is added here by using <code>.hyp-u-focus-outline</code>{' '}
-                on the <code>input</code> element.
-              </p>
-              <p>
-                <code>Dialogs</code> are styled using the <code>panel</code>{' '}
-                pattern.
-              </p>
-            </div>
-            <div className="Example__demo hyp-frame">
-              <div>
-                <div id="dialog1" />
-                {!dialogIsOpen && (
-                  <LabeledButton variant="primary" onClick={openDialog}>
-                    Open dialog
-                  </LabeledButton>
-                )}
-              </div>
-            </div>
-          </div>
-        </div>
-      </Pattern>
-
-      <Pattern title="Modal">
-        <div className="Example">
-          <p>
-            A <code>Modal</code> is a type of <code>Dialog</code> that centers
-            on the screen and obscures the background with an overlay.
-          </p>
-          <div className="Example__content">
-            <div className="Example__usage">
-              <p>
-                Close the modal by clicking the close (X) button, the cancel
-                button or clicking anywhere outside of it.
-              </p>
-            </div>
-            <div className="Example__demo hyp-frame">
-              <div>
-                <div id="modal1" />
-                <LabeledButton variant="primary" onClick={openModal}>
-                  Open modal
+          <Library.Demo>
+            <div>
+              <div id="dialog1" />
+              {!dialogIsOpen && (
+                <LabeledButton variant="primary" onClick={openDialog}>
+                  Open dialog
                 </LabeledButton>
-              </div>
+              )}
             </div>
-          </div>
-        </div>
-      </Pattern>
+          </Library.Demo>
+        </Library.Example>
+      </Library.Pattern>
 
-      <Pattern title="Modal with long content">
-        <div className="Example">
+      <Library.Pattern title="Modal">
+        <p>
+          A <code>Modal</code> is a type of <code>Dialog</code> that centers on
+          the screen and obscures the background with an overlay.
+        </p>
+        <Library.Example title="Basic usage">
+          <p>
+            Close the modal by clicking the close (X) button, the cancel button
+            or clicking anywhere outside of it.
+          </p>
+          <Library.Demo>
+            <div>
+              <div id="modal1" />
+              <LabeledButton variant="primary" onClick={openModal}>
+                Open modal
+              </LabeledButton>
+            </div>
+          </Library.Demo>
+        </Library.Example>
+
+        <Library.Example title="Handling content overflow">
           <p>
             Modals that may contain a lot of content may need to handle overflow
             (i.e. make their content scrollable) so that the modal height
             doesn&apos;t exceed available viewport space.
           </p>
-          <div className="Example__content">
-            <div className="Example__usage">
-              <p>
-                To make something in a modal scroll-able, apply{' '}
-                <code>overflow: auto</code> to the element you wish to contain.
-                This element needs to be an immediate-child element of the{' '}
-                <code>Modal</code>.
-              </p>
-            </div>
-            <div className="Example__demo hyp-frame">
-              <div>
-                <div id="modal2" />
-                <LabeledButton variant="primary" onClick={openLongModal}>
-                  Open long modal
-                </LabeledButton>
-              </div>
-            </div>
-          </div>
-        </div>
-      </Pattern>
-
-      <Pattern title="Confirm Modal">
-        <div className="Example">
           <p>
-            <code>ConfirmModal</code> is intended to mirror the functionality of{' '}
-            <code>window.confirm</code>.
+            To make something in a modal scroll-able, apply{' '}
+            <code>overflow: auto</code> to the element you wish to contain. This
+            element needs to be an immediate-child element of the{' '}
+            <code>Modal</code>.
           </p>
-          <div className="Example__content">
-            <div className="Example__usage">
-              <p>
-                <code>ConfirmModal</code> prompts the user for a boolean yes/no
-                input. Close and cancel are considered no.
-              </p>
-              <p>
-                Handlers need to be provided for what to do on yes (
-                <code>onConfirm</code>) and no/cancel (<code>onCancel</code>).
-                Typically, both would (also) close the modal, though in this
-                example, the <code>onConfirm</code> handler does not close the
-                modal.
-              </p>
+          <Library.Demo>
+            <div>
+              <div id="modal2" />
+              <LabeledButton variant="primary" onClick={openLongModal}>
+                Open long modal
+              </LabeledButton>
             </div>
-            <div className="Example__demo hyp-frame">
-              <div>
-                <div id="confirm-modal1" />
-                <LabeledButton variant="primary" onClick={openConfirmModal}>
-                  Open confirm modal
-                </LabeledButton>
-              </div>
+          </Library.Demo>
+        </Library.Example>
+      </Library.Pattern>
+
+      <Library.Pattern title="ConfirmModal">
+        <p>
+          <code>ConfirmModal</code> is intended to mirror the functionality of{' '}
+          <code>window.confirm</code>.
+        </p>
+        <Library.Example>
+          <p>
+            <code>ConfirmModal</code> prompts the user for a boolean yes/no
+            input. Close and cancel are considered no.
+          </p>
+          <p>
+            Handlers need to be provided for what to do on yes (
+            <code>onConfirm</code>) and no/cancel (<code>onCancel</code>).
+            Typically, both would (also) close the modal, though in this
+            example, the <code>onConfirm</code> handler does not close the
+            modal.
+          </p>
+          <Library.Demo>
+            <div>
+              <div id="confirm-modal1" />
+              <LabeledButton variant="primary" onClick={openConfirmModal}>
+                Open confirm modal
+              </LabeledButton>
             </div>
-          </div>
-        </div>
-      </Pattern>
-    </PatternPage>
+          </Library.Demo>
+        </Library.Example>
+      </Library.Pattern>
+    </Library.Page>
   );
 }


### PR DESCRIPTION
In some cases, it's useful to be able to opt out of the automatic focus handling of `Dialog` and `Modal` components. From https://github.com/hypothesis/frontend-shared/issues/143 :

> There are some cases in which neither of these quite fit the bill, as in a case I've run into in which a given Modal's contents themselves are built via several sub-components, making passing a ref to Modal cumbersome and fractious. In my case, I want to manage focus on a text input that is a couple of levels nested, and only focus it in some cases.

> To provide for use cases like this, it would be nice to have a way to "opt out" of any focus handling at the Modal/Dialog level and allow manual control.

This PR introduces the ability to set the `initialFocus` ref to `null` to opt out of automatic focus control, and allow for manual focus control.

There are three commits on this branch:

1. Convert the dialog-components pattern-library page to use the new Library components — "boilerplate" conversion
2. Update `Dialog` to handle `null` for `initialFocus`
3. Add example of manual focus control to the dialog-components pattern-library page

Fixes https://github.com/hypothesis/frontend-shared/issues/143

Screenshot of [updated Dialogs component page](http://localhost:4001/ui-playground/components-dialogs) after these changes:

![image](https://user-images.githubusercontent.com/439947/125824967-fb5b6e6e-e21b-4008-a286-c91e60059361.png)
