### PR TITLE
Do not hard-code `localhost` in web template asset paths

### DIFF
--- a/templates/index.mustache
+++ b/templates/index.mustache
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>UI component pattern library</title>
-  <link rel="stylesheet" href="http://localhost:4001/styles/pattern-library.css">
+  <link rel="stylesheet" href="/styles/pattern-library.css">
 </head>
 <body>
   <a href="/ui-playground">Go to the Pattern Library</a>

--- a/templates/pattern-library.mustache
+++ b/templates/pattern-library.mustache
@@ -4,10 +4,10 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>UI component pattern library</title>
-  <link rel="stylesheet" href="http://localhost:4001/styles/pattern-library.css">
+  <link rel="stylesheet" href="/styles/pattern-library.css">
 </head>
 <body>
   <div id="app"></div>
-  <script src="http://localhost:4001/scripts/pattern-library.bundle.js"></script>
+  <script src="/scripts/pattern-library.bundle.js"></script>
 </body>
 </html>


### PR DESCRIPTION
Use relative links so that the Pattern Library web site may be accessed by devices on the same network.

Before, I could access the landing page of the Pattern Library from another device on my home network, but styles were not accessible, as they were referenced with a full `localhost` path. Pages in the Pattern Library were not accessible because the script path was also hard-coded to `localhost`.

After these changes, sweet bowls of cherries.