### PR TITLE
Automatic type substitution of Object for object

### DIFF
--- a/src/components/SvgIcon.js
+++ b/src/components/SvgIcon.js
@@ -4,7 +4,7 @@ import { useLayoutEffect, useRef } from 'preact/hooks';
 /**
  * Object mapping icon names to SVG markup.
  *
- * @typedef {Object.<string,string>} IconMap
+ * @typedef {Record<string,string>} IconMap
  */
 
 /**
@@ -79,7 +79,7 @@ export function SvgIcon({ name, className = '', inline = false, title = '' }) {
  * Register icons for use with the `SvgIcon` component.
  *
  * @param {IconMap} icons
- * @param {Object} options
+ * @param {object} options
  *  @param {boolean} [options.reset] - If `true`, remove existing registered icons.
  */
 export function registerIcons(icons, { reset = false } = {}) {

--- a/src/components/Thumbnail.js
+++ b/src/components/Thumbnail.js
@@ -10,7 +10,7 @@ import { Spinner } from './Spinner';
  * @prop {Children|null} [children] - Thumbnail content (typically an img)
  * @prop {string} [classes] - Additional CSS classes to apply
  * @prop {boolean} [isLoading=false] - Is the thumbnail loading?
- * @prop {Object} [placeholder='...'] - Optional placeholder to replace default
+ * @prop {object} [placeholder='...'] - Optional placeholder to replace default
  * @prop {'small'|'medium'|'large'} [size='medium'] - Relative size of spinner
  *   to surrounding content. Typically the `large` size is appropriate, but for
  *   small thumbnails, `medium` might feel more appropriate.

--- a/src/hooks/use-element-should-close.js
+++ b/src/hooks/use-element-should-close.js
@@ -9,7 +9,7 @@ import { normalizeKeyName } from '../browser-compatibility-utils';
  * @param {HTMLElement} element
  * @param {string[]} events
  * @param {EventListener} listener
- * @param {Object} options
+ * @param {object} options
  *   @param {boolean} [options.useCapture]
  * @return {() => void} Function which removes the event listeners.
  */

--- a/src/pattern-library/components/patterns/LayoutFoundations.js
+++ b/src/pattern-library/components/patterns/LayoutFoundations.js
@@ -16,7 +16,7 @@ function SquareBlock() {
 /**
  * Render an example of vertical or horizontal spacing between elements.
  *
- * @param {Object} options
+ * @param {object} options
  *   @param {'horizontal'|'vertical'} options.direction
  *   @param {number} options.size - Spacing unit size, 0 - 9
  *   @param {boolean} [options.defaultSize] - Is this the "default" spacing for


### PR DESCRIPTION
For the past few months, we have started to use the `object` type instead of `Object`. Both are almost interchangeable, but we prefer `object` for simplicity.

This PR substitutes all `Object` to `object` and makes the code more consistent.

I used these commands (Mac version):

```
% ag -0 -l '@.+Object' | xargs -0 sed -ri '' -e '/@/s/(.*{.*)Object(.*})/\1object\2/'
% ag -0 -l '@.+object\.' | xargs -0 sed -ri '' -e '/@/s/object\.</Record</'
```