### PR TITLE
Fix icon naming for Spinner component

### DIFF
--- a/src/components/Spinner.js
+++ b/src/components/Spinner.js
@@ -22,5 +22,7 @@ registerIcons({
  */
 export function Spinner({ classes = '', size = 'medium' }) {
   const baseClass = `Hyp-Spinner--${size}`;
-  return <SvgIcon name="spinner" className={classnames(baseClass, classes)} />;
+  return (
+    <SvgIcon name="hyp-spinner" className={classnames(baseClass, classes)} />
+  );
 }

--- a/src/components/test/Spinner-test.js
+++ b/src/components/test/Spinner-test.js
@@ -12,6 +12,11 @@ describe('Spinner', () => {
     assert.isTrue(wrapper.find('SvgIcon.Hyp-Spinner--medium').exists());
   });
 
+  it('uses the registered `hyp-spinner` icon', () => {
+    const wrapper = createSpinner();
+    assert.equal(wrapper.find('SvgIcon').props().name, 'hyp-spinner');
+  });
+
   it('applies additional classes', () => {
     const wrapper = createSpinner({ classes: 'foo bar' });
     assert.isTrue(wrapper.find('SvgIcon.Hyp-Spinner--medium.foo.bar').exists());

--- a/src/components/test/Thumbnail-test.js
+++ b/src/components/test/Thumbnail-test.js
@@ -28,7 +28,7 @@ describe('Thumbnail', () => {
   context('when in loading state', () => {
     it('renders a loading spinner', () => {
       const wrapper = createComponent({ isLoading: true });
-      assert.isTrue(wrapper.find('SvgIcon[name="spinner"]').exists());
+      assert.isTrue(wrapper.find('Spinner').exists());
     });
 
     it('does not render content', () => {


### PR DESCRIPTION
Derp/facepalm territory. The `Spinner` component indeed registered its needed icon but then used `spinner` in its rendered output. This was a bit of a trainwreck; what happened was:

* This project already had a registered `spinner` icon pre-existing the addition of the `spinner` pattern and `Spinner` component, so `spinner` was present/registered in this project, quietly lurking
* There was a faulty test here on `Spinner` that checked for `spinner` instead of `hyp-spinner`
* LMS—the first project this component was intended for—also registers a `spinner` icon, so this wasn't caught
* Today I tried starting to replace `Spinner` components in the client, and whammo. No `spinner` icon in that project.

Also discovered a silly test in the `Thumbnail` component which broke when I changed the icon naming.

Follow-up issue forthcoming to not register or use any non-prefixed (`hyp-`) icons in the pattern library to avoid this conflict in the future.