### PR TITLE
Make all Library pages import from package entry point

### DIFF
--- a/src/pattern-library/components/patterns/ButtonComponents.js
+++ b/src/pattern-library/components/patterns/ButtonComponents.js
@@ -1,5 +1,4 @@
 import { IconButton, LabeledButton, LinkButton } from '../../../';
-
 import Library from '../Library';
 
 export default function ButtonComponents() {

--- a/src/pattern-library/components/patterns/ContainerComponents.js
+++ b/src/pattern-library/components/patterns/ContainerComponents.js
@@ -1,6 +1,4 @@
-import { Frame, Card, Actions, Scrollbox } from '../../..';
-import { LabeledButton } from '../../..';
-
+import { Actions, Card, Frame, Scrollbox, LabeledButton } from '../../..';
 import Library from '../Library';
 
 import { SampleListElements } from './samples';

--- a/src/pattern-library/components/patterns/ContainerPatterns.js
+++ b/src/pattern-library/components/patterns/ContainerPatterns.js
@@ -1,8 +1,7 @@
 import { useState } from 'preact/hooks';
 
-import Library from '../Library';
-
 import { IconButton, LabeledButton } from '../../../';
+import Library from '../Library';
 
 import { SampleListElements } from './samples';
 

--- a/src/pattern-library/components/patterns/DialogComponents.js
+++ b/src/pattern-library/components/patterns/DialogComponents.js
@@ -1,16 +1,17 @@
 import { createRef } from 'preact';
 import { useState } from 'preact/hooks';
+
+import Library from '../Library';
+
 import {
   ConfirmModal,
   Dialog,
+  IconButton,
   LabeledButton,
   Modal,
-  TextInputWithButton,
   TextInput,
-  IconButton,
+  TextInputWithButton,
 } from '../../../';
-
-import Library from '../Library';
 
 import { LoremIpsum } from './samples';
 

--- a/src/pattern-library/components/patterns/FormComponents.js
+++ b/src/pattern-library/components/patterns/FormComponents.js
@@ -1,9 +1,11 @@
 import { useState } from 'preact/hooks';
 
-import { IconButton } from '../../../components/buttons';
-import { LabeledCheckbox } from '../../../components/Checkbox';
-import { TextInput, TextInputWithButton } from '../../../components/TextInput';
-
+import {
+  IconButton,
+  LabeledCheckbox,
+  TextInput,
+  TextInputWithButton,
+} from '../../..';
 import Library from '../Library';
 
 export default function FormComponents() {

--- a/src/pattern-library/components/patterns/FormPatterns.js
+++ b/src/pattern-library/components/patterns/FormPatterns.js
@@ -1,6 +1,5 @@
-import Library from '../Library';
-
 import { IconButton, SvgIcon } from '../../../';
+import Library from '../Library';
 
 export default function FormPatterns() {
   return (

--- a/src/pattern-library/components/patterns/LayoutFoundations.js
+++ b/src/pattern-library/components/patterns/LayoutFoundations.js
@@ -2,7 +2,6 @@ import classnames from 'classnames';
 import { useState } from 'preact/hooks';
 
 import { LabeledButton } from '../../../';
-
 import Library from '../Library';
 
 function SquareBlock() {

--- a/src/pattern-library/components/patterns/PanelComponents.js
+++ b/src/pattern-library/components/patterns/PanelComponents.js
@@ -1,5 +1,4 @@
 import { Panel } from '../../../';
-
 import Library from '../Library';
 
 export default function PanelComponents() {

--- a/src/pattern-library/components/patterns/PanelPatterns.js
+++ b/src/pattern-library/components/patterns/PanelPatterns.js
@@ -1,6 +1,5 @@
-import Library from '../Library';
-
 import { IconButton, LabeledButton } from '../../../';
+import Library from '../Library';
 
 export default function OrganismPatterns() {
   return (

--- a/src/pattern-library/components/patterns/SpinnerComponents.js
+++ b/src/pattern-library/components/patterns/SpinnerComponents.js
@@ -1,6 +1,5 @@
-import Library from '../Library';
-
 import { Spinner } from '../../..';
+import Library from '../Library';
 
 export default function SpinnerComponents() {
   return (

--- a/src/pattern-library/components/patterns/SpinnerPatterns.js
+++ b/src/pattern-library/components/patterns/SpinnerPatterns.js
@@ -1,6 +1,5 @@
-import Library from '../Library';
-
 import { SvgIcon } from '../../..';
+import Library from '../Library';
 
 export default function SpinnerPatterns() {
   return (

--- a/src/pattern-library/components/patterns/ThumbnailComponents.js
+++ b/src/pattern-library/components/patterns/ThumbnailComponents.js
@@ -1,5 +1,4 @@
 import { Thumbnail } from '../../..';
-
 import Library from '../Library';
 
 export default function ThumbnailComponents() {

--- a/src/pattern-library/components/patterns/ThumbnailPatterns.js
+++ b/src/pattern-library/components/patterns/ThumbnailPatterns.js
@@ -1,6 +1,5 @@
-import Library from '../Library';
-
 import { SvgIcon } from '../../..';
+import Library from '../Library';
 
 export default function ThumbnailPatterns() {
   return (


### PR DESCRIPTION
Pattern Library page component modules should import common components from the package's entry point. This makes the Pattern Library more clearly a consumer of the package, and serves as an additional layer of assurance that we are exporting package components correctly.

Also: make imports more consistent in these modules (ordering, alphabetization...)

Fixes #124