### PR TITLE
Add types for SVG "modules"

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,8 +62,8 @@
     "build": "yarn build-lib && tsc --build src/tsconfig.json",
     "typecheck": "tsc --build src/tsconfig.json",
     "lint": "eslint .",
-    "checkformatting": "prettier --check '**/*.{js,scss,md}'",
-    "format": "prettier --list-different --write '**/*.{js,scss,md}'",
+    "checkformatting": "prettier --check '**/*.{md,js,scss,ts}'",
+    "format": "prettier --list-different --write '**/*.{md,js,scss,ts}'",
     "test": "gulp test",
     "push": "yarn build && yalc push",
     "changelog": "gulp changelog"

--- a/src/icons.js
+++ b/src/icons.js
@@ -1,5 +1,3 @@
-// @ts-nocheck
-
 export { default as annotate } from '../images/icons/annotate.svg';
 export { default as annotateAlt } from '../images/icons/annotate-alt.svg';
 export { default as arrowDown } from '../images/icons/arrow-down.svg';

--- a/src/svg.d.ts
+++ b/src/svg.d.ts
@@ -1,0 +1,4 @@
+declare module '*.svg' {
+  const markup: string;
+  export default markup;
+}

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -14,7 +14,7 @@
     "noImplicitAny": false,
     "target": "ES2020"
   },
-  "include": ["**/*.js"],
+  "include": ["**/*.js", "svg.d.ts"],
   "exclude": [
     // Tests are not checked.
     "**/test/**/*.js",

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -14,7 +14,7 @@
     "noImplicitAny": false,
     "target": "ES2020"
   },
-  "include": ["**/*.js", "svg.d.ts"],
+  "include": ["**/*.js", "types/*.d.ts"],
   "exclude": [
     // Tests are not checked.
     "**/test/**/*.js",

--- a/src/types/svg.d.ts
+++ b/src/types/svg.d.ts
@@ -1,4 +1,5 @@
 declare module '*.svg' {
   const markup: string;
+
   export default markup;
 }


### PR DESCRIPTION
Declare the type of modules generated from SVG files. Approach cribbed
from https://stackoverflow.com/a/58150006.

The same approach could be used downstream for project-specific icons.