### PR TITLE
Fix demo-source layout and a wayward font rule

### DIFF
--- a/styles/base/index.scss
+++ b/styles/base/index.scss
@@ -1,7 +1,15 @@
 @use 'normalize.css/normalize';
 
+// This is a temporary stand-in until we get a typography layer
+$sans-font-family: 'Helvetica Neue', Helvetica, Arial, 'Lucida Grande',
+  sans-serif;
+
 * {
   box-sizing: border-box;
+}
+
+body {
+  font-family: $sans-font-family;
 }
 
 button,

--- a/styles/library.scss
+++ b/styles/library.scss
@@ -4,6 +4,7 @@
 @use 'variables' as var;
 @use './mixins/layout';
 @use './mixins/atoms';
+@use './mixins/reset';
 @use './mixins/patterns/containers';
 
 .Library {
@@ -29,25 +30,23 @@
     'content';
 
   &__content {
-    padding: 1em;
+    padding: 1rem;
   }
 
   &__sidebar {
     grid-area: 'navigation';
-    max-height: 20em;
+    max-height: 20rem;
     overflow: scroll;
     background-color: var.$color-grey-2;
   }
 
   &__sidebar-home {
     text-align: center;
-    padding: 1em;
+    padding: 1rem;
   }
 
   &__nav {
-    list-style: none;
-    margin: 0;
-    padding: 0;
+    @include reset.reset-list;
   }
 
   &__content {
@@ -57,8 +56,8 @@
 
 .PlaygroundApp__nav-item {
   width: 100%;
-  padding: 1em 2em;
-  font-size: 16px; // TODO: variable later
+  padding: 1rem 2rem;
+  font-size: 1rem;
   &:hover {
     background-color: var.$color-grey-3;
   }
@@ -160,6 +159,23 @@ $-library-vertical-spacing: 7;
   &__source,
   &__demo {
     width: 100%;
+  }
+
+  &__source {
+    @include atoms.border;
+    @include layout.padding;
+    overflow: auto;
+
+    pre {
+      @include reset.reset-box-model;
+      white-space: pre-wrap;
+      font-size: 0.875rem;
+      line-height: 1.35;
+    }
+
+    ul {
+      @include reset.reset-list;
+    }
   }
 
   &__demo-content {

--- a/styles/library.scss
+++ b/styles/library.scss
@@ -68,11 +68,6 @@
   }
 }
 
-// Element styles
-body {
-  font-family: sans-serif;
-}
-
 @media screen and (min-width: 60em) {
   .PlaygroundApp {
     height: 100vh;

--- a/styles/mixins/_reset.scss
+++ b/styles/mixins/_reset.scss
@@ -1,0 +1,10 @@
+@mixin reset-box-model {
+  margin: 0;
+  padding: 0;
+  border: 0;
+}
+
+@mixin reset-list {
+  @include reset-box-model;
+  list-style: none;
+}


### PR DESCRIPTION
This housekeeping PR fixes a visual regression that resulted from removing all CSS resets from the pattern library styles. It adds back some targeted resets on just the affected elements, using a mixin approach used in the `client`. These mixins are not part of the public API, and will almost assuredly evolve.

While in there, I noticed a wayward font rule on a `body` selector in the library-specific styles that shouldn't be there. The `library` SASS module should only contain rules that are scoped to Library components and classes, so that external applications can use them within the context of their own CSS stack. Moving such a rule to the `base` styles, which are only used internally (i.e. by the pattern library served within this package) is safe.

For the source-styling changes, here's it broken before:

![image](https://user-images.githubusercontent.com/439947/139303356-2a9ba0fb-3c8f-4c80-9535-3c7db688797f.png)


And fixed after:

![image](https://user-images.githubusercontent.com/439947/139303307-d89b9100-6c7b-4bf6-87ef-6f1aba25e3a3.png)
