### PR TITLE
Add appropriate ARIA attributes for button role="tab"

### DIFF
--- a/src/components/buttons.js
+++ b/src/components/buttons.js
@@ -16,7 +16,7 @@ import { SvgIcon } from './SvgIcon';
  *   expanded (set `aria-expanded`)
  * @prop {never} [aria-expanded] - Use `expanded` prop instead
  * @prop {boolean} [pressed] - Is this button currently "active?" (set
- *   `aria-pressed`)
+ *   `aria-pressed` or `aria-selected` depending on button `role`)
  * @prop {never} [aria-pressed] - Use `pressed` prop instead
  * @prop {'small'|'medium'|'large'} [size='medium'] - Relative button size:
  *   affects padding
@@ -64,11 +64,19 @@ function ButtonBase({
   type = 'button',
   ...restProps
 }) {
+  const role = restProps?.role ?? 'button';
   const ariaProps = {
-    'aria-expanded': expanded,
-    'aria-pressed': pressed,
     'aria-label': restProps.title,
   };
+
+  // aria-pressed and aria-expanded are not allowed for buttons with
+  // an aria role of `tab`. Instead, the aria-selected attribute is expected.
+  if (role === 'tab') {
+    ariaProps['aria-selected'] = pressed;
+  } else {
+    ariaProps['aria-pressed'] = pressed;
+    ariaProps['aria-expanded'] = expanded;
+  }
 
   return (
     <button

--- a/src/components/test/buttons-test.js
+++ b/src/components/test/buttons-test.js
@@ -188,6 +188,14 @@ function addCommonTests({ componentName, createComponentFn, withIcon = true }) {
       });
     });
   });
+
+  it('provides appropriate aria attributes for buttons with role = "tab"', () => {
+    const wrapper = createComponentFn({ role: 'tab', pressed: true });
+
+    const element = wrapper.find('button').getDOMNode();
+    assert.equal(element.getAttribute('aria-selected'), 'true');
+    assert.isNull(element.getAttribute('aria-pressed'));
+  });
 }
 
 describe('buttons', () => {


### PR DESCRIPTION
It turns out that different ARIA attributes are required to denote
"on"-ness of buttons with a role of "tab." The `aria-pressed` attribute
is disallowed, and the `aria-selected` attribute is required.

Add some logic to support this.

I discovered this problem when attempting to transition the custom `button` in the client's `SelectionTabs` component over to a `LabeledButton`. These buttons are `role="tab"` within a `div role="tablist"` and a11y tests do not pass without this change (they do pass after this change).