### PR TITLE
Update supported browsers list

### DIFF
--- a/.babelrc.cjs
+++ b/.babelrc.cjs
@@ -1,41 +1,35 @@
 'use strict';
 
 module.exports = {
-  "presets": [
+  presets: [
     [
-      "@babel/preset-react",
+      '@babel/preset-react',
       {
-        "runtime": "automatic",
-        "importSource": "preact"
-      }
+        runtime: 'automatic',
+        importSource: 'preact',
+      },
     ],
     [
-      "@babel/preset-env",
+      '@babel/preset-env',
       {
-        "bugfixes": true,
-        "targets": {
-          "chrome": "57",
-          "firefox": "53",
-          "safari": "10.1",
-          "edge": "17"
-        }
-      }
-    ]
+        bugfixes: true,
+      },
+    ],
   ],
-  "env": {
-    "development": {
-      "presets": [
+  env: {
+    development: {
+      presets: [
         [
-          "@babel/preset-react",
+          '@babel/preset-react',
           {
-            "development": true,
-            "runtime": "automatic",
+            development: true,
+            runtime: 'automatic',
             // Use `preact/compat/jsx-dev-runtime` which is an alias for `preact/jsx-runtime`.
             // See https://github.com/preactjs/preact/issues/2974.
-            "importSource": "preact/compat"
-          }
-        ]
-      ]
-    }
-  }
-}
+            importSource: 'preact/compat',
+          },
+        ],
+      ],
+    },
+  },
+};

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
   "peerDependencies": {
     "preact": "^10.4.0"
   },
+  "browserslist": "chrome 70, firefox 70, safari 11",
   "scripts": {
     "build-js": "babel src --out-dir lib --source-maps --ignore '**/test' --ignore '**/karma.config.js'",
     "build": "yarn build-js && tsc --build src/tsconfig.json",


### PR DESCRIPTION
All frontend Hypothesis app are going to have the same base line as
this:

https://github.com/hypothesis/bouncer/pull/469/commits/6a01199bfc196a8932be271f61c07029dbf886c5

In LMS, the `browser_check` bundle is transpiled to an older version of the
browsers.