### PR TITLE
Add support for other "text-like" input types to TextInput

### DIFF
--- a/src/components/TextInput.js
+++ b/src/components/TextInput.js
@@ -9,13 +9,12 @@ import classnames from 'classnames';
  *   the rendered `input` element.
  * @prop {boolean} [hasError] - There is an error associated with this input. Will
  *   set some error styling.
+ * @prop {'email'|'search'|'text'|'url'} [type="text"] - Set the <input> type:
+ *   restricted to the "text-like" type values.
  */
 
 /**
- * `TextInput` sets the `type` attribute on the `input`, but any other valid
- * `input` attribute should be forwarded.
- * @typedef {Omit<import('preact').JSX.HTMLAttributes<HTMLInputElement>, 'type'>} HTMLInputElementProps
- * @typedef {TextInputBaseProps & HTMLInputElementProps} TextInputProps
+ * @typedef {TextInputBaseProps & import('preact').JSX.HTMLAttributes<HTMLInputElement>} TextInputProps
  */
 
 /**
@@ -33,6 +32,7 @@ export function TextInput({
   classes = '',
   inputRef,
   hasError = false,
+  type = 'text',
   ...restProps
 }) {
   return (
@@ -44,7 +44,7 @@ export function TextInput({
       )}
       {...restProps}
       ref={inputRef}
-      type="text"
+      type={type}
     />
   );
 }

--- a/src/components/test/TextInput-test.js
+++ b/src/components/test/TextInput-test.js
@@ -13,10 +13,10 @@ describe('TextInput', () => {
     assert.isFalse(wrapper.find('input').hasClass('has-error'));
   });
 
-  it('ignores `type` property and sets `type` to `text`', () => {
-    const wrapper = createComponent({ type: 'checkbox' });
+  it('sets input type based on `type` prop', () => {
+    const wrapper = createComponent({ type: 'url' });
 
-    assert.equal(wrapper.getDOMNode().getAttribute('type'), 'text');
+    assert.equal(wrapper.getDOMNode().getAttribute('type'), 'url');
   });
 
   it('applies an error class when in error', () => {

--- a/src/pattern-library/components/patterns/FormComponents.js
+++ b/src/pattern-library/components/patterns/FormComponents.js
@@ -56,6 +56,18 @@ export default function FormComponents() {
           </Library.Demo>
         </Library.Example>
 
+        <Library.Example title="As type='url'">
+          <p>
+            <code>TextInput</code> renders an <code>input</code> field of{' '}
+            <code>type=&quot;text&quot;</code> by default, but text-like `type`
+            values are also supported (<code>email</code>, <code>search</code>,{' '}
+            <code>url</code>).
+          </p>
+          <Library.Demo withSource>
+            <TextInput name="my-input" type="url" />
+          </Library.Demo>
+        </Library.Example>
+
         <Library.Example title="Error state">
           <Library.Demo withSource>
             <TextInput name="my-input" hasError />


### PR DESCRIPTION
When working on converting LMS' `URLPicker` over to use the shared `Modal`, I was also wanting to convert it to use `TextInput` for its URL-input field. However, `URLPicker` relies on browser validation on `input type="url"`, and `TextInput` wasn't allowing any `type` except text.

This PR adds support for the most "text-like" input `type`s, per https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input — we could open this up to more in the future if we wanted.

