### PR TITLE
Update color foundations page to newer components

### DIFF
--- a/src/pattern-library/components/patterns/ColorFoundations.js
+++ b/src/pattern-library/components/patterns/ColorFoundations.js
@@ -1,20 +1,16 @@
-import {
-  PatternPage,
-  Pattern,
-  PatternExamples,
-  PatternExample,
-} from '../PatternPage';
+import Library from '../Library';
 
 // TODO:
 // - color descriptions and guidance
 // - hex and other metadata about colors
-// - more sophisticated "swatches"
 // - foreground color examples
 // - more examples of overriding with `!` classes
 // - valid contrast combinations
 
-const backgroundExamples = [
-  'brand',
+const brand = ['brand'];
+
+const greys = [
+  'white',
   'grey-0',
   'grey-1',
   'grey-2',
@@ -25,39 +21,56 @@ const backgroundExamples = [
   'grey-7',
   'grey-8',
   'grey-9',
-  'success',
-  'notice',
-  'error',
-].map(colorName => {
+];
+
+const states = ['success', 'notice', 'error'];
+
+function ColorSwatch({ colorName }) {
   return (
-    <PatternExample details={`${colorName}`} key={`bg-${colorName}`}>
+    <div>
       <div
-        key={colorName}
-        className={`PatternSwatch hyp-u-bg-color--${colorName}`}
+        className={`hyp-u-bg-color--${colorName}`}
+        style="width:16rem;height:2rem;margin-right:1em"
       />
-    </PatternExample>
+      <p>
+        <i>{colorName}</i>
+      </p>
+    </div>
   );
-});
+}
+
+const brandExamples = brand.map(colorName => (
+  <ColorSwatch key={colorName} colorName={colorName} />
+));
+
+const greyExamples = greys.map(colorName => (
+  <ColorSwatch key={colorName} colorName={colorName} />
+));
+
+const stateExamples = states.map(colorName => (
+  <ColorSwatch key={colorName} colorName={colorName} />
+));
 
 export default function ColorFoundations() {
   return (
-    <PatternPage title="Colors">
-      <Pattern title="Color swatches">
-        <PatternExamples>{backgroundExamples}</PatternExamples>
-      </Pattern>
+    <Library.Page title="Colors">
+      <Library.Pattern title="Brand red">
+        <div className="hyp-u-layout-row" style="flex-wrap:wrap">
+          {brandExamples}
+        </div>
+      </Library.Pattern>
 
-      <Pattern title="Overriding background colors: example">
-        <PatternExamples>
-          <PatternExample details="Background-color utility class">
-            <div className="hyp-panel hyp-u-bg-color--grey-2">
-              <p>
-                This is a <code>panel</code> with an applied utility class
-                <code>.hyp-u-bg-color--grey-2</code>.
-              </p>
-            </div>
-          </PatternExample>
-        </PatternExamples>
-      </Pattern>
-    </PatternPage>
+      <Library.Pattern title="Greys">
+        <div className="hyp-u-layout-row" style="flex-wrap:wrap">
+          {greyExamples}
+        </div>
+      </Library.Pattern>
+
+      <Library.Pattern title="State indicators">
+        <div className="hyp-u-layout-row" style="flex-wrap:wrap">
+          {stateExamples}
+        </div>
+      </Library.Pattern>
+    </Library.Page>
   );
 }

--- a/styles/pattern-library.scss
+++ b/styles/pattern-library.scss
@@ -152,14 +152,6 @@ pre {
   }
 }
 
-.PatternSwatch {
-  width: 100px;
-  height: 100px;
-  display: flex;
-  align-items: center;
-  justify-items: center;
-}
-
 // Element styles
 body {
   font-family: sans-serif;


### PR DESCRIPTION
Update the "Colors" foundations page to use newer components and spiff the color swatches used. Remove details about how to use color utility classes, as that belongs on a Colors _Patterns_ page.[1] Part of a slow overall conversion to the newer Library components, as time allows.

After screen shots:

<img width="1590" alt="Screen Shot 2021-08-03 at 2 08 30 PM" src="https://user-images.githubusercontent.com/439947/128065859-02683df4-2b64-416c-b66f-47504bc55e54.png">

<img width="373" alt="Screen Shot 2021-08-03 at 2 07 55 PM" src="https://user-images.githubusercontent.com/439947/128065875-0f509dbe-07a6-45af-af78-4f5805393612.png">

[1] Pattern library category structure:

* Foundations: Foundational concepts of the design system, without implementation information
* Patterns: Applied design system patterns
* Components: react components that use the defined patterns

Part of #162