### PR TITLE
Adjust styling for `emptyItemsMessage`

### DIFF
--- a/styles/components/Table.scss
+++ b/styles/components/Table.scss
@@ -21,6 +21,9 @@ $-row-height: var.$touch-target-size;
 
   &__message {
     @include layout.absolute-centered;
+    @include layout.row($justify: center);
+    @include layout.padding;
+    width: 100%;
     top: $-row-height * 2;
   }
 }


### PR DESCRIPTION
Tweak the styles for the "no items message" in the `Table` component
such that the message can take up the full width of the table (minus
padding). This prevents the message from getting squished in width.

(The need for this was uncovered when implementing `emptyItemsMessage` on LMS).