### PR TITLE
Remove remaining prop-types usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "postcss": "^8.2.13",
     "preact": "^10.4.0",
     "prettier": "^2.2.1",
-    "prop-types": "^15.7.2",
     "puppeteer": "^7.1.0",
     "sass": "^1.32.11",
     "sinon": "^9.0.0",

--- a/src/components/SvgIcon.js
+++ b/src/components/SvgIcon.js
@@ -1,6 +1,5 @@
 import classnames from 'classnames';
 import { useLayoutEffect, useRef } from 'preact/hooks';
-import propTypes from 'prop-types';
 
 /**
  * Object mapping icon names to SVG markup.
@@ -75,13 +74,6 @@ export function SvgIcon({ name, className = '', inline = false, title = '' }) {
     />
   );
 }
-
-SvgIcon.propTypes = {
-  name: propTypes.string.isRequired,
-  className: propTypes.string,
-  inline: propTypes.bool,
-  title: propTypes.string,
-};
 
 /**
  * Register icons for use with the `SvgIcon` component.

--- a/src/hooks/test/use-element-should-close-test.js
+++ b/src/hooks/test/use-element-should-close-test.js
@@ -21,7 +21,6 @@ describe('useElementShouldClose', () => {
   ];
 
   // Create a fake component to mount in tests that uses the hook
-  // eslint-disable-next-line react/prop-types
   function FakeComponent({ isOpen = true }) {
     const myRef = useRef();
     useElementShouldClose(myRef, isOpen, handleClose);

--- a/test/util/mock-imported-components.js
+++ b/test/util/mock-imported-components.js
@@ -1,11 +1,19 @@
 /**
- * Return true if `value` "looks like" a React/Preact component.
+ * Return true if an imported `value` "looks like" a Preact function component.
+ *
+ * This check can have false positives (ie. match values which are not really components).
+ * That's OK because typical usage in a test is to first mock all components with
+ * `$imports.$mock(mockImportedComponents())` and then mock other things with
+ * `$imports.$mock(...)`. The more specific mocks will override the generic
+ * component mocks.
  */
 function isComponent(value) {
   return (
     typeof value === 'function' &&
-    Object.prototype.hasOwnProperty.call(value, 'propTypes') &&
-    value.name.match(/^[A-Z]/)
+    value.name.match(/^[A-Z]/) &&
+    // Check that function is not an ES class. Note this only works with real
+    // ES classes and may not work with ones transpiled to ES5.
+    !value.toString().match(/^class\b/)
   );
 }
 
@@ -63,9 +71,6 @@ export default function mockImportedComponents() {
     // Make it possible to do `wrapper.find('ComponentName')` where `wrapper`
     // is an Enzyme wrapper.
     mock.displayName = getDisplayName(value);
-
-    // Mocked components validate props in the same way as the real component.
-    mock.propTypes = value.propTypes;
 
     return mock;
   };


### PR DESCRIPTION
We stopped using prop-types some time ago in favor of TypeScript + JSDoc, but it was still used by the `SvgIcon` component and `mockImportedComponents` utility in this package.

1. Remove `prop-types` usage from `SvgIcon` and remove the dependency from package.json
2. Update `mockImportedComponents` to latest version from client repo, that no longer depends on the `propTypes` property