### PR TITLE
Prefix all project icon names with `hyp-`

### DIFF
--- a/src/components/test/Dialog-test.js
+++ b/src/components/test/Dialog-test.js
@@ -44,7 +44,7 @@ describe('Dialog', () => {
   });
 
   it('renders an icon', () => {
-    const wrapper = mount(<Dialog title="Test dialog" icon="edit" />);
+    const wrapper = mount(<Dialog title="Test dialog" icon="hyp-edit" />);
     const icon = wrapper.find('SvgIcon[data-testid="header-icon"]');
     assert.isTrue(icon.exists());
   });

--- a/src/components/test/Dialog-test.js
+++ b/src/components/test/Dialog-test.js
@@ -44,7 +44,7 @@ describe('Dialog', () => {
   });
 
   it('renders an icon', () => {
-    const wrapper = mount(<Dialog title="Test dialog" icon="hyp-edit" />);
+    const wrapper = mount(<Dialog title="Test dialog" icon="hyp-test" />);
     const icon = wrapper.find('SvgIcon[data-testid="header-icon"]');
     assert.isTrue(icon.exists());
   });

--- a/src/components/test/SvgIcon-test.js
+++ b/src/components/test/SvgIcon-test.js
@@ -15,8 +15,8 @@ describe('SvgIcon', () => {
 
     registerIcons(
       {
-        'arrow-left': require('../../../images/icons/arrow-left.svg'),
-        'arrow-right': require('../../../images/icons/arrow-right.svg'),
+        'hyp-arrow-left': require('../../../images/icons/arrow-left.svg'),
+        'hyp-arrow-right': require('../../../images/icons/arrow-right.svg'),
       },
       { reset: true }
     );
@@ -28,7 +28,7 @@ describe('SvgIcon', () => {
 
   it("sets the element's content to the content of the SVG", () => {
     const container = document.createElement('div');
-    render(<SvgIcon name="arrow-left" />, container);
+    render(<SvgIcon name="hyp-arrow-left" />, container);
     assert.ok(container.querySelector('svg'));
   });
 
@@ -41,29 +41,38 @@ describe('SvgIcon', () => {
 
   it('does not set the class of the SVG by default', () => {
     const container = document.createElement('div');
-    render(<SvgIcon name="arrow-left" />, container);
+    render(<SvgIcon name="hyp-arrow-left" />, container);
     const svg = container.querySelector('svg');
     assert.equal(svg.getAttribute('class'), '');
   });
 
   it('sets the class of the SVG if provided', () => {
     const container = document.createElement('div');
-    render(<SvgIcon name="arrow-left" className="thing__icon" />, container);
+    render(
+      <SvgIcon name="hyp-arrow-left" className="thing__icon" />,
+      container
+    );
     const svg = container.querySelector('svg');
     assert.equal(svg.getAttribute('class'), 'thing__icon');
   });
 
   it('retains the CSS class if the icon changes', () => {
     const container = document.createElement('div');
-    render(<SvgIcon name="arrow-left" className="thing__icon" />, container);
-    render(<SvgIcon name="arrow-right" className="thing__icon" />, container);
+    render(
+      <SvgIcon name="hyp-arrow-left" className="thing__icon" />,
+      container
+    );
+    render(
+      <SvgIcon name="hyp-arrow-right" className="thing__icon" />,
+      container
+    );
     const svg = container.querySelector('svg');
     assert.equal(svg.getAttribute('class'), 'thing__icon');
   });
 
   it('sets a default class on the wrapper element', () => {
     const container = document.createElement('div');
-    render(<SvgIcon name="arrow-left" />, container);
+    render(<SvgIcon name="hyp-arrow-left" />, container);
     const wrapper = container.querySelector('span');
     assert.isTrue(wrapper.classList.contains('Hyp-SvgIcon'));
     assert.isFalse(wrapper.classList.contains('Hyp-SvgIcon--inline'));
@@ -71,7 +80,7 @@ describe('SvgIcon', () => {
 
   it('appends an inline class to wrapper if `inline` prop is `true`', () => {
     const container = document.createElement('div');
-    render(<SvgIcon name="arrow-left" inline={true} />, container);
+    render(<SvgIcon name="hyp-arrow-left" inline={true} />, container);
     const wrapper = container.querySelector('span');
     assert.isTrue(wrapper.classList.contains('Hyp-SvgIcon'));
     assert.isTrue(wrapper.classList.contains('Hyp-SvgIcon--inline'));
@@ -79,14 +88,14 @@ describe('SvgIcon', () => {
 
   it('sets a title to the containing `span` element if `title` is present', () => {
     const container = document.createElement('div');
-    render(<SvgIcon name="arrow-left" title="Open menu" />, container);
+    render(<SvgIcon name="hyp-arrow-left" title="Open menu" />, container);
     const wrapper = container.querySelector('span');
     assert.equal(wrapper.getAttribute('title'), 'Open menu');
   });
 
   it('sets does not set a title on the containing `span` element if `title` not present', () => {
     const container = document.createElement('div');
-    render(<SvgIcon name="arrow-left" />, container);
+    render(<SvgIcon name="hyp-arrow-left" />, container);
     const wrapper = container.querySelector('span');
     assert.notOk(wrapper.getAttribute('title'));
   });

--- a/src/icons.js
+++ b/src/icons.js
@@ -1,15 +1,16 @@
 // @ts-nocheck
 
+// These icons are for use in pattern-library components and examples
 export default {
-  'arrow-left': require('../images/icons/arrow-left.svg'),
-  'arrow-right': require('../images/icons/arrow-right.svg'),
-  cancel: require('../images/icons/cancel.svg'),
-  check: require('../images/icons/check.svg'),
-  checkbox: require('../images/icons/checkbox.svg'),
-  collapsed: require('../images/icons/collapsed.svg'),
-  edit: require('../images/icons/edit.svg'),
-  logo: require('../images/icons/logo.svg'),
-  profile: require('../images/icons/profile.svg'),
-  spinner: require('../images/icons/spinner.svg'),
-  trash: require('../images/icons/trash.svg'),
+  'hyp-arrow-left': require('../images/icons/arrow-left.svg'),
+  'hyp-arrow-right': require('../images/icons/arrow-right.svg'),
+  'hyp-cancel': require('../images/icons/cancel.svg'),
+  'hyp-check': require('../images/icons/check.svg'),
+  'hyp-checkbox': require('../images/icons/checkbox.svg'),
+  'hyp-collapsed': require('../images/icons/collapsed.svg'),
+  'hyp-edit': require('../images/icons/edit.svg'),
+  'hyp-logo': require('../images/icons/logo.svg'),
+  'hyp-profile': require('../images/icons/profile.svg'),
+  'hyp-spinner': require('../images/icons/spinner.svg'),
+  'hyp-trash': require('../images/icons/trash.svg'),
 };

--- a/src/pattern-library/components/PlaygroundApp.js
+++ b/src/pattern-library/components/PlaygroundApp.js
@@ -54,7 +54,7 @@ export default function PlaygroundApp({
       <div className="PlaygroundApp__sidebar">
         <div className="PlaygroundApp__sidebar-home">
           <a href={baseURL} onClick={e => navigate(e, '/')}>
-            <SvgIcon name="logo" />
+            <SvgIcon name="hyp-logo" />
           </a>
         </div>
         {routeGroups.map(rGroup => (

--- a/src/pattern-library/components/patterns/ButtonComponents.js
+++ b/src/pattern-library/components/patterns/ButtonComponents.js
@@ -22,40 +22,40 @@ export default function ButtonComponents() {
         </p>
         <PatternExamples>
           <PatternExample details="Sizes: medium is default">
-            <IconButton icon="edit" title="Edit" size="small" />
-            <IconButton icon="edit" title="Edit" size="medium" />
-            <IconButton icon="edit" title="Edit" size="large" />
+            <IconButton icon="hyp-edit" title="Edit" size="small" />
+            <IconButton icon="hyp-edit" title="Edit" size="medium" />
+            <IconButton icon="hyp-edit" title="Edit" size="large" />
           </PatternExample>
         </PatternExamples>
 
         <h3>Default variant</h3>
         <PatternExamples>
           <PatternExample details="Default state">
-            <IconButton icon="trash" title="Delete annotation" />
+            <IconButton icon="hyp-trash" title="Delete annotation" />
           </PatternExample>
 
           <PatternExample details="Pressed">
-            <IconButton icon="trash" title="Delete annotation" pressed />
+            <IconButton icon="hyp-trash" title="Delete annotation" pressed />
           </PatternExample>
 
           <PatternExample details="Expanded">
-            <IconButton icon="trash" title="Delete annotation" expanded />
+            <IconButton icon="hyp-trash" title="Delete annotation" expanded />
           </PatternExample>
 
           <PatternExample details="Disabled">
-            <IconButton icon="trash" title="Delete annotation" disabled />
+            <IconButton icon="hyp-trash" title="Delete annotation" disabled />
           </PatternExample>
         </PatternExamples>
 
         <h3>Primary variant</h3>
         <PatternExamples>
           <PatternExample details="Basic usage">
-            <IconButton icon="edit" title="Edit" variant="primary" />
+            <IconButton icon="hyp-edit" title="Edit" variant="primary" />
           </PatternExample>
 
           <PatternExample details="Pressed">
             <IconButton
-              icon="trash"
+              icon="hyp-trash"
               title="Delete annotation"
               pressed
               variant="primary"
@@ -64,7 +64,7 @@ export default function ButtonComponents() {
 
           <PatternExample details="Expanded">
             <IconButton
-              icon="trash"
+              icon="hyp-trash"
               title="Delete annotation"
               expanded
               variant="primary"
@@ -73,7 +73,7 @@ export default function ButtonComponents() {
 
           <PatternExample details="Disabled">
             <IconButton
-              icon="trash"
+              icon="hyp-trash"
               title="Delete annotation"
               disabled
               variant="primary"
@@ -95,31 +95,46 @@ export default function ButtonComponents() {
             details="Basic usage"
             style={{ backgroundColor: '#ececec' }}
           >
-            <IconButton icon="cancel" title="Close" variant="dark" />
+            <IconButton icon="hyp-cancel" title="Close" variant="dark" />
           </PatternExample>
           <PatternExample
             details="Note that the button has a background color"
             style={{ backgroundColor: '#ffffff' }}
           >
-            <IconButton icon="cancel" title="Close" variant="dark" />
+            <IconButton icon="hyp-cancel" title="Close" variant="dark" />
           </PatternExample>
           <PatternExample
             details="Pressed"
             style={{ backgroundColor: '#ececec' }}
           >
-            <IconButton icon="cancel" title="Close" variant="dark" pressed />
+            <IconButton
+              icon="hyp-cancel"
+              title="Close"
+              variant="dark"
+              pressed
+            />
           </PatternExample>
           <PatternExample
             details="Expanded"
             style={{ backgroundColor: '#ececec' }}
           >
-            <IconButton icon="cancel" title="Close" variant="dark" expanded />
+            <IconButton
+              icon="hyp-cancel"
+              title="Close"
+              variant="dark"
+              expanded
+            />
           </PatternExample>
           <PatternExample
             details="Disabled"
             style={{ backgroundColor: '#ececec' }}
           >
-            <IconButton icon="cancel" title="Close" variant="dark" disabled />
+            <IconButton
+              icon="hyp-cancel"
+              title="Close"
+              variant="dark"
+              disabled
+            />
           </PatternExample>
         </PatternExamples>
 
@@ -133,7 +148,7 @@ export default function ButtonComponents() {
             details="Basic usage"
             style={{ backgroundColor: 'white' }}
           >
-            <IconButton icon="collapsed" title="Edit" variant="light" />
+            <IconButton icon="hyp-collapsed" title="Edit" variant="light" />
           </PatternExample>
 
           <PatternExample
@@ -141,7 +156,7 @@ export default function ButtonComponents() {
             style={{ backgroundColor: 'white' }}
           >
             <IconButton
-              icon="collapsed"
+              icon="hyp-collapsed"
               title="Delete annotation"
               pressed
               variant="light"
@@ -153,7 +168,7 @@ export default function ButtonComponents() {
             style={{ backgroundColor: 'white' }}
           >
             <IconButton
-              icon="collapsed"
+              icon="hyp-collapsed"
               title="Delete annotation"
               expanded
               variant="light"
@@ -165,7 +180,7 @@ export default function ButtonComponents() {
             style={{ backgroundColor: 'white' }}
           >
             <IconButton
-              icon="collapsed"
+              icon="hyp-collapsed"
               title="Delete annotation"
               disabled
               variant="light"
@@ -191,23 +206,23 @@ export default function ButtonComponents() {
           </PatternExample>
 
           <PatternExample details="Label and icon">
-            <LabeledButton icon="profile" size="small">
+            <LabeledButton icon="hyp-profile" size="small">
               Edit User
             </LabeledButton>
-            <LabeledButton icon="profile">Edit User</LabeledButton>
-            <LabeledButton icon="profile" size="large">
+            <LabeledButton icon="hyp-profile">Edit User</LabeledButton>
+            <LabeledButton icon="hyp-profile" size="large">
               Edit User
             </LabeledButton>
           </PatternExample>
 
           <PatternExample details="Label and icon: icon on right">
-            <LabeledButton icon="profile" size="small" iconPosition="right">
+            <LabeledButton icon="hyp-profile" size="small" iconPosition="right">
               Edit User
             </LabeledButton>
-            <LabeledButton icon="profile" iconPosition="right">
+            <LabeledButton icon="hyp-profile" iconPosition="right">
               Edit User
             </LabeledButton>
-            <LabeledButton icon="profile" size="large" iconPosition="right">
+            <LabeledButton icon="hyp-profile" size="large" iconPosition="right">
               Edit User
             </LabeledButton>
           </PatternExample>
@@ -218,26 +233,26 @@ export default function ButtonComponents() {
         <PatternExamples>
           <PatternExample details="Default state">
             <LabeledButton>Edit</LabeledButton>
-            <LabeledButton icon="edit">Edit</LabeledButton>
+            <LabeledButton icon="hyp-edit">Edit</LabeledButton>
           </PatternExample>
 
           <PatternExample details="Pressed">
             <LabeledButton pressed>Edit</LabeledButton>
-            <LabeledButton icon="edit" pressed>
+            <LabeledButton icon="hyp-edit" pressed>
               Edit
             </LabeledButton>
           </PatternExample>
 
           <PatternExample details="Expanded">
             <LabeledButton expanded>Edit</LabeledButton>
-            <LabeledButton icon="edit" expanded>
+            <LabeledButton icon="hyp-edit" expanded>
               Edit
             </LabeledButton>
           </PatternExample>
 
           <PatternExample details="Disabled">
             <LabeledButton disabled>Edit</LabeledButton>
-            <LabeledButton icon="edit" disabled>
+            <LabeledButton icon="hyp-edit" disabled>
               Edit
             </LabeledButton>
           </PatternExample>
@@ -248,7 +263,7 @@ export default function ButtonComponents() {
         <PatternExamples>
           <PatternExample details="Default state">
             <LabeledButton variant="primary">Edit user</LabeledButton>
-            <LabeledButton icon="profile" variant="primary">
+            <LabeledButton icon="hyp-profile" variant="primary">
               Edit user
             </LabeledButton>
           </PatternExample>
@@ -257,7 +272,7 @@ export default function ButtonComponents() {
             <LabeledButton pressed variant="primary">
               Edit user
             </LabeledButton>
-            <LabeledButton icon="profile" pressed variant="primary">
+            <LabeledButton icon="hyp-profile" pressed variant="primary">
               Edit user
             </LabeledButton>
           </PatternExample>
@@ -266,7 +281,7 @@ export default function ButtonComponents() {
             <LabeledButton expanded variant="primary">
               Edit user
             </LabeledButton>
-            <LabeledButton icon="profile" expanded variant="primary">
+            <LabeledButton icon="hyp-profile" expanded variant="primary">
               Edit user
             </LabeledButton>
           </PatternExample>
@@ -275,7 +290,7 @@ export default function ButtonComponents() {
             <LabeledButton disabled variant="primary">
               Edit user
             </LabeledButton>
-            <LabeledButton icon="profile" disabled variant="primary">
+            <LabeledButton icon="hyp-profile" disabled variant="primary">
               Edit user
             </LabeledButton>
           </PatternExample>
@@ -290,7 +305,7 @@ export default function ButtonComponents() {
             style={{ backgroundColor: '#ececec' }}
           >
             <LabeledButton variant="dark">Buy ice cream</LabeledButton>
-            <LabeledButton icon="trash" variant="dark">
+            <LabeledButton icon="hyp-trash" variant="dark">
               Buy ice cream
             </LabeledButton>
           </PatternExample>
@@ -302,7 +317,7 @@ export default function ButtonComponents() {
             <LabeledButton pressed variant="dark">
               Buy ice cream
             </LabeledButton>
-            <LabeledButton icon="trash" pressed variant="dark">
+            <LabeledButton icon="hyp-trash" pressed variant="dark">
               Buy ice cream
             </LabeledButton>
           </PatternExample>
@@ -314,7 +329,7 @@ export default function ButtonComponents() {
             <LabeledButton expanded variant="dark">
               Buy ice cream
             </LabeledButton>
-            <LabeledButton expanded icon="edit" variant="dark">
+            <LabeledButton expanded icon="hyp-edit" variant="dark">
               Buy ice cream
             </LabeledButton>
           </PatternExample>
@@ -326,7 +341,7 @@ export default function ButtonComponents() {
             <LabeledButton disabled variant="dark">
               Buy ice cream
             </LabeledButton>
-            <LabeledButton disabled icon="edit" variant="dark">
+            <LabeledButton disabled icon="hyp-edit" variant="dark">
               Buy ice cream
             </LabeledButton>
           </PatternExample>

--- a/src/pattern-library/components/patterns/ContainerPatterns.js
+++ b/src/pattern-library/components/patterns/ContainerPatterns.js
@@ -61,9 +61,9 @@ export default function ContainerPatterns() {
                 actions.
               </div>
               <div className="hyp-actions">
-                <IconButton title="User" icon="profile" />
-                <IconButton title="Edit" icon="edit" />
-                <IconButton title="Delete" icon="trash" />
+                <IconButton title="User" icon="hyp-profile" />
+                <IconButton title="Edit" icon="hyp-edit" />
+                <IconButton title="Delete" icon="hyp-trash" />
               </div>
             </div>
           </PatternExample>
@@ -75,9 +75,9 @@ export default function ContainerPatterns() {
                   borders or box-shadows.
                 </div>
                 <div className="hyp-actions">
-                  <IconButton title="User" icon="profile" />
-                  <IconButton title="Edit" icon="edit" />
-                  <IconButton title="Delete" icon="trash" />
+                  <IconButton title="User" icon="hyp-profile" />
+                  <IconButton title="Edit" icon="hyp-edit" />
+                  <IconButton title="Delete" icon="hyp-trash" />
                 </div>
               </div>
             </div>
@@ -94,16 +94,16 @@ export default function ContainerPatterns() {
         <PatternExamples>
           <PatternExample details="A set of LabeledButtons">
             <div className="hyp-actions">
-              <LabeledButton icon="profile">User</LabeledButton>
-              <LabeledButton icon="edit">Edit</LabeledButton>
-              <LabeledButton icon="trash">Delete</LabeledButton>
+              <LabeledButton icon="hyp-profile">User</LabeledButton>
+              <LabeledButton icon="hyp-edit">Edit</LabeledButton>
+              <LabeledButton icon="hyp-trash">Delete</LabeledButton>
             </div>
           </PatternExample>
           <PatternExample details="A set of IconButtons">
             <div className="hyp-actions">
-              <IconButton title="User" icon="profile" />
-              <IconButton title="Edit" icon="edit" />
-              <IconButton title="Delete" icon="trash" />
+              <IconButton title="User" icon="hyp-profile" />
+              <IconButton title="Edit" icon="hyp-edit" />
+              <IconButton title="Delete" icon="hyp-trash" />
             </div>
           </PatternExample>
           <PatternExample details="Columnar layout">

--- a/src/pattern-library/components/patterns/DialogComponents.js
+++ b/src/pattern-library/components/patterns/DialogComponents.js
@@ -63,7 +63,7 @@ const showDialog = ({ DialogComponent, container, setOpen, props }) => {
 
   return render(
     <DialogComponent
-      icon="edit"
+      icon="hyp-edit"
       initialFocus={initialFocusRef}
       title="Basic dialog with icon"
       onCancel={() => close()}
@@ -137,7 +137,7 @@ export default function DialogComponents() {
         </div>
         <TextInputWithButton>
           <TextInput inputRef={inputRef} />
-          <IconButton icon="edit" title="go" variant="dark" />
+          <IconButton icon="hyp-edit" title="go" variant="dark" />
         </TextInputWithButton>
       </>
     );

--- a/src/pattern-library/components/patterns/FormComponents.js
+++ b/src/pattern-library/components/patterns/FormComponents.js
@@ -78,7 +78,7 @@ export default function FormComponents() {
           <PatternExample details="basic text input field">
             <TextInputWithButton>
               <TextInput name="my-input" />
-              <IconButton icon="arrow-right" variant="dark" title="go" />
+              <IconButton icon="hyp-arrow-right" variant="dark" title="go" />
             </TextInputWithButton>
           </PatternExample>
 
@@ -86,7 +86,7 @@ export default function FormComponents() {
             <TextInputWithButton>
               <TextInput name="my-input" hasError={textInputHasError} />
               <IconButton
-                icon="arrow-right"
+                icon="hyp-arrow-right"
                 variant="dark"
                 title="go"
                 onClick={() => setTextInputHasError(!textInputHasError)}

--- a/src/pattern-library/components/patterns/FormPatterns.js
+++ b/src/pattern-library/components/patterns/FormPatterns.js
@@ -18,18 +18,18 @@ export default function FormPatterns() {
         <PatternExamples>
           <PatternExample details="checkbox">
             <input className="hyp-checkbox" type="checkbox" />
-            <SvgIcon name="checkbox" />
+            <SvgIcon name="hyp-checkbox" />
           </PatternExample>
 
           <PatternExample details="checkbox, checked">
             <input className="hyp-checkbox" type="checkbox" checked />
-            <SvgIcon name="checkbox" />
+            <SvgIcon name="hyp-checkbox" />
           </PatternExample>
 
           <PatternExample details="checkbox with label">
             <label className="hyp-label">
               <input className="hyp-checkbox" type="checkbox" />
-              <SvgIcon name="checkbox" />
+              <SvgIcon name="hyp-checkbox" />
               <span>Click me, please</span>
             </label>
           </PatternExample>
@@ -69,7 +69,7 @@ export default function FormPatterns() {
           >
             <div className="hyp-text-input-with-button">
               <input type="text" placeholder="http://www.example.com" />
-              <IconButton icon="arrow-right" title="go" variant="dark" />
+              <IconButton icon="hyp-arrow-right" title="go" variant="dark" />
             </div>
           </PatternExample>
 
@@ -83,7 +83,7 @@ export default function FormPatterns() {
                 placeholder="http://www.example.com"
                 className="has-error"
               />
-              <IconButton icon="arrow-right" title="go" variant="dark" />
+              <IconButton icon="hyp-arrow-right" title="go" variant="dark" />
             </div>
           </PatternExample>
         </PatternExamples>

--- a/src/pattern-library/components/patterns/PanelComponents.js
+++ b/src/pattern-library/components/patterns/PanelComponents.js
@@ -29,7 +29,7 @@ export default function PanelComponents() {
           </PatternExample>
           <PatternExample details="A panel can also have an icon in the header">
             <Panel
-              icon="edit"
+              icon="hyp-edit"
               title="Panel with optional heading icon"
               onClose={() => alert('close clicked')}
             >
@@ -39,7 +39,7 @@ export default function PanelComponents() {
           <PatternExample details="A panel in the clean theme">
             <div className="theme-clean" style="width:100%">
               <Panel
-                icon="edit"
+                icon="hyp-edit"
                 title="Panel with clean-theme styling"
                 onClose={() => alert('close clicked')}
               >

--- a/src/pattern-library/components/patterns/PanelPatterns.js
+++ b/src/pattern-library/components/patterns/PanelPatterns.js
@@ -54,7 +54,7 @@ export default function OrganismPatterns() {
                   Panel title on a closeable panel
                 </h2>
                 <div className="hyp-panel__close">
-                  <IconButton icon="cancel" title="Close" />
+                  <IconButton icon="hyp-cancel" title="Close" />
                 </div>
               </header>
               <div>
@@ -69,7 +69,7 @@ export default function OrganismPatterns() {
               <header>
                 <h2 className="hyp-panel__title">Panel title</h2>
                 <div className="hyp-panel__close">
-                  <IconButton icon="cancel" title="Close" />
+                  <IconButton icon="hyp-cancel" title="Close" />
                 </div>
               </header>
               <div>

--- a/src/pattern-library/components/patterns/SpinnerPatterns.js
+++ b/src/pattern-library/components/patterns/SpinnerPatterns.js
@@ -22,13 +22,13 @@ export default function SpinnerPatterns() {
         </p>
         <PatternExamples>
           <PatternExample details="basic spinner">
-            <SvgIcon name="spinner" className="hyp-spinner" />
+            <SvgIcon name="hyp-spinner" className="hyp-spinner" />
           </PatternExample>
           <PatternExample details="spinner, large size">
-            <SvgIcon name="spinner" className="hyp-spinner--large" />
+            <SvgIcon name="hyp-spinner" className="hyp-spinner--large" />
           </PatternExample>
           <PatternExample details="spinner, small size">
-            <SvgIcon name="spinner" className="hyp-spinner--small" />
+            <SvgIcon name="hyp-spinner" className="hyp-spinner--small" />
           </PatternExample>
         </PatternExamples>
       </Pattern>

--- a/styles/patterns/_panels.scss
+++ b/styles/patterns/_panels.scss
@@ -17,7 +17,7 @@
   *   <header>
   *     <h2 class="hyp-panel__title">Panel title</h2>
   *     <div class="hyp-panel__close">
-  *       <IconButton icon="cancel" title="Close" />
+  *       <IconButton icon="hyp-cancel" title="Close" />
   *     </div>
   *   </header>
   *   <div>This panel has an icon-only close button</div>

--- a/test/bootstrap.js
+++ b/test/bootstrap.js
@@ -9,11 +9,13 @@ import { Adapter } from 'enzyme-adapter-preact-pure';
 
 configure({ adapter: new Adapter() });
 
-// Make all the icons that are available for use with `SvgIcon` in the actual
-// app available in the tests. This enables validation of icon names passed to
-// `SvgIcon`.
-import testIcons from '../src/icons';
+// Register a single (fake) icon, `hyp-test` for test-use convenience
+// No other icons are registered; components are responsible for registering
+// their own needed icons
 import { registerIcons } from '../src/components/SvgIcon';
+const testIcons = {
+  'hyp-test': require('../images/icons/logo.svg'),
+};
 registerIcons(testIcons);
 
 // Ensure that uncaught exceptions between tests result in the tests failing.


### PR DESCRIPTION
This PR prefixes the names of all icons used in this project with `hyp-` to avoid namespace collisions with other projects, and ambiguity. These are boilerplate/grep changes to update name references throughout the pattern library.

It also updates test bootstrapping such that it doesn't register the icons in the `icons` module. Instead, it registers a single "test" icon for convenience, and leaves it up to components to register the icons they require.

The icons registered in the project's main `icons` module are intended for use within pattern-library examples (comment added to that effect). They should not ever be relied upon for any public component.  Components must register any icons they use (using the `hyp-` prefix). This last part was already the convention in play, but the changes in this PR should help prevent pilot error in this regard.

There are no changes here to anything publicly available (components, e.g.). This will not affect users of the package, but is intended to prevent mess-ups like #150 from happening in the first place.

Depends on #150 because of the spinner-icon rename in that branch

Fixes #151
