### PR TITLE
Add `Table` component

### DIFF
--- a/src/components/Table.js
+++ b/src/components/Table.js
@@ -1,0 +1,214 @@
+import classnames from 'classnames';
+import { useEffect, useRef } from 'preact/hooks';
+
+import { downcastRef } from '../util/typing';
+
+import { Spinner } from './Spinner';
+import { Scrollbox } from './containers';
+
+/**
+ * @typedef TableHeader
+ * @prop {string} label
+ * @prop {string} [classes] - Additional CSS classes for the column's `<th>` element
+ */
+
+/**
+ * @template Item
+ * @typedef TableProps
+ * @prop {string} accessibleLabel - An accessible label for the table
+ * @prop {string} [classes] - Extra CSS classes to apply to the <table>
+ * @prop {string} [containerClasses] - Extra CSS classes to apply to the outermost
+ *   element, which is a <Scrollbox> div
+ * @prop {TableHeader[]} tableHeaders - The columns to display in this table
+ * @prop {boolean} [isLoading] - Show an indicator that data for the table is
+ *   currently being fetched
+ * @prop {Item[]} items -
+ *   The items to display in this table, one per row. `renderItem` defines how
+ *   information from each item is represented as a series of table cells.
+ * @prop {(it: Item, selected: boolean) => any} renderItem -
+ *   A function to render an item as a table row. It should return
+ *   a `<td>` element for each `tableHeader` column, wrapped in a `Fragment`
+ * @prop {Item|null} selectedItem - The currently selected item from `items`
+ * @prop {(it: Item) => void} onSelectItem -
+ *   Callback invoked when the user changes the selected item
+ * @prop {(it: Item) => void} onUseItem -
+ *   Callback invoked when a user chooses to use an item by double-clicking it
+ *   or pressing Enter while it is selected
+ */
+
+/**
+ * Return the next item to select when advancing the selection by `step` items
+ * forwards (if positive) or backwards (if negative).
+ *
+ * @template Item
+ * @param {Item[]} items
+ * @param {Item|null} currentItem
+ * @param {number} step
+ */
+function nextItem(items, currentItem, step) {
+  const index = currentItem ? items.indexOf(currentItem) : -1;
+  const delta = index + step;
+  if (index < 0) {
+    return items[0];
+  }
+
+  if (delta < 0) {
+    return items[0];
+  }
+
+  if (delta >= items.length) {
+    return items[items.length - 1];
+  }
+
+  return items[delta];
+}
+
+/**
+ * An interactive table of items with a sticky header.
+ *
+ * @template Item
+ * @param {TableProps<Item>} props
+ */
+export function Table({
+  accessibleLabel,
+  classes,
+  containerClasses,
+  isLoading = false,
+  items,
+  onSelectItem,
+  onUseItem,
+  renderItem,
+  selectedItem,
+  tableHeaders,
+}) {
+  const rowRefs = useRef(/** @type {(HTMLElement|null)[]} */ ([]));
+  const scrollboxRef = useRef(/** @type {HTMLElement|null} */ (null));
+  const headerRef = useRef(/** @type {HTMLElement|null} */ (null));
+
+  /** @param {Item} item */
+  const onKeyboardSelect = item => {
+    const rowEl = rowRefs.current[items.indexOf(item)];
+    if (rowEl) {
+      rowEl.focus();
+    }
+    onSelectItem(item);
+  };
+
+  /** @param {KeyboardEvent} event */
+  const onKeyDown = event => {
+    let handled = false;
+    switch (event.key) {
+      case 'Enter':
+        handled = true;
+        if (selectedItem) {
+          onUseItem(selectedItem);
+        }
+        break;
+      case 'ArrowUp':
+        handled = true;
+        onKeyboardSelect(nextItem(items, selectedItem, -1));
+        break;
+      case 'ArrowDown':
+        handled = true;
+        onKeyboardSelect(nextItem(items, selectedItem, 1));
+        break;
+      default:
+        handled = false;
+        break;
+    }
+
+    if (handled) {
+      event.preventDefault();
+      event.stopPropagation();
+    }
+  };
+
+  // When the selectedItem changes, assure that the table row associated with it
+  // is fully visible and not obscured by the sticky table header. This could
+  // happen if the table is partially scrolled. Scroll the Scrollbox as needed
+  // to make the item row fully visible below the header.
+  useEffect(() => {
+    if (!selectedItem) {
+      return;
+    }
+    const rowEl = rowRefs.current[items.indexOf(selectedItem)];
+    const headingEl = headerRef.current;
+    const scrollboxEl = scrollboxRef.current;
+
+    if (rowEl && headingEl && scrollboxEl) {
+      const headingHeight = headingEl.offsetHeight;
+      // The top of the selected row, relative to the top of the Scrollbox frame
+      const rowOffsetFromScrollbox = rowEl.offsetTop - scrollboxEl.scrollTop;
+
+      if (rowOffsetFromScrollbox >= scrollboxEl.clientHeight) {
+        // The `selectedItem` is in a table row that is not visible because it
+        // is below the visible content in the `scrollbox`. This is most likely
+        // to occur if a `Table` is rendered with an initial `selectedItem` that
+        // is towards the bottom of the table (later in the `items` array).
+        // Scroll it into view.
+        rowEl.scrollIntoView();
+      }
+
+      // If the offset position is smaller than the height of the header,
+      // the row is partially or fully obscured by the header. Scroll just
+      // enough to make the full row visible beneath the header.
+      if (rowOffsetFromScrollbox <= headingHeight) {
+        scrollboxEl.scrollBy(0, rowOffsetFromScrollbox - headingHeight);
+      }
+    }
+  }, [items, selectedItem]);
+
+  return (
+    <Scrollbox
+      withHeader
+      classes={classnames('Hyp-Table-Scrollbox', containerClasses)}
+      containerRef={scrollboxRef}
+    >
+      <table
+        aria-label={accessibleLabel}
+        className={classnames('Hyp-Table', classes)}
+        tabIndex={0}
+        role="grid"
+        onKeyDown={onKeyDown}
+      >
+        <thead ref={downcastRef(headerRef)}>
+          <tr>
+            {tableHeaders.map(({ classes, label }, index) => (
+              <th
+                key={`${label}-${index}`}
+                className={classnames(classes)}
+                scope="col"
+              >
+                {label}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {!isLoading &&
+            items.map((item, index) => (
+              <tr
+                aria-selected={selectedItem === item}
+                key={index}
+                className={classnames({
+                  'is-selected': selectedItem === item,
+                })}
+                onMouseDown={() => onSelectItem(item)}
+                onClick={() => onSelectItem(item)}
+                onDblClick={() => onUseItem(item)}
+                ref={node => (rowRefs.current[index] = node)}
+                tabIndex={-1}
+              >
+                {renderItem(item, selectedItem === item)}
+              </tr>
+            ))}
+        </tbody>
+      </table>
+      {isLoading && (
+        <div className="Hyp-Table-Scrollbox__loading">
+          <Spinner size="large" />
+        </div>
+      )}
+    </Scrollbox>
+  );
+}

--- a/src/components/test/Table-test.js
+++ b/src/components/test/Table-test.js
@@ -1,0 +1,223 @@
+import { mount } from 'enzyme';
+
+import { Table } from '../Table';
+import { checkAccessibility } from '../../../test/util/accessibility';
+
+describe('Table', () => {
+  let constrainedContainer;
+  let fakeItems;
+
+  const createComponent = (props = {}) => {
+    return mount(
+      <Table
+        accessibleLabel="Test table"
+        tableHeaders={[{ label: 'Item' }]}
+        items={fakeItems}
+        renderItem={item => <td>{item}</td>}
+        onSelectItem={sinon.stub()}
+        onUseItem={sinon.stub()}
+        selectedItem={null}
+        {...props}
+      />,
+      { attachTo: constrainedContainer }
+    );
+  };
+
+  beforeEach(() => {
+    fakeItems = [
+      'One',
+      'Two',
+      'Three',
+      'Four',
+      'Five',
+      'Six',
+      'Seven',
+      'Eight',
+    ];
+    constrainedContainer = document.createElement('div');
+    constrainedContainer.style.height = '200px';
+    constrainedContainer.style.maxHeight = '200px';
+    document.body.appendChild(constrainedContainer);
+  });
+
+  afterEach(() => {
+    constrainedContainer.remove();
+  });
+
+  context('when loading', () => {
+    it('does not render items', () => {
+      const wrapper = createComponent({ isLoading: true });
+      const items = wrapper.find('tr > td');
+
+      assert.equal(items.length, 0);
+    });
+
+    it('shows spinner', () => {
+      const wrapper = createComponent({ isLoading: true });
+      assert.isTrue(wrapper.exists('Spinner'));
+    });
+
+    it('renders column headings', () => {
+      const wrapper = createComponent({
+        isLoading: true,
+        tableHeaders: [{ label: 'Name' }, { label: 'Size' }],
+      });
+
+      const columns = wrapper.find('thead th').map(col => col.text());
+      assert.deepEqual(columns, ['Name', 'Size']);
+    });
+  });
+
+  it('renders column headings', () => {
+    const wrapper = createComponent({
+      tableHeaders: [{ label: 'Name' }, { label: 'Size' }],
+    });
+    const columns = wrapper.find('thead th').map(col => col.text());
+    assert.deepEqual(columns, ['Name', 'Size']);
+  });
+
+  it('renders items', () => {
+    const wrapper = createComponent({
+      tableHeaders: [{ label: 'Item' }],
+      items: ['One', 'Two', 'Three'],
+      // eslint-disable-next-line react/display-name
+      renderItem: item => <td>{item}</td>,
+    });
+
+    const items = wrapper.find('tr > td');
+    assert.equal(items.length, 3);
+    assert.isTrue(wrapper.contains(<td>One</td>));
+    assert.isTrue(wrapper.contains(<td>Two</td>));
+    assert.isTrue(wrapper.contains(<td>Three</td>));
+  });
+
+  ['click', 'mousedown'].forEach(event => {
+    it(`selects item on ${event}`, () => {
+      const onSelectItem = sinon.stub();
+      const wrapper = createComponent({
+        items: ['One', 'Two', 'Three'],
+        onSelectItem,
+      });
+
+      wrapper.find('tbody > tr').first().simulate(event);
+
+      assert.calledWith(onSelectItem, 'One');
+    });
+  });
+
+  it('uses selected item on double-click', () => {
+    const item = 'Test item';
+    const onUseItem = sinon.stub();
+    const wrapper = createComponent({ items: [item], onUseItem });
+
+    wrapper.find('tbody > tr').first().simulate('dblclick');
+
+    assert.calledWith(onUseItem, item);
+  });
+
+  it('supports keyboard navigation', () => {
+    const onSelectItem = sinon.stub();
+    const onUseItem = sinon.stub();
+    const items = ['One', 'Two', 'Three'];
+    const wrapper = createComponent({
+      items,
+      selectedItem: items[1],
+      onSelectItem,
+      onUseItem,
+    });
+    const rows = wrapper.find('tbody > tr').map(n => n.getDOMNode());
+    rows.forEach(row => (row.focus = sinon.stub()));
+
+    const assertKeySelectsItem = (key, index) => {
+      rows[index].focus.reset();
+      onSelectItem.reset();
+
+      wrapper.find('table').simulate('keydown', { key });
+
+      assert.calledWith(onSelectItem, items[index]);
+      assert.called(rows[index].focus);
+    };
+
+    // Down arrow should select item below selected item.
+    assertKeySelectsItem('ArrowDown', 2);
+
+    // Up arrow should select item above selected item.
+    assertKeySelectsItem('ArrowUp', 0);
+
+    // Enter should use selected item.
+    onSelectItem.reset();
+    wrapper.find('table').simulate('keydown', { key: 'Enter' });
+    assert.calledWith(onUseItem, items[1]);
+
+    // Up arrow should not change selection if first item is selected.
+    wrapper.setProps({ selectedItem: items[0] });
+    assertKeySelectsItem('ArrowUp', 0);
+
+    // Down arrow should not change selection if last item is selected.
+    wrapper.setProps({ selectedItem: items[items.length - 1] });
+    assertKeySelectsItem('ArrowDown', items.length - 1);
+
+    // Up or down arrow should select the first item if no item is selected.
+    wrapper.setProps({ selectedItem: null });
+    assertKeySelectsItem('ArrowUp', 0);
+    assertKeySelectsItem('ArrowDown', 0);
+
+    // Other keys should do nothing.
+    onSelectItem.reset();
+    wrapper.find('table').simulate('keydown', { key: 'Tab' });
+    assert.notCalled(onSelectItem);
+  });
+
+  it('hides spinner if data is fetched', () => {
+    const wrapper = createComponent({ isLoading: false });
+    assert.isFalse(wrapper.exists('Spinner'));
+  });
+
+  it('leaves the table scrolling as-is if no item is selected', () => {
+    const wrapper = createComponent({
+      selectedItem: null,
+    });
+
+    const scrollboxOffset = wrapper.find('Scrollbox').getDOMNode().scrollTop;
+    const scrollboxHeight = wrapper.find('Scrollbox').getDOMNode().clientHeight;
+
+    assert.equal(scrollboxOffset, 0);
+    assert.equal(scrollboxHeight, 200); // Inline styles in container
+  });
+
+  it('adds a selected class to the selected item', () => {
+    const wrapper = createComponent({
+      selectedItem: fakeItems[0],
+    });
+
+    const selectedItemRow = wrapper.find('tbody > tr').first();
+    assert.isTrue(selectedItemRow.hasClass('is-selected'));
+  });
+
+  it('scrolls to selected element if below visible scrollbox', () => {
+    const wrapper = createComponent({
+      selectedItem: fakeItems[fakeItems.length - 1],
+    });
+
+    const lastItemRow = wrapper.find('tbody > tr').last();
+
+    // Selected row offset from top of scrollbox (369)
+    const rowOffset = lastItemRow.getDOMNode().offsetTop;
+    // Scrollbox scroll top (213)
+    const scrollboxScrollTop = wrapper.find('Scrollbox').getDOMNode().scrollTop;
+    // Selected row height (from applied Table styles) (44)
+    const rowHeight = lastItemRow.getDOMNode().clientHeight;
+    // The visible height of the scrollbox (from inline styles in these tests)
+    const scrollboxHeight = wrapper.find('Scrollbox').getDOMNode().clientHeight;
+
+    // The selected row <tr> is within the visible scrollbox content
+    assert.equal(rowOffset - scrollboxScrollTop + rowHeight, scrollboxHeight);
+  });
+
+  it(
+    'should pass a11y checks',
+    checkAccessibility({
+      content: () => createComponent({ selectedItem: fakeItems[3] }),
+    })
+  );
+});

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,7 @@ export { Modal, ConfirmModal } from './components/Modal';
 export { Panel } from './components/Panel';
 export { Spinner } from './components/Spinner';
 export { SvgIcon, registerIcons } from './components/SvgIcon';
+export { Table } from './components/Table';
 export { TextInput, TextInputWithButton } from './components/TextInput';
 export { Thumbnail } from './components/Thumbnail';
 

--- a/src/pattern-library/components/patterns/TableComponents.js
+++ b/src/pattern-library/components/patterns/TableComponents.js
@@ -1,0 +1,104 @@
+import { Fragment } from 'preact';
+import { useState } from 'preact/hooks';
+
+import { LabeledButton, Table } from '../../../';
+
+import Library from '../Library';
+
+import { sampleTableContent } from './samples';
+
+const renderCallback = file => (
+  <Fragment>
+    <td>{file.displayName}</td>
+    <td>{file.updated}</td>
+  </Fragment>
+);
+
+const { tableHeaders, items } = sampleTableContent();
+
+function TableExample() {
+  const [isLoading, setIsLoading] = useState(false);
+  const [selectedFile, setSelectedFile] = useState(
+    /** @type {null|object} */ (null)
+  );
+
+  return (
+    <Library.Example title="Basic Table" variant="wide">
+      <p>
+        A <code>Table</code> will fill available space if none of its ancestors
+        apply any constraints on height or width. It will fill 100% of its
+        available space horizontally, and take up all the vertical space it
+        needs. In this case, it will change vertical size during loading.
+      </p>
+      <Library.Demo>
+        <div className="hyp-u-padding--5">
+          <LabeledButton onClick={() => setIsLoading(!isLoading)}>
+            Toggle Loading
+          </LabeledButton>
+        </div>
+        <Table
+          accessibleLabel="File list"
+          isLoading={isLoading}
+          items={items}
+          selectedItem={selectedFile}
+          onSelectItem={file => setSelectedFile(file)}
+          onUseItem={file => alert(`Selected ${file.displayName}`)}
+          renderItem={file => renderCallback(file)}
+          tableHeaders={tableHeaders}
+        />
+      </Library.Demo>
+    </Library.Example>
+  );
+}
+
+function ScrollboxTableExample() {
+  const [isLoading, setIsLoading] = useState(false);
+  const [selectedFile, setSelectedFile] = useState(
+    /** @type {null|object} */ (items[items.length - 1])
+  );
+
+  return (
+    <Library.Example title="Constrained Table" variant="wide">
+      <p>
+        <code>Tables</code> render inside of a <code>Scrollbox</code> container
+        component, which gives the table a scroll context and allows it to
+        scroll if it overflows. Apply height/width constraints to an appropriate
+        parent elements to enable this. Height will not change when loading.
+      </p>
+      <p>In this example, the last item in the table is pre-selected.</p>
+      <Library.Demo withSource>
+        <div className="hyp-u-padding--5">
+          <LabeledButton onClick={() => setIsLoading(!isLoading)}>
+            Toggle Loading
+          </LabeledButton>
+        </div>
+        <div
+          className="hyp-u-layout-column hyp-u-padding--3"
+          style="max-height:300px;height:300px;"
+        >
+          <Table
+            accessibleLabel="File list"
+            isLoading={isLoading}
+            items={isLoading ? [] : items}
+            selectedItem={selectedFile}
+            onSelectItem={file => setSelectedFile(file)}
+            onUseItem={file => alert(`Selected ${file.displayName}`)}
+            renderItem={file => renderCallback(file)}
+            tableHeaders={tableHeaders}
+          />
+        </div>
+      </Library.Demo>
+    </Library.Example>
+  );
+}
+
+export default function TableComponents() {
+  return (
+    <Library.Page title="Table">
+      <Library.Pattern title="Table">
+        <TableExample />
+        <ScrollboxTableExample />
+      </Library.Pattern>
+    </Library.Page>
+  );
+}

--- a/src/pattern-library/components/patterns/samples.js
+++ b/src/pattern-library/components/patterns/samples.js
@@ -165,3 +165,58 @@ export function LoremIpsum() {
     </p>
   );
 }
+
+export function sampleTableContent() {
+  return {
+    tableHeaders: [
+      {
+        label: 'Name',
+      },
+      {
+        label: 'Last modified',
+      },
+    ],
+    items: [
+      {
+        displayName: 'Persnickety.pdf',
+        updated: 'Jul 28, 2021',
+      },
+      {
+        displayName: 'Albumen.pdf',
+        updated: 'Jul 20, 2021',
+      },
+      {
+        displayName: 'Yams-and-sauce.pdf',
+        updated: 'Aug 04, 2021',
+      },
+      {
+        displayName: 'Coneflowers-and-their-allies.pdf',
+        updated: 'Aug 01, 2021',
+      },
+      {
+        displayName: 'Dollars-and-sense.pdf',
+        updated: 'Aug 22, 2021',
+      },
+      {
+        displayName: 'Mendicant Friars.PDF',
+        updated: 'Jul 20, 2021',
+      },
+      {
+        displayName: 'Paleogeography.pdf',
+        updated: 'Aug 04, 2021',
+      },
+      {
+        displayName: 'Foregone conclusions.pdf',
+        updated: 'Aug 01, 2021',
+      },
+      {
+        displayName: 'Forklifts-and-bananas.pdf',
+        updated: 'Aug 01, 2021',
+      },
+      {
+        displayName: 'Coracles.pdf',
+        updated: 'Aug 05, 2021',
+      },
+    ],
+  };
+}

--- a/src/pattern-library/routes.js
+++ b/src/pattern-library/routes.js
@@ -16,6 +16,7 @@ import DialogComponents from './components/patterns/DialogComponents';
 import FormComponents from './components/patterns/FormComponents';
 import PanelComponents from './components/patterns/PanelComponents';
 import SpinnerComponents from './components/patterns/SpinnerComponents';
+import TableComponents from './components/patterns/TableComponents';
 import ThumbnailComponents from './components/patterns/ThumbnailComponents';
 
 /**
@@ -120,6 +121,12 @@ const routes = [
     route: '/components-spinner',
     title: 'Spinner',
     component: SpinnerComponents,
+    group: 'components',
+  },
+  {
+    route: '/components-table',
+    title: 'Table',
+    component: TableComponents,
     group: 'components',
   },
   {

--- a/styles/components/Table.scss
+++ b/styles/components/Table.scss
@@ -1,0 +1,25 @@
+@use 'sass:math';
+@use '../variables' as var;
+
+@use '../mixins/layout';
+@use '../mixins/patterns/tables';
+
+$-row-height: var.$touch-target-size;
+
+.Hyp-Table-Scrollbox {
+  // Loading (Spinner) affordances:
+  // - Make sure there is enough vertical space for spinner
+  // - Make sure there is a relatively-positioned ancestor for spinner's
+  //   absolute positioning
+  min-height: $-row-height * 3;
+
+  &__loading {
+    @include layout.absolute-centered;
+    // Adjust vertical position to account for header, which takes up one "row"
+    margin-top: math.div($-row-height, 2);
+  }
+}
+
+.Hyp-Table {
+  @include tables.table;
+}

--- a/styles/index.scss
+++ b/styles/index.scss
@@ -10,6 +10,7 @@
 @use './components/Panel';
 @use './components/Spinner';
 @use './components/SvgIcon';
+@use './components/Table';
 @use './components/TextInput';
 @use './components/Thumbnail';
 @use './components/buttons/styles';

--- a/styles/mixins/_layout.scss
+++ b/styles/mixins/_layout.scss
@@ -110,6 +110,16 @@ $-color-overlay: var.$color-overlay;
 }
 
 /**
+ * Position an element, absolutely, vertically and horizontally
+ */
+@mixin absolute-centered {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+}
+
+/**
  * Semi-opaque overlay, full-viewport
  */
 @mixin overlay {

--- a/styles/mixins/patterns/_containers.scss
+++ b/styles/mixins/patterns/_containers.scss
@@ -246,10 +246,11 @@ $-header-height: var.$touch-target-size;
   height: $-header-height;
 
   @include layout.padding;
-  @include atoms.border(bottom);
-
-  background-color: var.$color-grey-1;
   font-weight: bold;
+
+  // This element needs a background of some sort so that text scrolling
+  // beneath it doesn't show through
+  background-color: var.$color-background;
 
   width: 100%;
 

--- a/styles/mixins/patterns/_tables.scss
+++ b/styles/mixins/patterns/_tables.scss
@@ -6,9 +6,18 @@
 
 @use './containers';
 
-$-color-background--light: var.$color-white;
-$-color-background--dark: var.$color-grey-7;
-$-color-header-background: var.$color-grey-1;
+// TODO: Extract these to colors if adopted
+// These two colors are adapted from https://hypothesis-pattern-library.netlify.app/helpers
+$-color-background--inverted: #595969;
+// 8-bit HEX with opacity
+$-color-background-hover: #babac444;
+
+// This background-border combination is novel.
+// TODO: Extract into pattern if adopted
+$-color-header-background: var.$color-grey-2;
+$-color-header-border: var.$color-grey-5;
+
+$-color-text--inverted: var.$color-white;
 $-min-row-height: var.$touch-target-size;
 
 @mixin table {
@@ -42,10 +51,11 @@ $-min-row-height: var.$touch-target-size;
 
     th {
       @include containers.sticky-header;
+      border-bottom: 1px solid $-color-header-border;
+      background-color: $-color-header-background;
       // Ensure the header is displayed above content in the table when it is
       // scrolled, including any content which establishes a new stacking context.
       z-index: 1;
-
       text-align: left;
     }
   }
@@ -60,13 +70,24 @@ $-min-row-height: var.$touch-target-size;
       border-top: none;
     }
 
+    & tr:nth-child(odd) {
+      // Need a low-opacity black versus a named greyscale color because
+      // this background needs to be very low opacity so as not to obscure
+      // scroll-hinting shadows
+      background-color: rgba(0, 0, 0, 0.025);
+    }
+
     & tr {
       height: $-min-row-height;
 
       &.is-selected {
-        background-color: $-color-background--dark;
-        color: var.$color-white;
+        background-color: $-color-background--inverted;
+        color: $-color-text--inverted;
       }
+    }
+
+    & tr:hover:not(.is-selected) {
+      background-color: $-color-background-hover;
     }
   }
 }

--- a/styles/util/_layout.scss
+++ b/styles/util/_layout.scss
@@ -170,6 +170,11 @@
   @include layout.fixed-centered;
 }
 
+// Position the element centered vertically and horizontally in the entire viewport
+.hyp-u-absolute-centered {
+  @include layout.absolute-centered;
+}
+
 // A full-viewport-width and -height semi-opaque backdrop overlay
 .hyp-u-overlay {
   @include layout.overlay;


### PR DESCRIPTION
This PR adds a `Table` component and examples, and makes a few adjustment to the underlying `table` pattern to support the component better.

Implementation is based on the [LMS `Table` component](https://github.com/hypothesis/lms/blob/9d4b4c4f6dde458b3cc8e67e6ef37314c9436047/lms/static/scripts/frontend_apps/components/Table.js).

Here is a video of it in action, including some keyboard navigation:

![Table-component](https://user-images.githubusercontent.com/439947/129209545-361df63a-ea06-444a-93dd-51c681613ca8.gif)

`Table` API changes:

* (Breaking): `columns` prop renamed `tableHeaders`; property `className` on `TableHeader` objects now named `classes`
* Additions (non-breaking): `classes` and `tableClasses` support

`Table` behavior and UI changes:

* `Table`s are wrapped in a `Scrollbox` component (in LMS' implementation, they had a wrapper div, but this has been abstracted and formalized here)
* When a row is selected that is partially or completely obscured by the (sticky) table header, the scrollbox is scrolled to assure the entire row is visible
* Column headers render while loading; items explicitly do not (in LMS implementation, everything displays, but also a loading spinner, which could lead to some funky combinations)
* This PR proposes using a slightly bluish grey (as defined in a proposed palette a few years ago) for table-row hover and selection colors
* When rendered inside of a parent with height constraints, the `Table` will not change height when loading or changing contents. A loading Spinner is absolute-centered, and the minimum Table height accounts for a Spinner.
* Row striping and hover are introduced, per suggestion

Fixes https://github.com/hypothesis/frontend-shared/issues/157
Depends on #172 