### PR TITLE
Update margins on spacing patterns

### DIFF
--- a/src/pattern-library/components/patterns/ContainerPatterns.js
+++ b/src/pattern-library/components/patterns/ContainerPatterns.js
@@ -17,9 +17,7 @@ export default function ContainerPatterns() {
           </p>
           <Library.Demo withSource>
             <div className="hyp-frame">
-              <div>
-                Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-              </div>
+              <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
               <div>
                 Sed do eiusmod tempor incididunt ut labore et dolore magna
                 aliqua.
@@ -55,14 +53,14 @@ export default function ContainerPatterns() {
           </p>
           <Library.Demo withSource>
             <div className="hyp-card">
-              <div>
+              <p>
                 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
                 eiusmod tempor incididunt ut labore et dolore magna aliqua.
-              </div>
-              <div>
+              </p>
+              <p>
                 Ut enim ad minim veniam, quis nostrud exercitation ullamco
                 laboris nisi ut aliquip ex ea commodo consequat.
-              </div>
+              </p>
             </div>
           </Library.Demo>
         </Library.Example>
@@ -71,8 +69,10 @@ export default function ContainerPatterns() {
           <p>A card&apos;s hover can be disabled by using a modifying class.</p>
           <Library.Demo withSource>
             <div className="hyp-card--no-hover">
-              Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
-              eiusmod tempor incididunt ut labore et dolore magna aliqua.
+              <p>
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+                eiusmod tempor incididunt ut labore et dolore magna aliqua.
+              </p>
             </div>
           </Library.Demo>
         </Library.Example>
@@ -81,9 +81,7 @@ export default function ContainerPatterns() {
           <p>This example shows a card with some available actions.</p>
           <Library.Demo withSource>
             <div className="hyp-card">
-              <div>
-                Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-              </div>
+              <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
               <div className="hyp-actions">
                 <IconButton title="User" icon="profile" />
                 <IconButton title="Edit" icon="edit" />

--- a/src/pattern-library/components/patterns/PanelComponents.js
+++ b/src/pattern-library/components/patterns/PanelComponents.js
@@ -8,7 +8,9 @@ export default function PanelComponents() {
         <Library.Example title="Basic usage">
           <Library.Demo withSource>
             <Panel title="Basic panel">
-              Here is a panel with no close button and very simple content.
+              <p>
+                Here is a panel with no close button and very simple content.
+              </p>
             </Panel>
           </Library.Demo>
         </Library.Example>
@@ -18,9 +20,11 @@ export default function PanelComponents() {
               title="Basic panel with close button"
               onClose={() => alert('close clicked')}
             >
-              Here is a panel with very basic content and a close button.
-              Providing an <code>onClose</code> function will cause a close
-              button to render.
+              <p>Here is a panel with very basic content and a close button.</p>
+              <p>
+                Providing an <code>onClose</code> function will cause a close
+                button to render.
+              </p>
             </Panel>
           </Library.Demo>
         </Library.Example>

--- a/styles/mixins/_layout.scss
+++ b/styles/mixins/_layout.scss
@@ -85,6 +85,14 @@ $-color-overlay: var.$color-overlay;
   & > :not(:first-child) {
     margin-top: var.space($size);
   }
+
+  & > :first-child {
+    margin-top: 0;
+  }
+
+  & > :last-child {
+    margin-bottom: 0;
+  }
 }
 
 /**
@@ -95,6 +103,14 @@ $-color-overlay: var.$color-overlay;
 @mixin horizontal-spacing($size: 3) {
   & > :not(:first-child) {
     margin-left: var.space($size);
+  }
+
+  & > :first-child {
+    margin-left: 0;
+  }
+
+  & > :last-child {
+    margin-right: 0;
   }
 }
 


### PR DESCRIPTION
This package exports some utility classes that can be applied to a parent element to apply even margins between each of its immediate-child elements. These come in both vertical and horizontal flavors.

Until this point, the pattern asserted the margins _between_ elements but didn't have an opinion about "outside" margins for the first- or last-child elements. These changes update these patterns such that immediate-child elements will be "flush" against the parent container, margin-wise.

The most specific use case this fixes is the case of `<p>` elements, which have a browser-default top and bottom margin. In the `client` application, we use a CSS reset, so `<p>` elements don't have this margin, but we don't reset `<p>` margins in either the `lms` or this project (what combination of normalize and/or reset strategy we _should_ be taking is a conversation for another day). The net result is that in some contexts, using a `<p>` within a container using a spacing pattern could end up with extra margin-gaps at the top or bottom. This got irritating enough (and hard to manage since `<p>` elements behave differently across apps) that I started avoiding using `<p>` tags in examples and I even see one place where I've avoided a `<p>` in an LMS component.

After this change, `<p>` elements do what you'd expect when used inside vertically-spaced containers, and the same should be the case for other elements that have margin rules.

There are no user-visible effects from these changes.

Believe it or not, this is part of https://github.com/hypothesis/lms/issues/3139