### PR TITLE
Change SVG icon imports from CommonJS to ES imports

### DIFF
--- a/src/components/Checkbox.js
+++ b/src/components/Checkbox.js
@@ -1,9 +1,10 @@
+// @ts-ignore
+import checkboxIcon from '../../images/icons/checkbox.svg';
 import { registerIcons, SvgIcon } from './SvgIcon';
 
 // Register the checkbox icon for use
 registerIcons({
-  /** @ts-ignore - TS doesn't understand require here */
-  'hyp-checkbox': require('../../images/icons/checkbox.svg'),
+  'hyp-checkbox': checkboxIcon,
 });
 
 /**

--- a/src/components/Dialog.js
+++ b/src/components/Dialog.js
@@ -1,13 +1,14 @@
 import classnames from 'classnames';
 import { useEffect, useLayoutEffect, useRef, useState } from 'preact/hooks';
 
+// @ts-ignore
+import cancelIcon from '../../images/icons/cancel.svg';
 import { IconButton, LabeledButton } from './buttons';
 import { registerIcons, SvgIcon } from './SvgIcon';
 
 // Register the checkbox icon for use
 registerIcons({
-  /** @ts-ignore - TS doesn't understand require here */
-  'hyp-cancel': require('../../images/icons/cancel.svg'),
+  'hyp-cancel': cancelIcon,
 });
 
 let idCounter = 0;

--- a/src/components/Panel.js
+++ b/src/components/Panel.js
@@ -1,12 +1,13 @@
 import classnames from 'classnames';
 
+// @ts-ignore
+import cancelIcon from '../../images/icons/cancel.svg';
 import { IconButton } from './buttons';
 import { registerIcons, SvgIcon } from './SvgIcon';
 
 // Register the cancel icon for use
 registerIcons({
-  /** @ts-ignore - TS doesn't understand require here */
-  'hyp-cancel': require('../../images/icons/cancel.svg'),
+  'hyp-cancel': cancelIcon,
 });
 
 /**

--- a/src/components/Spinner.js
+++ b/src/components/Spinner.js
@@ -1,11 +1,12 @@
 import classnames from 'classnames';
 
+// @ts-ignore
+import spinnerIcon from '../../images/icons/spinner--spokes.svg';
 import { registerIcons, SvgIcon } from './SvgIcon';
 
 // Register the spinner icon for use
 registerIcons({
-  /** @ts-ignore - TS doesn't understand require here */
-  'hyp-spinner': require('../../images/icons/spinner--spokes.svg'),
+  'hyp-spinner': spinnerIcon,
 });
 
 /**

--- a/src/components/test/SvgIcon-test.js
+++ b/src/components/test/SvgIcon-test.js
@@ -1,5 +1,7 @@
 import { render } from 'preact';
 
+import arrowLeftIcon from '../../../images/icons/arrow-left.svg';
+import arrowRightIcon from '../../../images/icons/arrow-right.svg';
 import { SvgIcon, availableIcons, registerIcons } from '../SvgIcon';
 
 describe('SvgIcon', () => {
@@ -15,8 +17,8 @@ describe('SvgIcon', () => {
 
     registerIcons(
       {
-        'arrow-left': require('../../../images/icons/arrow-left.svg'),
-        'arrow-right': require('../../../images/icons/arrow-right.svg'),
+        'arrow-left': arrowLeftIcon,
+        'arrow-right': arrowRightIcon,
       },
       { reset: true }
     );

--- a/src/icons.js
+++ b/src/icons.js
@@ -1,15 +1,27 @@
 // @ts-nocheck
 
+import arrowLeftIcon from '../images/icons/arrow-left.svg';
+import arrowRightIcon from '../images/icons/arrow-right.svg';
+import cancelIcon from '../images/icons/cancel.svg';
+import checkIcon from '../images/icons/check.svg';
+import checkboxIcon from '../images/icons/checkbox.svg';
+import collapsedIcon from '../images/icons/collapsed.svg';
+import editIcon from '../images/icons/edit.svg';
+import logoIcon from '../images/icons/logo.svg';
+import profileIcon from '../images/icons/profile.svg';
+import spinnerIcon from '../images/icons/spinner--spokes.svg';
+import trashIcon from '../images/icons/trash.svg';
+
 export default {
-  'arrow-left': require('../images/icons/arrow-left.svg'),
-  'arrow-right': require('../images/icons/arrow-right.svg'),
-  cancel: require('../images/icons/cancel.svg'),
-  check: require('../images/icons/check.svg'),
-  checkbox: require('../images/icons/checkbox.svg'),
-  collapsed: require('../images/icons/collapsed.svg'),
-  edit: require('../images/icons/edit.svg'),
-  logo: require('../images/icons/logo.svg'),
-  profile: require('../images/icons/profile.svg'),
-  'hyp-spinner': require('../images/icons/spinner--spokes.svg'),
-  trash: require('../images/icons/trash.svg'),
+  'arrow-left': arrowLeftIcon,
+  'arrow-right': arrowRightIcon,
+  cancel: cancelIcon,
+  check: checkIcon,
+  checkbox: checkboxIcon,
+  collapsed: collapsedIcon,
+  edit: editIcon,
+  logo: logoIcon,
+  profile: profileIcon,
+  'hyp-spinner': spinnerIcon,
+  trash: trashIcon,
 };


### PR DESCRIPTION
This will facilitate an upcoming migration to a new module bundler (I
have been testing Rollup, but it likely applies to others as well) which
speaks ES modules natively.