### PR TITLE
Add "scrollbox" pattern

### DIFF
--- a/src/pattern-library/components/patterns/ContainerPatterns.js
+++ b/src/pattern-library/components/patterns/ContainerPatterns.js
@@ -217,6 +217,39 @@ export default function ContainerPatterns() {
           </Library.Demo>
         </Library.Example>
       </Library.Pattern>
+
+      <Library.Pattern title="Scrollbox">
+        <p>
+          <code>Scrollbox</code> is a CSS-only pattern that provides scroll-hint
+          affordances for overflowing content (shadows). It sets its own{' '}
+          <code>overflow: auto</code> scrolling context, but authors need to
+          define bounding dimensions.
+        </p>
+        <Library.Example title="List in a scrollbox">
+          <p>
+            This example shows an overflowing <code>ul</code> in a{' '}
+            <code>scrollbox</code>.
+          </p>
+          <Library.Demo withSource>
+            <div className="hyp-scrollbox" style="height: 150px; width:250px">
+              <ul className="hyp-u-padding hyp-u-vertical-spacing">
+                <li>Alpha</li>
+                <li>Bravo</li>
+                <li>Charlie</li>
+                <li>Delta</li>
+                <li>Echo</li>
+                <li>Foxtrot</li>
+                <li>Golf</li>
+                <li>Hotel</li>
+                <li>India</li>
+                <li>Juliet</li>
+                <li>Kilo</li>
+                <li>Lima</li>
+              </ul>
+            </div>
+          </Library.Demo>
+        </Library.Example>
+      </Library.Pattern>
     </Library.Page>
   );
 }

--- a/src/pattern-library/components/patterns/DialogComponents.js
+++ b/src/pattern-library/components/patterns/DialogComponents.js
@@ -160,7 +160,7 @@ export default function DialogComponents() {
 
   const openLongModal = () => {
     const children = (
-      <div style={{ overflow: 'auto' }}>
+      <div className="hyp-scrollbox">
         <p>
           Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis a sapien
           cursus, fringilla diam posuere, varius urna. Phasellus dictum sodales

--- a/styles/mixins/patterns/_containers.scss
+++ b/styles/mixins/patterns/_containers.scss
@@ -149,3 +149,65 @@ $-color-background: var.$color-background;
     }
   }
 }
+
+/**
+ * A scrolling "frame" that shows scroll-hint shadows at the top and bottom
+ * of the frame if:
+ *  - The content height exceeds the frame height: i.e. can be scrolled, and
+ *  - The content is scrollable in the shadow's direction (up or down)
+ *
+ * Shadows are not visible once the frame has been scrolled all the way in the
+ * shadow's direction. Shadows are not visible if the height of the content
+ * does not overflow the frame (is not scrollable).
+ *
+ * The shadow hinting is handled by four positioned background gradients:
+ *   - One gradient each at top and bottom of frame that obscure the shadow hints
+ *     (shadow covers). These use `background-attachment: local`, which makes
+ *     their position fixed to the _content_ within the scrollbox.
+ *   - One gradient each at the top and the bottom of the frame that are the
+ *     shadow hints (shadows). These use `background-attachment: scroll` such
+ *     that they are always positioned at the top and the bottom of the
+ *     _scrollbox_ frame. When these positions align with the positions of the
+ *     shadow covers--at the top and the bottom of the overflowing content--
+ *     they will be obscured by those shadow covers.
+ *
+ * See https://lea.verou.me/2012/04/background-attachment-local/
+ *
+ * Safari's behavior is different because of a bug with
+ * `background-attachment: local`.
+ * See https://bugs.webkit.org/show_bug.cgi?id=219324
+ * In Safari:
+ *   - Scroll-hint shadows do not appear if content does not overflow (this is
+ *     consistent with other browsers)
+ *   - Only the bottom scroll-hint shadow appears if content overflows
+ *   - The bottom scroll-hint shadow is always present, even if content is
+ *     fully scrolled
+ */
+@mixin scrollbox {
+  overflow: auto;
+  @include atoms.border;
+
+  background:
+    // Shadow covers
+    linear-gradient($-color-background 30%, rgba(255, 255, 255, 0)),
+    linear-gradient(rgba(255, 255, 255, 0), $-color-background 70%) 0 100%,
+    // Shadows
+    linear-gradient(
+        to bottom,
+        rgba(0, 0, 0, 0.1),
+        rgba(0, 0, 0, 0.05) 5px,
+        rgba(255, 255, 255, 0) 70%
+      ),
+    linear-gradient(
+        to top,
+        rgba(0, 0, 0, 0.1),
+        rgba(0, 0, 0, 0.05) 5px,
+        rgba(255, 255, 255, 0) 70%
+      )
+      0 100%;
+  background-repeat: no-repeat;
+  background-color: $-color-background;
+  background-size: 100% 40px, 100% 40px, 100% 14px, 100% 14px;
+
+  background-attachment: local, local, scroll, scroll;
+}

--- a/styles/patterns/_containers.scss
+++ b/styles/patterns/_containers.scss
@@ -32,3 +32,7 @@
 .hyp-modal {
   @include containers.modal;
 }
+
+.hyp-scrollbox {
+  @include containers.scrollbox;
+}


### PR DESCRIPTION
This PR introduces a "scrollbox" container pattern. 

A scrollbox is a scrolling "frame" that shows scroll-hint shadows at the top and bottomof the frame if:
 *  The content height exceeds the frame height: i.e. it is overflowing and can be scrolled, and
 *  The content is scrollable in the shadow's direction (up or down)

This is a CSS-only implementation of hinting behavior to help users see when content is overflowing its container and can be scrolled (thanks, browsers, for hiding scrollbars, is awesome).

This pattern will help with overflowing Table content, as it is not always obvious when said content is vertically scrollable otherwise. This pattern has been tested in Firefox, Chrome and Safari (desktop and iOS) (_updated_: this has also been tested in Opera). Safari's behavior is different than Chrome and Firefox's, as shown and explained below and in code comments. It relies on the `background-attachment` CSS rule, which, except for bugginess in Safari (with the `local` value), has had support in all major browsers for quite some time: https://developer.mozilla.org/en-US/docs/Web/CSS/background-attachment

Example of `scrollbox` with overflowing content (Chrome, Firefox, Opera behavior):

![overflow-list-example](https://user-images.githubusercontent.com/439947/128365933-bd094eab-71ba-47fe-98be-fa755bbf53f7.gif)

Safari has a bug with `background-attachment: local` detailed in code comments. Its behavior is different, but I think acceptable: if content is scrollable, the bottom shadow will always show. Top shadows never show. As in other browsers, the bottom shadow will only show if the content overflows (so we don't end up with meaningless shadows):

![overflow-safari-behavior](https://user-images.githubusercontent.com/439947/128366193-f9383621-d1b0-4f7f-9056-fd46b3a3b87a.gif)

Finally, here is an example of a `table`-pattern prototype in a `scrollbox`, to demonstrate the intended application of this pattern:

![table-prototype-with-scrollbox](https://user-images.githubusercontent.com/439947/128366362-21827d9c-0ba4-4b3f-a0e9-9f9c6750d48f.gif)

The CSS to achieve this is moderately arcane, but I've attempted to comment thoroughly and link to resources.

Depends on https://github.com/hypothesis/frontend-shared/pull/161