### PR TITLE
Bump package to v3.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,33 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v3.6.0] - 2021-07-19
+
+Adds ability to opt out of `Dialog`, `Modal` focus handling and fixes focus
+mixins to work without the https://github.com/WICG/focus-visible polyfill.
+
+### Changed
+
+- Add ability to opt out of focus control for `Dialog`, `Modal` [#146](https://github.com/hypothesis/frontend-shared/pull/146)
+- Library layout components, simplified [#144](https://github.com/hypothesis/frontend-shared/pull/144)
+
+### Fixed
+
+- Make `:focus-visible` rules work when polyfill not present [#145](https://github.com/hypothesis/frontend-shared/pull/145)
+
+## [v3.5.0] - 2021-07-14
+
+Renames a prop and adjusts error state for `TextInput`.
+
+### Breaking Changes
+
+- Change `error` prop to `hasError` on `TextInput` [#140](https://github.com/hypothesis/frontend-shared/pull/140)
+
+### Changed
+
+- Update structure of checkbox styling to match other patterns [#142](https://github.com/hypothesis/frontend-shared/pull/142)
+- Remediate broken tests using `assert.exists` [#141](https://github.com/hypothesis/frontend-shared/pull/141)
+
 ## [v3.4.0] - 2021-07-01
 
 Provides `Spinner` and `Thumbnail` components.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hypothesis/frontend-shared",
-  "version": "3.4.0",
+  "version": "3.6.0",
   "description": "Shared components, styles and utilities for Hypothesis projects",
   "license": "BSD-2-Clause",
   "repository": "hypothesis/frontend-shared",


### PR DESCRIPTION
Note that there was a fumble in the `3.5.0` release, which was correctly tagged, but the `CHANGELOG` and `package.json` were not correctly updated. Currently trying to debug how that happened, and what I can put in place to avoid it happening again. I try to be careful when juggling version tags and commit hashes and whatnot.