### PR TITLE
Provide more options for closing Modals and Dialogs

### DIFF
--- a/src/components/Dialog.js
+++ b/src/components/Dialog.js
@@ -48,6 +48,11 @@ function useUniqueId(prefix) {
  *   "Cancel" button will be displayed.
  * @prop {'dialog'|'alertdialog'} [role] - The aria role for the dialog (defaults to" dialog")
  * @prop {string} title
+ * @prop {boolean} [withCancelButton=true] - If `onCancel` is provided, render
+ *   a Cancel button as one of the Dialog's buttons (along with any other
+ *   `buttons`)
+ * @prop {boolean} [withCloseButton=true] - If `onCancel` is provided, render
+ *   a close button (X icon) in the Dialog's header
  */
 
 /**
@@ -73,6 +78,8 @@ export function Dialog({
   onCancel,
   role = 'dialog',
   title,
+  withCancelButton = true,
+  withCloseButton = true,
 }) {
   const dialogDescriptionId = useUniqueId('dialog-description');
   const dialogTitleId = useUniqueId('dialog-title');
@@ -112,12 +119,16 @@ export function Dialog({
     }
   }, [dialogDescriptionId]);
 
+  const hasCancelButton = onCancel && withCancelButton;
+  const hasCloseButton = onCancel && withCloseButton;
+  const hasButtons = buttons || hasCancelButton;
+
   return (
     <div
       aria-labelledby={dialogTitleId}
       className={classnames(
         'Hyp-Dialog',
-        { 'Hyp-Dialog--closeable': !!onCancel },
+        { 'Hyp-Dialog--closeable': hasCloseButton },
         contentClass
       )}
       ref={rootEl}
@@ -133,21 +144,28 @@ export function Dialog({
         <h2 className="Hyp-Dialog__title" id={dialogTitleId}>
           {title}
         </h2>
-        {onCancel && (
+        {onCancel && withCloseButton && (
           <div className="Hyp-Dialog__close">
-            <IconButton icon="hyp-cancel" title="Close" onClick={onCancel} />
+            <IconButton
+              data-testid="close-button"
+              icon="hyp-cancel"
+              title="Close"
+              onClick={onCancel}
+            />
           </div>
         )}
       </header>
       {children}
-      <div className="Hyp-Dialog__actions">
-        {onCancel && (
-          <LabeledButton data-testid="cancel-button" onClick={onCancel}>
-            {cancelLabel}
-          </LabeledButton>
-        )}
-        {buttons}
-      </div>
+      {hasButtons && (
+        <div className="Hyp-Dialog__actions">
+          {hasCancelButton && (
+            <LabeledButton data-testid="cancel-button" onClick={onCancel}>
+              {cancelLabel}
+            </LabeledButton>
+          )}
+          {buttons}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -10,11 +10,10 @@ import { LabeledButton } from './buttons';
 
 /**
  * @typedef ModalBaseProps
- * @prop {boolean} [closeOnExternalInteraction=true] - By default, a modal
- *   with a provided `onCancel` callback will close when a user clicks outside
- *   the modal, or focus is moved outside of the modal. In some cases, this
- *   may not be desireable. When this option is disabled, the modal may still
- *   be closed by pressing ESC.
+ * @prop {boolean} [closeOnExternalInteraction=false] - By default, a modal
+ *   with a provided `onCancel` callback will close when a user presses ESC.
+ *   Enabling this option will also close the modal if the user clicks outside
+ *   of the modal, or if focus is moved outside of the modal.
  *
  * @typedef {ModalBaseProps & DialogProps} ModalProps
  */
@@ -29,7 +28,7 @@ import { LabeledButton } from './buttons';
 export function Modal({
   children,
   onCancel,
-  closeOnExternalInteraction = true,
+  closeOnExternalInteraction = false,
   ...restProps
 }) {
   const modalContainerRef = useRef(/** @type {HTMLDivElement | null} */ (null));

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -10,26 +10,33 @@ import { LabeledButton } from './buttons';
 
 /**
  * @typedef ModalBaseProps
- * @prop {() => void} onCancel - `onCancel` is required for Modals
- */
-
-/**
- * @typedef {DialogProps & ModalBaseProps} ModalProps
+ * @prop {boolean} [closeOnExternalInteraction=true] - By default, a modal
+ *   with a provided `onCancel` callback will close when a user clicks outside
+ *   the modal, or focus is moved outside of the modal. In some cases, this
+ *   may not be desireable. When this option is disabled, the modal may still
+ *   be closed by pressing ESC.
+ *
+ * @typedef {ModalBaseProps & DialogProps} ModalProps
  */
 
 /**
  * A modal dialog. Presents a dialog with an overlay background. Will close
- * if user clicks/taps outside of it.
+ * if user clicks/taps outside of it unless `closeOnExternalInteraction` is
+ * disabled.
  *
  * @param {ModalProps} props
  */
-export function Modal({ children, onCancel, ...restProps }) {
+export function Modal({
+  children,
+  onCancel,
+  closeOnExternalInteraction = true,
+  ...restProps
+}) {
   const modalContainerRef = useRef(/** @type {HTMLDivElement | null} */ (null));
 
-  useElementShouldClose(modalContainerRef, true /* isOpen */, () => {
-    if (onCancel) {
-      onCancel();
-    }
+  useElementShouldClose(modalContainerRef, true /* isOpen */, onCancel, {
+    closeOnExternalInteraction,
+    enabled: !!onCancel,
   });
 
   return (

--- a/src/components/test/Dialog-test.js
+++ b/src/components/test/Dialog-test.js
@@ -49,7 +49,19 @@ describe('Dialog', () => {
     assert.isTrue(icon.exists());
   });
 
-  it('closes when close button is clicked', () => {
+  it('renders cancel and close buttons by default if `onCancel` provided', () => {
+    const onCancel = sinon.stub();
+    const wrapper = mount(<Dialog title="Test dialog" onCancel={onCancel} />);
+
+    assert.isTrue(
+      wrapper.find('LabeledButton[data-testid="cancel-button"]').exists()
+    );
+    assert.isTrue(
+      wrapper.find('IconButton[data-testid="close-button"]').exists()
+    );
+  });
+
+  it('invokes `onCancel` callback when cancel button is clicked', () => {
     const onCancel = sinon.stub();
     const wrapper = mount(<Dialog title="Test dialog" onCancel={onCancel} />);
 
@@ -61,11 +73,38 @@ describe('Dialog', () => {
     assert.called(onCancel);
   });
 
+  it('invokes `onCancel` callback when close button is clicked', () => {
+    const onCancel = sinon.stub();
+    const wrapper = mount(<Dialog title="Test dialog" onCancel={onCancel} />);
+
+    wrapper.find('IconButton[data-testid="close-button"]').props().onClick();
+
+    assert.called(onCancel);
+  });
+
   it(`defaults cancel button's label to "Cancel"`, () => {
     const wrapper = mount(<Dialog onCancel={sinon.stub()} />);
     assert.equal(
       wrapper.find('LabeledButton[data-testid="cancel-button"]').text().trim(),
       'Cancel'
+    );
+  });
+
+  it('does not render a cancel button if `withCancelButton` is disabled', () => {
+    const wrapper = mount(
+      <Dialog onCancel={sinon.stub()} withCancelButton={false} />
+    );
+    assert.isFalse(
+      wrapper.find('LabeledButton[data-testid="cancel-button"]').exists()
+    );
+  });
+
+  it('does not render a close button if `withCloseButton` is disabled', () => {
+    const wrapper = mount(
+      <Dialog onCancel={sinon.stub()} withCloseButton={false} />
+    );
+    assert.isFalse(
+      wrapper.find('IconButton[data-testid="close-button"]').exists()
     );
   });
 

--- a/src/components/test/Modal-test.js
+++ b/src/components/test/Modal-test.js
@@ -19,7 +19,7 @@ describe('Modal', () => {
   });
 
   describe('closing the modal', () => {
-    it('closes when `ESC` pressed', () => {
+    it('closes when `ESC` pressed if `onCancel` is provided', () => {
       const onCancel = sinon.stub();
       const container = document.createElement('div');
       document.body.appendChild(container);
@@ -36,6 +36,48 @@ describe('Modal', () => {
       event.key = 'Escape';
       document.body.dispatchEvent(event);
       assert.called(onCancel);
+      container.remove();
+    });
+
+    it('closes on external click if `onCancel` is provided', () => {
+      const onCancel = sinon.stub();
+      const container = document.createElement('div');
+      document.body.appendChild(container);
+      mount(
+        <Modal title="Test dialog" onCancel={onCancel}>
+          This is my modal
+        </Modal>,
+        {
+          attachTo: container,
+        }
+      );
+
+      const event = new Event('mousedown');
+      document.body.dispatchEvent(event);
+      assert.called(onCancel);
+      container.remove();
+    });
+
+    it('does not close on external click if `closeOnExternalInteraction` disabled', () => {
+      const onCancel = sinon.stub();
+      const container = document.createElement('div');
+      document.body.appendChild(container);
+      mount(
+        <Modal
+          title="Test dialog"
+          onCancel={onCancel}
+          closeOnExternalInteraction={false}
+        >
+          This is my modal
+        </Modal>,
+        {
+          attachTo: container,
+        }
+      );
+
+      const event = new Event('mousedown');
+      document.body.dispatchEvent(event);
+      assert.notCalled(onCancel);
       container.remove();
     });
 

--- a/src/components/test/Modal-test.js
+++ b/src/components/test/Modal-test.js
@@ -39,12 +39,16 @@ describe('Modal', () => {
       container.remove();
     });
 
-    it('closes on external click if `onCancel` is provided', () => {
+    it('closes on external click if `closeOnExternalInteraction` is enabled', () => {
       const onCancel = sinon.stub();
       const container = document.createElement('div');
       document.body.appendChild(container);
       mount(
-        <Modal title="Test dialog" onCancel={onCancel}>
+        <Modal
+          title="Test dialog"
+          onCancel={onCancel}
+          closeOnExternalInteraction={true}
+        >
           This is my modal
         </Modal>,
         {
@@ -58,16 +62,12 @@ describe('Modal', () => {
       container.remove();
     });
 
-    it('does not close on external click if `closeOnExternalInteraction` disabled', () => {
+    it('does not close on external click if `closeOnExternalInteraction` is disabled (default)', () => {
       const onCancel = sinon.stub();
       const container = document.createElement('div');
       document.body.appendChild(container);
       mount(
-        <Modal
-          title="Test dialog"
-          onCancel={onCancel}
-          closeOnExternalInteraction={false}
-        >
+        <Modal title="Test dialog" onCancel={onCancel}>
           This is my modal
         </Modal>,
         {

--- a/src/hooks/test/use-element-should-close-test.js
+++ b/src/hooks/test/use-element-should-close-test.js
@@ -21,9 +21,9 @@ describe('useElementShouldClose', () => {
   ];
 
   // Create a fake component to mount in tests that uses the hook
-  function FakeComponent({ isOpen = true }) {
+  function FakeComponent({ isOpen = true, options = {} }) {
     const myRef = useRef();
-    useElementShouldClose(myRef, isOpen, handleClose);
+    useElementShouldClose(myRef, isOpen, handleClose, options);
     return (
       <div ref={myRef}>
         <button>Hi</button>
@@ -60,6 +60,38 @@ describe('useElementShouldClose', () => {
       // Cleanup of hook should have removed eventListeners, so the callback
       // is not called again
       assert.calledOnce(handleClose);
+    });
+  });
+
+  events.forEach(event => {
+    it(`should not invoke callback if disabled (${event.type})`, () => {
+      const wrapper = createComponent({ options: { enabled: false } });
+
+      act(() => {
+        document.body.dispatchEvent(event);
+      });
+      wrapper.update();
+
+      assert.notCalled(handleClose);
+    });
+  });
+
+  events.forEach(event => {
+    it(`should only respond to keypress events if \`closeOnExternalInteraction\` is false (${event.type})`, () => {
+      const wrapper = createComponent({
+        options: { closeOnExternalInteraction: false },
+      });
+
+      act(() => {
+        document.body.dispatchEvent(event);
+      });
+      wrapper.update();
+
+      if (!event.key) {
+        assert.notCalled(handleClose);
+      } else {
+        assert.calledOnce(handleClose);
+      }
     });
   });
 

--- a/src/pattern-library/components/patterns/DialogComponents.js
+++ b/src/pattern-library/components/patterns/DialogComponents.js
@@ -184,7 +184,7 @@ function NonCloseableModalExample() {
   }
 }
 
-function ModalWithoutHookExample() {
+function ModalWithCloseExample() {
   const [dialogOpen, setDialogOpen] = useState(false);
 
   if (!dialogOpen) {
@@ -199,15 +199,15 @@ function ModalWithoutHookExample() {
   } else {
     return (
       <Modal
-        title="Modal: does not close on external events"
+        title="Modal: closes on external click or focus"
         onCancel={() => setDialogOpen(false)}
-        closeOnExternalInteraction={false}
+        closeOnExternalInteraction={true}
       >
         <p>
           This is a <code>Modal</code> with{' '}
-          <code>closeOnExternalInteraction</code> disabled. You can close it
-          with its close or cancel buttons or pressing ESC, but clicks or focus
-          events outside of the modal will not close it.
+          <code>closeOnExternalInteraction</code> enabled. You can close it with
+          its close or cancel buttons or pressing ESC, but clicks or focus
+          events outside of the modal will <b>also</b> close it.
         </p>
       </Modal>
     );
@@ -339,8 +339,7 @@ export default function DialogComponents() {
         </p>
         <Library.Example title="Basic usage">
           <p>
-            Close the modal by clicking the close (X) button, the cancel button
-            or clicking anywhere outside of it.
+            Close the modal by clicking the close (X) button or pressing ESC.
           </p>
           <Library.Demo>
             <ModalExample />
@@ -351,21 +350,20 @@ export default function DialogComponents() {
           <p>
             By default, if an <code>onCancel</code> callback is provided to{' '}
             <code>Modal</code>, the rendered modal will close if the ESC key is
-            pressed, or if the user clicks outside of the modal, or if focus is
-            moved to outside the modal.
+            pressed.
           </p>
           <p>
-            There are cases when it might not be desirable for external
-            clicks/focus changes to close the modal. The{' '}
-            <code>closeOnExternalInteraction</code> prop can be used to control
-            this.
+            {' '}
+            The <code>closeOnExternalInteraction</code> prop can be used to
+            allow the modal to close if the user clicks outside of the modal, or
+            if focus is moved to outside the modal.
           </p>
           <p>
             If no <code>onCancel</code> is provided, the modal will not close on
             any interaction (unless controlled by the parent).
           </p>
-          <Library.Demo title="Does not close on external events">
-            <ModalWithoutHookExample />
+          <Library.Demo title="Closes on external events">
+            <ModalWithCloseExample />
           </Library.Demo>
 
           <Library.Demo title="Non-closeable modal">

--- a/src/pattern-library/components/patterns/DialogComponents.js
+++ b/src/pattern-library/components/patterns/DialogComponents.js
@@ -63,6 +63,58 @@ function DialogExample() {
   }
 }
 
+function DialogWithoutCancelButtonExample() {
+  const [dialogOpen, setDialogOpen] = useState(false);
+
+  if (!dialogOpen) {
+    return (
+      <LabeledButton
+        onClick={() => setDialogOpen(!dialogOpen)}
+        variant="primary"
+      >
+        Show Dialog Example
+      </LabeledButton>
+    );
+  } else {
+    return (
+      <Dialog
+        icon="edit"
+        onCancel={() => setDialogOpen(false)}
+        title="Dialog: No cancel button"
+        withCancelButton={false}
+      >
+        <p>This is a Dialog that has a close button but no Cancel button.</p>
+      </Dialog>
+    );
+  }
+}
+
+function DialogWithoutCloseButtonExample() {
+  const [dialogOpen, setDialogOpen] = useState(false);
+
+  if (!dialogOpen) {
+    return (
+      <LabeledButton
+        onClick={() => setDialogOpen(!dialogOpen)}
+        variant="primary"
+      >
+        Show Dialog Example
+      </LabeledButton>
+    );
+  } else {
+    return (
+      <Dialog
+        icon="edit"
+        onCancel={() => setDialogOpen(false)}
+        title="Dialog: no close button"
+        withCloseButton={false}
+      >
+        <p>This is a Dialog that has a Cancel button but no close button.</p>
+      </Dialog>
+    );
+  }
+}
+
 function ModalExample() {
   const [dialogOpen, setDialogOpen] = useState(false);
   const focusRef = createRef();
@@ -102,6 +154,61 @@ function ModalExample() {
           <TextInput name="my-input" inputRef={focusRef} />
           <IconButton icon="arrow-right" variant="dark" title="go" />
         </TextInputWithButton>
+      </Modal>
+    );
+  }
+}
+
+function NonCloseableModalExample() {
+  const [dialogOpen, setDialogOpen] = useState(false);
+
+  if (!dialogOpen) {
+    return (
+      <LabeledButton
+        onClick={() => setDialogOpen(!dialogOpen)}
+        variant="primary"
+      >
+        Show Non-Closeable Modal Example
+      </LabeledButton>
+    );
+  } else {
+    return (
+      <Modal title="Sample Modal">
+        <p>
+          This is a <code>Modal</code> with no <code>onCancel</code> callback
+          provided. It cannot be dismissed by interacting with outside elements.
+          You will have to reload the page to dismiss it (sorry).
+        </p>
+      </Modal>
+    );
+  }
+}
+
+function ModalWithoutHookExample() {
+  const [dialogOpen, setDialogOpen] = useState(false);
+
+  if (!dialogOpen) {
+    return (
+      <LabeledButton
+        onClick={() => setDialogOpen(!dialogOpen)}
+        variant="primary"
+      >
+        Show Modal Example
+      </LabeledButton>
+    );
+  } else {
+    return (
+      <Modal
+        title="Modal: does not close on external events"
+        onCancel={() => setDialogOpen(false)}
+        closeOnExternalInteraction={false}
+      >
+        <p>
+          This is a <code>Modal</code> with{' '}
+          <code>closeOnExternalInteraction</code> disabled. You can close it
+          with its close or cancel buttons or pressing ESC, but clicks or focus
+          events outside of the modal will not close it.
+        </p>
       </Modal>
     );
   }
@@ -206,6 +313,23 @@ export default function DialogComponents() {
             <DialogExample />
           </Library.Demo>
         </Library.Example>
+
+        <Library.Example title="Dialog with no cancel or close button">
+          <p>
+            By default, a <code>Dialog</code> will render both a close button
+            (x) and a Cancel button if an <code>onCancel</code> callback is
+            provided, but this can be overridden with the{' '}
+            <code>withCancelButton</code> and <code>withCloseButton</code>{' '}
+            boolean props for the cancel button and close button, respectively.
+          </p>
+          <Library.Demo title="Dialog with no Cancel button">
+            <DialogWithoutCancelButtonExample />
+          </Library.Demo>
+
+          <Library.Demo title="Dialog with no Close button">
+            <DialogWithoutCloseButtonExample />
+          </Library.Demo>
+        </Library.Example>
       </Library.Pattern>
 
       <Library.Pattern title="Modal">
@@ -220,6 +344,32 @@ export default function DialogComponents() {
           </p>
           <Library.Demo>
             <ModalExample />
+          </Library.Demo>
+        </Library.Example>
+
+        <Library.Example title="Controlling how to close the Modal">
+          <p>
+            By default, if an <code>onCancel</code> callback is provided to{' '}
+            <code>Modal</code>, the rendered modal will close if the ESC key is
+            pressed, or if the user clicks outside of the modal, or if focus is
+            moved to outside the modal.
+          </p>
+          <p>
+            There are cases when it might not be desirable for external
+            clicks/focus changes to close the modal. The{' '}
+            <code>closeOnExternalInteraction</code> prop can be used to control
+            this.
+          </p>
+          <p>
+            If no <code>onCancel</code> is provided, the modal will not close on
+            any interaction (unless controlled by the parent).
+          </p>
+          <Library.Demo title="Does not close on external events">
+            <ModalWithoutHookExample />
+          </Library.Demo>
+
+          <Library.Demo title="Non-closeable modal">
+            <NonCloseableModalExample />
           </Library.Demo>
         </Library.Example>
 


### PR DESCRIPTION
This PR contains updates to `Modal`, `Dialog` and the `useElementShouldClose` hook to support several use cases in our applications.

Fixes https://github.com/hypothesis/frontend-shared/issues/139
Part of https://github.com/hypothesis/lms/issues/3139
Related to / a dependency for https://github.com/hypothesis/lms/issues/3106

### Dialog with a close button but no cancel button

I want to be able to replace the `SidebarPanel` `Panel` components in the client with `Dialog` for consistency and the nice focus routing that `Dialog` provides:

![image](https://user-images.githubusercontent.com/439947/135275801-8019c544-e397-4970-b88d-d1305264bfbd.png)

That UI renders a close button but does not render any buttons in the panel/dialog itself. Previous to these changes, the `Dialog` component would always automatically render both a close and a cancel button if an `onCancel` (i.e. close callback) is provided. Now there is granular control via two new props: `withCloseButton` and `withCancelButton` (which default to `true` such that default behavior is unchanged).

#### Similarly, a modal with a cancel button but no close button

In LMS, the `OAuth2RedirectErrorApp` modals have a cancel button (it's labeled "Close" here but it is a "cancel button" from the perspective of the Dialog) but no close ("X") button:

<img width="680" alt="OAuthErrorApp-scope-keys" src="https://user-images.githubusercontent.com/439947/135276571-c455c89f-a2b9-4409-9482-5dfaa2172db1.png">

These changes support this.

### Modal that doesn't close when you click outside of it

When working within assignment-configuration Modals in the LMS, it's easy to accidentally click outside the Modal and close it (e.g. when selecting text in an input field, or navigating across several file folders in the file picker). These changes include a new `Modal` prop: `closeOnExternalInteraction`. When disabled, the Modal (assuming it has an `onCancel` callback) will still close when `ESC` is pressed, but not on other external events.

### Modal that doesn't close at all

This use case is specific to the LMS `ErrorDialogApp` use case, in which a "modal" is displayed but provides no further functionality:

<img width="752" alt="ErrorDialogApp-reused_tool_guid" src="https://user-images.githubusercontent.com/439947/135276358-7c36e3c0-e920-4e7c-8402-ffdc4a49f241.png">

These changes include the ability to not provide an `onCancel` to the `Modal`.

## Testing

These changes include a commit that adds several [new Dialog examples to the pattern library](http://localhost:4001/components-dialogs).

