### PR TITLE
Create types using `tsconfig.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,8 +59,7 @@
   },
   "scripts": {
     "build-js": "babel src --out-dir lib --source-maps --ignore '**/test' --ignore '**/karma.config.js'",
-    "build-types": "tsc --allowJs --declaration --emitDeclarationOnly --outDir lib src/index.js",
-    "build": "yarn build-js && yarn build-types",
+    "build": "yarn build-js && tsc --build src/tsconfig.json",
     "typecheck": "tsc --build src/tsconfig.json",
     "lint": "eslint .",
     "checkformatting": "prettier --check '**/*.{js,scss,md}'",

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -6,7 +6,9 @@
     "jsx": "react-jsx",
     "jsxImportSource": "preact",
     "module": "commonjs",
-    "noEmit": true,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "declarationDir": "../lib",
     "strict": true,
     "noImplicitAny": false,
     "target": "ES2020"
@@ -15,6 +17,6 @@
   "exclude": [
     // Tests are not checked.
     "**/test/**/*.js",
-    "karma.config.js",
+    "karma.config.js"
   ]
 }


### PR DESCRIPTION
Problem: the `tsc` command that generate the type declaration didn't
include all the options used for type checking the project.

Solution: use `tsc --build` command for both, type checking, and the
generation of the type declaration.