### PR TITLE
Update CSS normalization

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "mocha": "8.2.1",
     "mustache": "^4.2.0",
     "mustache-express": "^1.3.0",
+    "normalize.css": "^8.0.1",
     "postcss": "^8.2.13",
     "preact": "^10.4.0",
     "prettier": "^2.2.1",

--- a/styles/base/_reset.scss
+++ b/styles/base/_reset.scss
@@ -1,57 +1,5 @@
+@use 'normalize.css/normalize';
 @use '../mixins/reset';
-
-/*
-  Consistency fixes
-  adopted from http://necolas.github.com/normalize.css/
-  */
-
-* {
-  box-sizing: border-box;
-}
-
-html {
-  height: 100%;
-  text-size-adjust: 100%;
-}
-
-body {
-  min-height: 100%;
-  font-size: 100%;
-  margin: 0;
-}
-
-sub,
-sup {
-  font-size: 75%;
-  line-height: 0;
-  position: relative;
-}
-
-sup {
-  top: -0.5em;
-}
-sub {
-  bottom: -0.25em;
-}
-
-pre {
-  white-space: pre;
-  white-space: pre-wrap;
-  word-wrap: break-word;
-}
-
-b,
-strong {
-  font-weight: bold;
-}
-abbr[title] {
-  border-bottom: 1px dotted;
-}
-
-a img,
-img {
-  -ms-interpolation-mode: bicubic;
-}
 
 input,
 textarea,
@@ -60,23 +8,6 @@ select {
   @include reset.reset-font;
   line-height: normal;
   margin: 0;
-}
-
-button,
-html input[type='button'],
-input[type='reset'],
-input[type='submit'] {
-  cursor: pointer;
-  -webkit-appearance: button;
-}
-
-textarea {
-  overflow: auto;
-}
-
-img::selection,
-img::-moz-selection {
-  background: transparent;
 }
 
 ul,

--- a/styles/base/index.scss
+++ b/styles/base/index.scss
@@ -1,2 +1,13 @@
 @use 'reset';
 @use 'elements';
+
+* {
+  box-sizing: border-box;
+}
+
+button,
+input[type='button'],
+input[type='reset'],
+input[type='submit'] {
+  cursor: pointer;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5242,6 +5242,11 @@ normalize-range@^0.1.2:
   resolved "https://registry.yarnpkg.com/normalize-range/-/normalize-range-0.1.2.tgz#2d10c06bdfd312ea9777695a4d28439456b75942"
   integrity sha1-LRDAa9/TEuqXd2laTShDlFa3WUI=
 
+normalize.css@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/normalize.css/-/normalize.css-8.0.1.tgz#9b98a208738b9cc2634caacbc42d131c97487bf3"
+  integrity sha512-qizSNPO93t1YUuUhP22btGOo3chcvDFqFaj2TRybP0DMxkHOCTYwp3n34fel4a31ORXy4m1Xq0Gyqpb5m33qIg==
+
 now-and-later@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/now-and-later/-/now-and-later-2.0.1.tgz"


### PR DESCRIPTION
Part of https://github.com/hypothesis/frontend-shared/issues/208

Replace custom, legacy normalization rules with `normalize.css`, similar to how it's done in the `lms` app.