### PR TITLE
Fix test watch mode

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -56,11 +56,13 @@ function logRollupWarning(warning) {
   log.info(`Rollup warning: ${warning} (${warning.url})`);
 }
 
+async function readConfig(path) {
+  const { default: config } = await import(path);
+  return Array.isArray(config) ? config : [config];
+}
+
 async function buildJS(rollupConfig) {
-  let { default: configs } = await import(rollupConfig);
-  if (!Array.isArray(configs)) {
-    configs = [configs];
-  }
+  const configs = await readConfig(rollupConfig);
 
   await Promise.all(
     configs.map(async config => {
@@ -74,7 +76,8 @@ async function buildJS(rollupConfig) {
 }
 
 async function watchJS(rollupConfig) {
-  const { default: configs } = await import(rollupConfig);
+  const configs = await readConfig(rollupConfig);
+
   const watcher = rollup.watch(
     configs.map(config => ({
       ...config,


### PR DESCRIPTION
`gulp test --watch` failed because `watchJS` assumes the Rollup config exports
an array, but `rollup-tests.config.mjs` exports a single item.

The client and lms repos have the same error and will need the same fix, or to share code that has the same fix.