### PR TITLE
Revise icon registration API to prevent conflicts

### DIFF
--- a/src/components/Checkbox.js
+++ b/src/components/Checkbox.js
@@ -1,10 +1,10 @@
-import { registerIcons, SvgIcon } from './SvgIcon';
+import { registerIcon, SvgIcon } from './SvgIcon';
 
-// Register the checkbox icon for use
-registerIcons({
-  /** @ts-ignore - TS doesn't understand require here */
-  'hyp-checkbox': require('../../images/icons/checkbox.svg'),
-});
+const checkboxIcon = registerIcon(
+  'checkbox',
+  // @ts-ignore - TS doesn't understand require
+  require('../../images/icons/checkbox.svg')
+);
 
 /**
  * @typedef CheckboxBaseProps
@@ -59,7 +59,7 @@ export function Checkbox({ inputRef, onToggle, onClick, ...restProps }) {
         onClick={onPressed}
         {...restProps}
       />
-      <SvgIcon className="hyp-svg-checkbox" name="hyp-checkbox" />
+      <SvgIcon className="hyp-svg-checkbox" name={checkboxIcon} />
     </>
   );
 }

--- a/src/components/Dialog.js
+++ b/src/components/Dialog.js
@@ -2,13 +2,13 @@ import classnames from 'classnames';
 import { useEffect, useLayoutEffect, useRef, useState } from 'preact/hooks';
 
 import { IconButton, LabeledButton } from './buttons';
-import { registerIcons, SvgIcon } from './SvgIcon';
+import { registerIcon, SvgIcon } from './SvgIcon';
 
-// Register the checkbox icon for use
-registerIcons({
-  /** @ts-ignore - TS doesn't understand require here */
-  'hyp-cancel': require('../../images/icons/cancel.svg'),
-});
+const cancelIcon = registerIcon(
+  'cancel',
+  // @ts-ignore - TS doesn't understand require
+  require('../../images/icons/cancel.svg')
+);
 
 let idCounter = 0;
 
@@ -134,7 +134,7 @@ export function Dialog({
         </h2>
         {onCancel && (
           <div className="Hyp-Dialog__close">
-            <IconButton icon="hyp-cancel" title="Close" onClick={onCancel} />
+            <IconButton icon={cancelIcon} title="Close" onClick={onCancel} />
           </div>
         )}
       </header>

--- a/src/components/Panel.js
+++ b/src/components/Panel.js
@@ -1,13 +1,14 @@
 import classnames from 'classnames';
 
 import { IconButton } from './buttons';
-import { registerIcons, SvgIcon } from './SvgIcon';
+import { registerIcon, SvgIcon } from './SvgIcon';
 
 // Register the cancel icon for use
-registerIcons({
+const cancelIcon = registerIcon(
+  'cancel',
   /** @ts-ignore - TS doesn't understand require here */
-  'hyp-cancel': require('../../images/icons/cancel.svg'),
-});
+  require('../../images/icons/cancel.svg')
+);
 
 /**
  * @typedef PanelProps
@@ -41,7 +42,7 @@ export function Panel({ children, icon, onClose, title }) {
         <h2 className="Hyp-Panel__title">{title}</h2>
         {withCloseButton && (
           <div className="Hyp-Panel__close">
-            <IconButton icon="hyp-cancel" title="Close" onClick={onClose} />
+            <IconButton icon={cancelIcon} title="Close" onClick={onClose} />
           </div>
         )}
       </header>

--- a/src/components/Spinner.js
+++ b/src/components/Spinner.js
@@ -1,12 +1,12 @@
 import classnames from 'classnames';
 
-import { registerIcons, SvgIcon } from './SvgIcon';
+import { registerIcon, SvgIcon } from './SvgIcon';
 
-// Register the spinner icon for use
-registerIcons({
+const spinnerIcon = registerIcon(
+  'spinner',
   /** @ts-ignore - TS doesn't understand require here */
-  'hyp-spinner': require('../../images/icons/spinner--spokes.svg'),
-});
+  require('../../images/icons/spinner--spokes.svg')
+);
 
 /**
  * @typedef SpinnerProps
@@ -23,6 +23,6 @@ registerIcons({
 export function Spinner({ classes = '', size = 'medium' }) {
   const baseClass = `Hyp-Spinner--${size}`;
   return (
-    <SvgIcon name="hyp-spinner" className={classnames(baseClass, classes)} />
+    <SvgIcon name={spinnerIcon} className={classnames(baseClass, classes)} />
   );
 }

--- a/src/components/SvgIcon.js
+++ b/src/components/SvgIcon.js
@@ -4,7 +4,7 @@ import { useLayoutEffect, useRef } from 'preact/hooks';
 /**
  * Object mapping icon names to SVG markup.
  *
- * @typedef {Object.<string,string>} IconMap
+ * @typedef {Map<string|symbol, string>} IconMap
  */
 
 /**
@@ -17,13 +17,13 @@ import { useLayoutEffect, useRef } from 'preact/hooks';
  *
  * @type {IconMap}
  */
-let iconRegistry = {};
+const iconRegistry = new Map();
 
 /**
  * @typedef SvgIconProps
- * @prop {string} name - The name of the icon to display.
+ * @prop {string|symbol} name - The name of the icon to display.
  *   The name must match a name that has already been registered using the
- *   `registerIcons` function.
+ *   `registerIcon` or `registerIcons` functions.
  * @prop {string} [className] - A CSS class to apply to the `<svg>` element.
  * @prop {boolean} [inline] - Apply a style allowing for inline display of icon wrapper.
  * @prop {string} [title] - Optional title attribute to apply to the SVG's containing `span`.
@@ -39,10 +39,10 @@ let iconRegistry = {};
  * @param {SvgIconProps} props
  */
 export function SvgIcon({ name, className = '', inline = false, title = '' }) {
-  if (!iconRegistry[name]) {
-    throw new Error(`Icon name "${name}" is not registered`);
+  const markup = iconRegistry.get(name);
+  if (!markup) {
+    throw new Error(`Icon "${name.toString()}" is not registered`);
   }
-  const markup = iconRegistry[name];
 
   const element = /** @type {Ref<HTMLElement>} */ (useRef());
   useLayoutEffect(() => {
@@ -76,17 +76,38 @@ export function SvgIcon({ name, className = '', inline = false, title = '' }) {
 }
 
 /**
+ * Register an icon for use with the `SvgIcon` component.
+ *
+ * Returns a symbol that can be passed as the `name` prop to `SvgIcon` in order
+ * to render this icon.
+ *
+ * @param {string} name - A name for this icon
+ * @param {string} markup - SVG markup for the icon
+ * @return {symbol}
+ */
+export function registerIcon(name, markup) {
+  const key = Symbol(name);
+  iconRegistry.set(key, markup);
+  return key;
+}
+
+/**
  * Register icons for use with the `SvgIcon` component.
  *
- * @param {IconMap} icons
+ * @deprecated Prefer the `registerIcon` function instead which will return a
+ * key that does not conflict with existing icons.
+ *
+ * @param {Record<string, string>} icons
  * @param {Object} options
  *  @param {boolean} [options.reset] - If `true`, remove existing registered icons.
  */
 export function registerIcons(icons, { reset = false } = {}) {
   if (reset) {
-    iconRegistry = {};
+    iconRegistry.clear();
   }
-  Object.assign(iconRegistry, icons);
+  for (let [key, value] of Object.entries(icons)) {
+    iconRegistry.set(key, value);
+  }
 }
 
 /**

--- a/src/components/buttons.js
+++ b/src/components/buttons.js
@@ -5,7 +5,7 @@ import { SvgIcon } from './SvgIcon';
 /**
  * @typedef ButtonProps
  * @prop {import('preact').Ref<HTMLButtonElement>} [buttonRef]
- * @prop {string} [icon] - Name of `SvgIcon` to render in the button
+ * @prop {string|symbol} [icon] - Name of `SvgIcon` to render in the button
  * @prop {'left'|'right'} [iconPosition] - Icon positioned to left or to
  *   right of button text
  * @prop {boolean} [expanded] - Is the element associated with this button
@@ -22,16 +22,16 @@ import { SvgIcon } from './SvgIcon';
  */
 
 /**
- * Fold in HTML button prop definitions into ButtonProps, but ignore `size` because it's inherited
- * from HTMLElement and conflicts with the _ButtonProps.size prop above.
+ * Fold in HTML button prop definitions into ButtonProps, but ignore several
+ * which conflict with `ButtonProps` above.
  *
- * @typedef {Omit<import('preact').JSX.HTMLAttributes<HTMLButtonElement>, 'size'> } HTMLButtonElementProps
+ * @typedef {Omit<import('preact').JSX.HTMLAttributes<HTMLButtonElement>, 'size'|'icon'> } HTMLButtonElementProps
  * @typedef {ButtonProps & HTMLButtonElementProps} ButtonBaseProps
  */
 
 /**
  * @typedef IconButtonBaseProps
- * @prop {string} icon - Icon is required for icon buttons
+ * @prop {string|symbol} icon - Icon is required for icon buttons
  * @prop {string} title - Title is required for icon buttons
  * @prop {never} [children] - children are not allowed (use LabeledButton instead)
  */

--- a/src/pattern-library/index.js
+++ b/src/pattern-library/index.js
@@ -8,7 +8,6 @@ import PlaygroundApp from './components/PlaygroundApp';
 
 /**
  * @typedef {import("./components/PlaygroundApp").PlaygroundRoute} PlaygroundRoute
- * @typedef {import("../components/SvgIcon").IconMap} IconMap
  */
 
 /**
@@ -17,7 +16,7 @@ import PlaygroundApp from './components/PlaygroundApp';
  *   library is served. Defaults to `/ui-playground`.
  * @prop {PlaygroundRoute[]} [extraRoutes] - Local-/application-specific routes
  *   to add to this pattern library in addition to the shared/common routes
- * @prop {IconMap} [icons] - Icons, additional to default pattern-library icons,
+ * @prop {Record<string, string>} [icons] - Icons, additional to default pattern-library icons,
  *   to register for use in patterns/components in the pattern library
  */
 


### PR DESCRIPTION
Revise the API used to register icons with `SvgIcon` to prevent conflicts between different packages using the component.

Previously the keys of registered icons were developer-chosen strings. This could lead to conflicts if different packages tried to use the same string for different icons. The new approach in this commit is for the developer to call a `registerIcon(name, svgMarkup)` function which registers an icon and returns a key for use with `<SvgIcon name={key}
..>`. `registerIcon(...)` creates a new symbol and uses it as the key for the map entry, then returns the key. It could just as well generate some other type of unique key, but a symbol seems the natural choice for this purpose.

An added bonus of the new approach is that it makes it easier to find all the places that use a particular icon, since you can just ask your editor / IDE for all references to the variable holding the key returned by `registerIcon(...)`.

Previous API:

```js
registerIcons({ 'cancel': require('path/to/icon.svg') })

<SvgIcon name="cancel" .../>
```

New API:

```js
const cancelIcon = registerIcon('cancel', require('path/to/icon.svg'))

<SvgIcon name={cancelIcon} .../>
```

_In the second API `cancelIcon` holds the unique key and the "cancel" string passed as the first argument to `registerIcon` is just descriptive for use in error messages etc. If two different components registered different icons using the same descriptive name, they won't conflict._

To enable gradual migration, the `registerIcons` function and support for string values for the `name` prop is maintained, but deprecated.