### PR TITLE
Introduce a `table` pattern

### DIFF
--- a/src/pattern-library/components/Library.js
+++ b/src/pattern-library/components/Library.js
@@ -1,3 +1,4 @@
+import classnames from 'classnames';
 import { toChildArray } from 'preact';
 import { useState } from 'preact/hooks';
 
@@ -69,11 +70,24 @@ function Pattern({ children, title }) {
 }
 
 /**
+ * @typedef LibraryExampleProps
+ * @prop {import("preact").ComponentChildren} [children]
+ * @prop {string} [title]
+ * @prop {'split'|'wide'} [variant='split'] - Layout variant. Applies
+ *   appropriate className.
+ *   - Split (default) lays out in a row. Non-demo example content is rendered
+ *     left, with demos right. Demos in this variant stack vertically.
+ *   - Wide lays out in a full-width column. Non-example is rendered first,
+ *     then a row to contain demos. Demos in this variant render next to each
+ *     other in a single row.
+ */
+
+/**
  * Render example content and optional Demo(s) for a pattern.
  *
- * @param {LibraryBaseProps} props
+ * @param {LibraryExampleProps} props
  */
-function Example({ children, title }) {
+function Example({ children, title, variant = 'split' }) {
   const kids = toChildArray(children);
 
   // Extract Demo components out of any children
@@ -84,15 +98,25 @@ function Example({ children, title }) {
   const notDemos = kids.filter(kid => !demos.includes(kid));
 
   return (
-    <div className="LibraryExample">
+    <div className={classnames('LibraryExample', `LibraryExample--${variant}`)}>
       <div className="LibraryExample__content">
         {title && <h3 className="LibraryExample__heading">{title}</h3>}
         {notDemos}
       </div>
-      <div className="LibraryExample__content">{demos}</div>
+      <div className="LibraryExample__demos">{demos}</div>
     </div>
   );
 }
+
+/**
+ * @typedef DemoProps
+ * @prop {import("preact").ComponentChildren} [children]
+ * @prop {boolean} [withSource=false] - Should the demo also render the source?
+ *   When true, a "Source" tab will be rendered, which will display the JSX
+ *   source of the Demo's children
+ * @prop {object} [style] - Inline styles to apply to the demo container
+ * @prop {string} [title]
+ */
 
 /**
  * Render a "Demo", with optional source. This will render the children as
@@ -100,14 +124,9 @@ function Example({ children, title }) {
  * of the children will be provided in a separate "Source" tab from the
  * rendered Demo content.
  *
- * @typedef DemoProps
- * @prop {import("preact").ComponentChildren} [children]
- * @prop {boolean} [withSource=false] - Should the demo also render the source?
- *   When true, a "Source" tab will be rendered, which will display the JSX
- *   source of the Demo's children
- * @prop {object} [style] - Inline styles to apply to the demo container
+ * @param {DemoProps} props
  */
-function Demo({ children, withSource = false, style = {} }) {
+function Demo({ children, withSource = false, style = {}, title }) {
   const [visibleTab, setVisibleTab] = useState('demo');
   const source = toChildArray(children).map((child, idx) => {
     return (
@@ -120,6 +139,7 @@ function Demo({ children, withSource = false, style = {} }) {
   });
   return (
     <div className="LibraryDemo">
+      {title && <h4 className="LibraryDemo__header">{title}</h4>}
       <div className="LibraryDemo__tabs">
         <LabeledButton
           onClick={() => setVisibleTab('demo')}

--- a/src/pattern-library/components/patterns/ContainerPatterns.js
+++ b/src/pattern-library/components/patterns/ContainerPatterns.js
@@ -4,6 +4,39 @@ import Library from '../Library';
 
 import { IconButton, LabeledButton } from '../../../';
 
+function ListElements() {
+  return (
+    <>
+      <li>Alpha</li>
+      <li>Bravo</li>
+      <li>Charlie</li>
+      <li>Delta</li>
+      <li>Echo</li>
+      <li>Foxtrot</li>
+      <li>Golf</li>
+      <li>Hotel</li>
+      <li>India</li>
+      <li>Juliett</li>
+      <li>Kilo</li>
+      <li>Lima</li>
+      <li>Mike</li>
+      <li>November</li>
+      <li>Oscar</li>
+      <li>Papa</li>
+      <li>Quebec</li>
+      <li>Romeo</li>
+      <li>Sierra</li>
+      <li>Tango</li>
+      <li>Uniform</li>
+      <li>Victor</li>
+      <li>Whiskey</li>
+      <li>XRay</li>
+      <li>Yankee</li>
+      <li>Zulu</li>
+    </>
+  );
+}
+
 export default function ContainerPatterns() {
   const [showModalExample, setShowModalExample] = useState(false);
   return (
@@ -231,21 +264,38 @@ export default function ContainerPatterns() {
             <code>scrollbox</code>.
           </p>
           <Library.Demo withSource>
-            <div className="hyp-scrollbox" style="height: 150px; width:250px">
-              <ul className="hyp-u-padding hyp-u-vertical-spacing">
-                <li>Alpha</li>
-                <li>Bravo</li>
-                <li>Charlie</li>
-                <li>Delta</li>
-                <li>Echo</li>
-                <li>Foxtrot</li>
-                <li>Golf</li>
-                <li>Hotel</li>
-                <li>India</li>
-                <li>Juliet</li>
-                <li>Kilo</li>
-                <li>Lima</li>
-              </ul>
+            <div style="height:250px;width:250px">
+              <div className="hyp-scrollbox">
+                <ul className="hyp-u-padding hyp-u-vertical-spacing">
+                  <ListElements />
+                </ul>
+              </div>
+            </div>
+          </Library.Demo>
+        </Library.Example>
+
+        <Library.Example title="Scrollbox with header offset">
+          <p>
+            The <code>scrollbox--with-header</code> pattern offsets the top
+            scroll-hinting shadow to accommodate one header-like element with a
+            touch-target height (currently 44px).
+          </p>
+
+          <Library.Demo withSource>
+            <div style="height:250px;width:250px">
+              <div className="hyp-scrollbox--with-header">
+                <div
+                  className="hyp-u-layout-row--center hyp-u-border--bottom hyp-u-bg-color--grey-1"
+                  style="position:sticky;top:0;min-height:44px;"
+                >
+                  <div>
+                    <strong>NATO Phonetic Alphabet</strong>
+                  </div>
+                </div>
+                <ul className="hyp-u-padding hyp-u-vertical-spacing">
+                  <ListElements />
+                </ul>
+              </div>
             </div>
           </Library.Demo>
         </Library.Example>

--- a/src/pattern-library/components/patterns/TablePatterns.js
+++ b/src/pattern-library/components/patterns/TablePatterns.js
@@ -1,0 +1,125 @@
+import Library from '../Library';
+
+// "Fixture" for example table contents
+function ExampleTBody() {
+  return (
+    <tbody>
+      <tr>
+        <td>Alphanumeric Balloons</td>
+        <td>Champagne Delusions</td>
+      </tr>
+      <tr>
+        <td>Elephantine Fry-ups</td>
+        <td>Gargantuan Hiccups</td>
+      </tr>
+      <tr className="is-selected">
+        <td>Illicit Jugglers</td>
+        <td>Katydid Lozenges Meringue</td>
+      </tr>
+      <tr>
+        <td>Alphanumeric Balloons</td>
+        <td>Champagne Delusions</td>
+      </tr>
+      <tr>
+        <td>Elephantine Fry-ups</td>
+        <td>Gargantuan Hiccups</td>
+      </tr>
+      <tr>
+        <td>Illicit Jugglers</td>
+        <td>Katydid Lozenges Moebius</td>
+      </tr>
+      <tr>
+        <td>Elephantine Fry-ups</td>
+        <td>Gargantuan Hiccups</td>
+      </tr>
+      <tr>
+        <td>Illicit Jugglers</td>
+        <td>Katydid Lozenges Meringue</td>
+      </tr>
+      <tr>
+        <td>Alphanumeric Balloons</td>
+        <td>Champagne Delusions</td>
+      </tr>
+    </tbody>
+  );
+}
+
+export default function TablePatterns() {
+  return (
+    <Library.Page title="Tables">
+      <p>
+        These <code>table</code> patterns support a basic table layout that
+        adapts to available space. They are intended for simpler tabular
+        display: maximum 2 or possibly 3 columns. Remember that{' '}
+        <code>table</code> content needs to be usable in tight and narrow
+        spaces.
+      </p>
+      <Library.Pattern title="Table">
+        <Library.Example title="Basic table" variant="wide">
+          <p>
+            By default, a <code>table</code> will fill available horizontal
+            space, and will use whatever height is needed to render its rows.{' '}
+            <code>tr.is-selected</code> styles a row as selected.
+          </p>
+
+          <Library.Demo withSource>
+            <table className="hyp-table">
+              <thead>
+                <tr>
+                  <th scope="col">Column A</th>
+                  <th scope="col">Column B</th>
+                </tr>
+              </thead>
+              <ExampleTBody />
+            </table>
+          </Library.Demo>
+        </Library.Example>
+
+        <Library.Example title="Adjusting column widths">
+          <p>
+            Table column widths may be adjusted by styling <code>thead th</code>{' '}
+            elements. In this example, the column widths are set to 30% and 70%.
+          </p>
+          <Library.Demo withSource>
+            <table className="hyp-table">
+              <thead>
+                <tr>
+                  <th scope="col" style="width:30%">
+                    Column A
+                  </th>
+                  <th scope="col" style="width:70%">
+                    Column B
+                  </th>
+                </tr>
+              </thead>
+              <ExampleTBody />
+            </table>
+          </Library.Demo>
+        </Library.Example>
+
+        <Library.Example title="Constraining with a scrollbox">
+          <p>
+            In this example, the <code>table</code> is constrained within a{' '}
+            <code>scrollbox</code> with a <code>max-height</code>.
+          </p>
+          <Library.Demo withSource>
+            <div
+              style="max-height:250px"
+              className="hyp-scrollbox--with-header"
+            >
+              <table className="hyp-table">
+                <thead>
+                  <tr>
+                    <th scope="col">Column A</th>
+                    <th scope="col">Column B</th>
+                  </tr>
+                </thead>
+                <ExampleTBody />
+              </table>
+            </div>
+          </Library.Demo>
+        </Library.Example>
+      </Library.Pattern>
+    </Library.Page>
+  );
+}

--- a/src/pattern-library/routes.js
+++ b/src/pattern-library/routes.js
@@ -7,6 +7,7 @@ import FormPatterns from './components/patterns/FormPatterns';
 import ContainerPatterns from './components/patterns/ContainerPatterns';
 import PanelPatterns from './components/patterns/PanelPatterns';
 import SpinnerPatterns from './components/patterns/SpinnerPatterns';
+import TablePatterns from './components/patterns/TablePatterns';
 import ThumbnailPatterns from './components/patterns/ThumbnailPatterns';
 
 import ButtonComponents from './components/patterns/ButtonComponents';
@@ -71,6 +72,12 @@ const routes = [
     route: '/patterns-spinners',
     title: 'Spinners',
     component: SpinnerPatterns,
+    group: 'patterns',
+  },
+  {
+    route: '/patterns-tables',
+    title: 'Tables',
+    component: TablePatterns,
     group: 'patterns',
   },
   {

--- a/styles/mixins/patterns/_containers.scss
+++ b/styles/mixins/patterns/_containers.scss
@@ -6,6 +6,7 @@
 
 $-border-radius: var.$border-radius;
 $-color-background: var.$color-background;
+$-header-height: var.$touch-target-size;
 
 /**
  * Patterns that are composites of multiple atomic utilities, but
@@ -182,32 +183,55 @@ $-color-background: var.$color-background;
  *   - Only the bottom scroll-hint shadow appears if content overflows
  *   - The bottom scroll-hint shadow is always present, even if content is
  *     fully scrolled
+ *
+ * @param {CSSLength} [$shadow-top-position=0] - Top scroll-indicating shadow
+ *   (y) position. Default 0: at top edge of scrollbox. Use case: move
+ *   shadow down to accommodate a sticky header of a known height, such that the
+ *   shadow appears below the header(s).
+ * @param {CSSLength} [$shadow-bottom-position=100%] - Bottom scroll-indicating
+ *   shadow position relative to scrollbox. Default 100%: flush to bottom.
  */
-@mixin scrollbox {
+@mixin scrollbox($shadow-top-position: 0, $shadow-bottom-position: 100%) {
   overflow: auto;
   @include atoms.border;
+  position: relative;
+  height: 100%;
+  width: 100%;
 
   background:
-    // Shadow covers
-    linear-gradient($-color-background 30%, rgba(255, 255, 255, 0)),
-    linear-gradient(rgba(255, 255, 255, 0), $-color-background 70%) 0 100%,
-    // Shadows
+    // Top Shadow cover
+    linear-gradient($-color-background 30%, rgba(255, 255, 255, 0)) 0
+      $shadow-top-position,
+    // Bottom shadow cover
+    linear-gradient(rgba(255, 255, 255, 0), $-color-background 70%) 0
+      $shadow-bottom-position,
+    // Top shadow
     linear-gradient(
         to bottom,
         rgba(0, 0, 0, 0.1),
         rgba(0, 0, 0, 0.05) 5px,
         rgba(255, 255, 255, 0) 70%
-      ),
+      )
+      0 $shadow-top-position,
+    // Bottom shadow
     linear-gradient(
         to top,
         rgba(0, 0, 0, 0.1),
         rgba(0, 0, 0, 0.05) 5px,
         rgba(255, 255, 255, 0) 70%
       )
-      0 100%;
+      0 $shadow-bottom-position;
   background-repeat: no-repeat;
   background-color: $-color-background;
   background-size: 100% 40px, 100% 40px, 100% 14px, 100% 14px;
 
   background-attachment: local, local, scroll, scroll;
+}
+
+/**
+ * A scrollbox with the top shadow repositioned down by touch-target-size
+ * to accommodate, e.g., a sticky header at the top of the scrollable content.
+ */
+@mixin scrollbox--with-header {
+  @include scrollbox($shadow-top-position: $-header-height);
 }

--- a/styles/mixins/patterns/_tables.scss
+++ b/styles/mixins/patterns/_tables.scss
@@ -1,0 +1,75 @@
+@use '../../variables' as var;
+
+@use '../atoms';
+@use '../focus';
+@use '../layout';
+
+$-color-background--light: var.$color-white;
+$-color-background--dark: var.$color-grey-7;
+$-color-header-background: var.$color-grey-1;
+$-min-row-height: var.$touch-target-size;
+
+@mixin table {
+  @include focus.outline-on-keyboard-focus;
+
+  // Keep separate borders (this is browser default) to allow control over
+  // the borders of the sticky-positioned top header row: this is needed to
+  // prevent gaps at the top of the <thead> row that scrolling content could peek
+  // through, and to assert control over the sticky-<th> borders as positioning
+  // changes.
+  border-collapse: separate;
+  border-spacing: 0;
+  // Allow th styles to define overall column widths for table
+  table-layout: fixed;
+  width: 100%;
+  color: var.$color-text;
+
+  th,
+  td {
+    @include layout.padding;
+  }
+
+  td {
+    @include atoms.border(top);
+  }
+
+  thead {
+    // Prevent extra vertical height with <th> elements
+    // FIXME: Review after typography patterns introduced
+    line-height: 1;
+
+    th {
+      @include atoms.border(bottom);
+      height: $-min-row-height;
+      position: sticky;
+      top: 0;
+
+      // Ensure the header is displayed above content in the table when it is
+      // scrolled, including any content which establishes a new stacking context.
+      z-index: 1;
+
+      background-color: $-color-header-background;
+      text-align: left;
+    }
+  }
+
+  tbody {
+    // Make table content look interact-able
+    cursor: pointer;
+
+    // No border on top of first row's <td> elements, to eliminate a
+    // double border with the <th>s
+    & tr:first-child td {
+      border-top: none;
+    }
+
+    & tr {
+      height: $-min-row-height;
+
+      &.is-selected {
+        background-color: $-color-background--dark;
+        color: var.$color-white;
+      }
+    }
+  }
+}

--- a/styles/pattern-library.scss
+++ b/styles/pattern-library.scss
@@ -252,22 +252,49 @@ $-library-vertical-spacing: 7;
 .LibraryExample {
   // Narrower screen/default shows single column
   @include layout.vertical-spacing($size: $-library-vertical-spacing);
+}
 
-  // Wider screen shows description and demo side-by-side
+@mixin library-row {
+  // Turn off any applied vertical spacing
+  @include layout.vertical-spacing($size: 0);
+  @include layout.row;
+  @include layout.horizontal-spacing($size: 5);
+}
+
+.LibraryExample--split {
+  // Wider screen shows description and demo side-by-side (where space allows)
   @media screen and (min-width: 60em) {
-    @include layout.row;
-    // Turn off vertical-spacing, as content is side-by-side
-    @include layout.vertical-spacing($size: 0);
-    @include layout.horizontal-spacing($size: 6);
+    @include library-row;
 
-    .LibraryExample__content {
+    .LibraryExample__content,
+    .LibraryExample__demos {
       width: 50%;
       @include layout.vertical-spacing($size: $-library-vertical-spacing);
     }
   }
 }
 
+.LibraryExample--wide {
+  // Show example content full width, and then a row containing demos
+  // side-by-side (where space allows)
+  .LibraryExample__demos {
+    @include layout.vertical-spacing($size: $-library-vertical-spacing);
+
+    @media screen and (min-width: 60em) {
+      @include library-row;
+    }
+  }
+}
+
 .LibraryDemo {
+  // When laid out in a row, make demos share space evenly
+  flex: 1 1 0px;
+
+  &__header {
+    font-size: 1.1em;
+    margin: 0.5rem 0;
+  }
+
   &__tabs {
     @include layout.row;
     @include layout.horizontal-spacing;
@@ -277,16 +304,15 @@ $-library-vertical-spacing: 7;
   }
 
   &__container {
-    @include containers.frame;
+    @include layout.padding($size: 5, $side: top);
+    @include atoms.border(top);
     @include layout.row($align: center, $justify: center);
     // Make the demo take up at least a minimal amount of vertical space
     min-height: 8rem;
-    background-color: var.$color-grey-1;
   }
 
   &__source,
   &__demo {
-    @include containers.frame;
     width: 100%;
   }
 

--- a/styles/patterns/_containers.scss
+++ b/styles/patterns/_containers.scss
@@ -36,3 +36,7 @@
 .hyp-scrollbox {
   @include containers.scrollbox;
 }
+
+.hyp-scrollbox--with-header {
+  @include containers.scrollbox--with-header;
+}

--- a/styles/patterns/_tables.scss
+++ b/styles/patterns/_tables.scss
@@ -1,0 +1,5 @@
+@use '../mixins/patterns/tables';
+
+.hyp-table {
+  @include tables.table;
+}

--- a/styles/patterns/index.scss
+++ b/styles/patterns/index.scss
@@ -2,4 +2,5 @@
 @use 'forms';
 @use 'panels';
 @use 'spinners';
+@use 'tables';
 @use 'thumbnails';

--- a/styles/variables/_colors.scss
+++ b/styles/variables/_colors.scss
@@ -25,6 +25,7 @@ $black: black;
 // Typography: TODO refactor when adding typography patterns
 $text: $grey-9;
 $text--light: $grey-6;
+$text--inverted: $grey-1;
 // This does not provide enough contrast on white to meet WCAG AA standards,
 // and should only be used for disabled interfaces.
 $text--disabled: $grey-4;


### PR DESCRIPTION
This PR introduces a `table` pattern, and adjusts the `scrollbox` pattern to support it. It also (in a separate commit) makes a few adjustment to `Library.Example` and `Library.Demo` component layouts to give more options in how examples and demos are styled, giving more flexibility that was useful for this work.

This is part of https://github.com/hypothesis/frontend-shared/issues/157

Following this will be a `Table` component implementation on top of this pattern (this is already in progress). I may also opt to create a simple `Scrollbox` container component to encapsulate some of the `scrollbox` pattern bits and bobs.

### Updates to `scrollbox` pattern to support `table`

The recently-introduced `scrollbox` pattern is a CSS implementation of an overflow container with scrollability-hinting when that scrollable content is overflowing:

![overflow-list-example](https://user-images.githubusercontent.com/439947/128757370-094669db-1f8c-43e2-8aa4-cac97c4c64a4.gif)

This PR contains a commit that adds some flexibility to the `scrollbox` pattern such that it can accommodate sticky headers, which are used in our table implementation. This variant (`scrollbox--with-header`) offsets the top hint-shadow down by one touch-target unit (44px in our implementation):

![scrollbox--with-header](https://user-images.githubusercontent.com/439947/128758727-9005b803-7f2b-4bbd-8b50-9c196c5fc85d.gif)

Without this affordance, tables will have bottom scroll-hint shadows, but not top ones, as those would be obscured by the sticky header background. 

Aside about this positioning: This does require that our sticky headers used within such scrollboxes are one touch-target (44px) high. Which I grieved over slightly, but feel that the trade-off is reasonably OK. We at least have a common unit—that 44px touch minimum—to apply here. More importantly, heights might grow _higher_ than the set `height` rule (e.g. text wrapping), but shouldn't get shorter. In the case that they grow higher, eh, no big deal, the top shadow will just be obscured (bottom shadow still works).

### The table pattern

The `table` pattern implementation here is based on the table stying from the LMS project. It has been simplified to remove non-table concerns, adjusted and commented. The contrast felt just a tad high on the headers on LMS, so I've lightened that a touch, while still leaving the `is-selected` styling not at all subtle.

![image](https://user-images.githubusercontent.com/439947/128758781-da0c17bc-361a-440d-8560-fe3a94e46085.png)

Partially-scrolled table inside of a `scrollbox--with-header` container:

![image](https://user-images.githubusercontent.com/439947/128758841-0c3b38ed-d058-4bbb-a952-90052b8e0871.png)

### Adjustments to Library Example and Demo layouts

There's a commit on this branch that adds a little layout flexibility to the Examples and Demos such that they don't always need to be 50%-50%, which is limiting in some cases. This allowed me to create a full-width table example in this case. This is just appearance stuff.

### Try it out

Pull this branch, run your local webserver (`make dev`) and visit the [Patterns: Containers page](http://localhost:4001/ui-playground/patterns-containers) (for the `scrollbox--with-header` pattern example) and the [Patterns: Tables page](http://localhost:4001/ui-playground/patterns-tables)