### PR TITLE
Update Spinner and add FullScreenSpinner pattern and component

### DIFF
--- a/src/components/Spinner.js
+++ b/src/components/Spinner.js
@@ -2,7 +2,8 @@ import classnames from 'classnames';
 
 // @ts-ignore
 import spinnerSVG from '../../images/icons/spinner--spokes.svg';
-import { registerIcon, SvgIcon } from './SvgIcon';
+import { Icon } from './Icon';
+import { registerIcon } from './SvgIcon';
 
 // Register the spinner icon for use
 const spinnerIcon = registerIcon('spinner', spinnerSVG);
@@ -22,6 +23,9 @@ const spinnerIcon = registerIcon('spinner', spinnerSVG);
 export function Spinner({ classes = '', size = 'medium' }) {
   const baseClass = `Hyp-Spinner--${size}`;
   return (
-    <SvgIcon name={spinnerIcon} className={classnames(baseClass, classes)} />
+    <Icon
+      name={spinnerIcon}
+      containerClasses={classnames(baseClass, classes)}
+    />
   );
 }

--- a/src/components/Spinner.js
+++ b/src/components/Spinner.js
@@ -16,6 +16,12 @@ const spinnerIcon = registerIcon('spinner', spinnerSVG);
  */
 
 /**
+ * @typedef FullScreenSpinnerProps
+ * @prop {string} [classes] - Additional CSS classes to apply
+ * @prop {string} [containerClasses] - CSS classes to apply to wrapping element.
+ */
+
+/**
  * Loading indicator.
  *
  * @param {SpinnerProps} props
@@ -27,5 +33,21 @@ export function Spinner({ classes = '', size = 'medium' }) {
       name={spinnerIcon}
       containerClasses={classnames(baseClass, classes)}
     />
+  );
+}
+
+/**
+ * Full-screen loading indicator.
+ *
+ * @param {FullScreenSpinnerProps} props
+ */
+export function FullScreenSpinner({ classes = '', containerClasses = '' }) {
+  return (
+    <div className={classnames('Hyp-FullScreenSpinner', containerClasses)}>
+      <Spinner
+        classes={classnames('Hyp-FullScreenSpinner__spinner', classes)}
+        size="large"
+      />
+    </div>
   );
 }

--- a/src/components/test/Spinner-test.js
+++ b/src/components/test/Spinner-test.js
@@ -9,25 +9,25 @@ describe('Spinner', () => {
 
   it('renders', () => {
     const wrapper = createSpinner();
-    assert.isTrue(wrapper.find('SvgIcon.Hyp-Spinner--medium').exists());
+    assert.isTrue(wrapper.find('Icon .Hyp-Spinner--medium').exists());
   });
 
   it('uses the registered `hyp-spinner` icon', () => {
     const wrapper = createSpinner();
     assert.equal(
-      wrapper.find('SvgIcon').props().name.toString(),
+      wrapper.find('Icon').props().name.toString(),
       Symbol('spinner').toString()
     );
   });
 
   it('applies additional classes', () => {
     const wrapper = createSpinner({ classes: 'foo bar' });
-    assert.isTrue(wrapper.find('SvgIcon.Hyp-Spinner--medium.foo.bar').exists());
+    assert.isTrue(wrapper.find('Icon .Hyp-Spinner--medium.foo.bar').exists());
   });
 
   it('sets indicated size', () => {
     const wrapper = createSpinner({ size: 'large' });
-    assert.isTrue(wrapper.find('SvgIcon.Hyp-Spinner--large').exists());
+    assert.isTrue(wrapper.find('Icon .Hyp-Spinner--large').exists());
   });
 
   it(

--- a/src/components/test/Spinner-test.js
+++ b/src/components/test/Spinner-test.js
@@ -1,6 +1,6 @@
 import { mount } from 'enzyme';
 
-import { Spinner } from '../Spinner';
+import { FullScreenSpinner, Spinner } from '../Spinner';
 
 import { checkAccessibility } from '../../../test/util/accessibility';
 
@@ -28,6 +28,54 @@ describe('Spinner', () => {
   it('sets indicated size', () => {
     const wrapper = createSpinner({ size: 'large' });
     assert.isTrue(wrapper.find('Icon .Hyp-Spinner--large').exists());
+  });
+
+  it(
+    'should pass a11y checks',
+    checkAccessibility({
+      content: () => createSpinner(),
+    })
+  );
+});
+
+describe('FullScreenSpinner', () => {
+  const createSpinner = (props = {}) => mount(<FullScreenSpinner {...props} />);
+
+  it('renders a containing div', () => {
+    const wrapper = createSpinner();
+    assert.isTrue(wrapper.find('div.Hyp-FullScreenSpinner').exists());
+  });
+
+  it('renders a spinner', () => {
+    const wrapper = createSpinner();
+
+    const spinner = wrapper.find('Spinner');
+    assert.isTrue(spinner.exists());
+    assert.equal(spinner.prop('size'), 'large');
+  });
+
+  it('applies additional classes', () => {
+    const wrapper = createSpinner({ classes: 'foo bar' });
+    const spinner = wrapper.find('Spinner');
+
+    assert.equal(
+      spinner.prop('classes'),
+      'Hyp-FullScreenSpinner__spinner foo bar'
+    );
+  });
+
+  it('applies container classes', () => {
+    const wrapper = createSpinner({ containerClasses: 'foo bar' });
+
+    assert.deepEqual(
+      [
+        ...wrapper
+          .find(`div.Hyp-FullScreenSpinner.foo.bar`)
+          .getDOMNode()
+          .classList.values(),
+      ],
+      ['Hyp-FullScreenSpinner', 'foo', 'bar']
+    );
   });
 
   it(

--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,7 @@ export { Icon } from './components/Icon';
 export { Link } from './components/Link';
 export { Modal, ConfirmModal } from './components/Modal';
 export { Panel } from './components/Panel';
-export { Spinner } from './components/Spinner';
+export { FullScreenSpinner, Spinner } from './components/Spinner';
 export { SvgIcon, registerIcon, registerIcons } from './components/SvgIcon';
 export { Table } from './components/Table';
 export { TextInput, TextInputWithButton } from './components/TextInput';

--- a/src/pattern-library/components/patterns/SpinnerComponents.js
+++ b/src/pattern-library/components/patterns/SpinnerComponents.js
@@ -1,7 +1,12 @@
-import { Spinner } from '../../..';
+import { useState } from 'preact/hooks';
+
+import { FullScreenSpinner, LabeledButton, Spinner } from '../../..';
 import Library from '../Library';
 
 export default function SpinnerComponents() {
+  const [fullScreenSpinnerVisible, setFullScreenSpinnerVisible] = useState(
+    false
+  );
   return (
     <Library.Page title="Spinner">
       <p>
@@ -22,6 +27,22 @@ export default function SpinnerComponents() {
         <Library.Example title="Large size">
           <Library.Demo withSource>
             <Spinner size="large" />
+          </Library.Demo>
+        </Library.Example>
+      </Library.Pattern>
+
+      <Library.Pattern title="Full-Screen Spinner">
+        <Library.Example>
+          <p>
+            A component that renders a full-screen spinner over an overlay. Note
+            that this page has to be reloaded to clear the full-screen spinner
+            after showing it.
+          </p>
+          <Library.Demo>
+            <LabeledButton onClick={() => setFullScreenSpinnerVisible(true)}>
+              Show Full-Screen Spinner
+            </LabeledButton>
+            {fullScreenSpinnerVisible && <FullScreenSpinner />}
           </Library.Demo>
         </Library.Example>
       </Library.Pattern>

--- a/src/pattern-library/components/patterns/SpinnerComponents.js
+++ b/src/pattern-library/components/patterns/SpinnerComponents.js
@@ -1,11 +1,24 @@
-import { useState } from 'preact/hooks';
+import { useRef, useState } from 'preact/hooks';
 
 import { FullScreenSpinner, LabeledButton, Spinner } from '../../..';
+import { useElementShouldClose } from '../../../hooks/use-element-should-close';
 import Library from '../Library';
 
 export default function SpinnerComponents() {
   const [fullScreenSpinnerVisible, setFullScreenSpinnerVisible] = useState(
     false
+  );
+
+  const fullScreenSpinnerContainerRef = useRef(
+    /** @type {HTMLDivElement | null} */ (null)
+  );
+
+  useElementShouldClose(
+    fullScreenSpinnerContainerRef,
+    true /* isOpen */,
+    () => {
+      setFullScreenSpinnerVisible(false);
+    }
   );
   return (
     <Library.Page title="Spinner">
@@ -34,15 +47,18 @@ export default function SpinnerComponents() {
       <Library.Pattern title="Full-Screen Spinner">
         <Library.Example>
           <p>
-            A component that renders a full-screen spinner over an overlay. Note
-            that this page has to be reloaded to clear the full-screen spinner
-            after showing it.
+            A component that renders a full-screen spinner over an overlay.
+            Press <code>ESC</code> to hide the spinner.
           </p>
           <Library.Demo>
             <LabeledButton onClick={() => setFullScreenSpinnerVisible(true)}>
               Show Full-Screen Spinner
             </LabeledButton>
-            {fullScreenSpinnerVisible && <FullScreenSpinner />}
+            {fullScreenSpinnerVisible && (
+              <div ref={fullScreenSpinnerContainerRef}>
+                <FullScreenSpinner />
+              </div>
+            )}
           </Library.Demo>
         </Library.Example>
       </Library.Pattern>

--- a/src/pattern-library/components/patterns/SpinnerPatterns.js
+++ b/src/pattern-library/components/patterns/SpinnerPatterns.js
@@ -1,7 +1,12 @@
-import { SvgIcon } from '../../..';
+import { useState } from 'preact/hooks';
+
+import { Icon, LabeledButton } from '../../..';
 import Library from '../Library';
 
 export default function SpinnerPatterns() {
+  const [fullScreenSpinnerVisible, setFullScreenSpinnerVisible] = useState(
+    false
+  );
   return (
     <Library.Page title="Spinners">
       <p>
@@ -21,7 +26,7 @@ export default function SpinnerPatterns() {
             At its default size, the spinner is <code>2em</code> square.
           </p>
           <Library.Demo withSource>
-            <SvgIcon name="hyp-spinner" className="hyp-spinner" />
+            <Icon name="hyp-spinner" containerClasses="hyp-spinner" />
           </Library.Demo>
         </Library.Example>
         <Library.Example title="Small size">
@@ -29,7 +34,7 @@ export default function SpinnerPatterns() {
             Small spinners are <code>1em</code> square and can be used inline.
           </p>
           <Library.Demo withSource>
-            <SvgIcon name="hyp-spinner" className="hyp-spinner--small" />
+            <Icon name="hyp-spinner" containerClasses="hyp-spinner--small" />
           </Library.Demo>
         </Library.Example>
         <Library.Example title="Large size">
@@ -37,7 +42,7 @@ export default function SpinnerPatterns() {
             Large spinners are <code>4em</code> square.
           </p>
           <Library.Demo withSource>
-            <SvgIcon name="hyp-spinner" className="hyp-spinner--large" />
+            <Icon name="hyp-spinner" containerClasses="hyp-spinner--large" />
           </Library.Demo>
         </Library.Example>
 
@@ -46,10 +51,33 @@ export default function SpinnerPatterns() {
             The color of the spinner may be changed by use of utility classes.
           </p>
           <Library.Demo withSource>
-            <SvgIcon
+            <Icon
               name="hyp-spinner"
-              className="hyp-spinner hyp-u-color--brand"
+              containerClasses="hyp-spinner hyp-u-color--brand"
             />
+          </Library.Demo>
+        </Library.Example>
+      </Library.Pattern>
+
+      <Library.Pattern title="Full Screen Spinner">
+        <Library.Example>
+          <p>
+            The full-screen spinner pattern centers a large spinner in a light
+            overlay. Note that this page must be reloaded to clear the full
+            screen spinner after showing it.
+          </p>
+          <Library.Demo>
+            <LabeledButton onClick={() => setFullScreenSpinnerVisible(true)}>
+              Show Full-Screen Spinner
+            </LabeledButton>
+            {fullScreenSpinnerVisible && (
+              <div className="hyp-full-screen-spinner">
+                <Icon
+                  name="hyp-spinner"
+                  containerClasses="hyp-spinner--large hyp-full-screen-spinner__spinner"
+                />
+              </div>
+            )}
           </Library.Demo>
         </Library.Example>
       </Library.Pattern>

--- a/src/pattern-library/components/patterns/SpinnerPatterns.js
+++ b/src/pattern-library/components/patterns/SpinnerPatterns.js
@@ -1,12 +1,26 @@
-import { useState } from 'preact/hooks';
+import { useRef, useState } from 'preact/hooks';
 
 import { Icon, LabeledButton } from '../../..';
+import { useElementShouldClose } from '../../../hooks/use-element-should-close';
 import Library from '../Library';
 
 export default function SpinnerPatterns() {
   const [fullScreenSpinnerVisible, setFullScreenSpinnerVisible] = useState(
     false
   );
+
+  const fullScreenSpinnerContainerRef = useRef(
+    /** @type {HTMLDivElement | null} */ (null)
+  );
+
+  useElementShouldClose(
+    fullScreenSpinnerContainerRef,
+    true /* isOpen */,
+    () => {
+      setFullScreenSpinnerVisible(false);
+    }
+  );
+
   return (
     <Library.Page title="Spinners">
       <p>
@@ -63,15 +77,17 @@ export default function SpinnerPatterns() {
         <Library.Example>
           <p>
             The full-screen spinner pattern centers a large spinner in a light
-            overlay. Note that this page must be reloaded to clear the full
-            screen spinner after showing it.
+            overlay. Press <code>ESC</code> to hide the spinner.
           </p>
           <Library.Demo>
             <LabeledButton onClick={() => setFullScreenSpinnerVisible(true)}>
               Show Full-Screen Spinner
             </LabeledButton>
             {fullScreenSpinnerVisible && (
-              <div className="hyp-full-screen-spinner">
+              <div
+                className="hyp-full-screen-spinner"
+                ref={fullScreenSpinnerContainerRef}
+              >
                 <Icon
                   name="hyp-spinner"
                   containerClasses="hyp-spinner--large hyp-full-screen-spinner__spinner"

--- a/styles/components/Spinner.scss
+++ b/styles/components/Spinner.scss
@@ -12,3 +12,7 @@
 .Hyp-Spinner--large {
   @include spinners.spinner($size: 'large');
 }
+
+.Hyp-FullScreenSpinner {
+  @include spinners.full-screen-spinner;
+}

--- a/styles/mixins/_layout.scss
+++ b/styles/mixins/_layout.scss
@@ -1,6 +1,7 @@
 @use '../variables' as var;
 
 $-color-overlay: var.$color-overlay;
+$-color-overlay--light: var.$color-overlay--light;
 
 /**
  * Apply a margin to all sides (default) or designated `$side` in specified
@@ -138,12 +139,16 @@ $-color-overlay: var.$color-overlay;
 /**
  * Semi-opaque overlay, full-viewport
  */
-@mixin overlay {
+@mixin overlay($variant: 'dark') {
+  $-background: $-color-overlay;
+  @if ($variant == 'light') {
+    $-background: $-color-overlay--light;
+  }
   z-index: 10;
   position: fixed;
   top: 0;
   left: 0;
   bottom: 0;
   right: 0;
-  background-color: $-color-overlay;
+  background-color: $-background;
 }

--- a/styles/mixins/patterns/_spinners.scss
+++ b/styles/mixins/patterns/_spinners.scss
@@ -15,6 +15,5 @@
   }
   color: var.$color-grey-6;
   // Assure that the spinner SVG is sized proportinally to local font-size
-  width: $-size;
-  height: $-size;
+  font-size: $-size;
 }

--- a/styles/mixins/patterns/_spinners.scss
+++ b/styles/mixins/patterns/_spinners.scss
@@ -1,7 +1,9 @@
 @use '../../variables' as var;
 
+@use '../layout';
+
 /**
- * Style an SVG as a loading spinner
+ * Style an svg icon as a loading spinner
  *
  * @param {'small'|'medium'|'large'} [$size='medium'] - Relative size of
  *   spinner image
@@ -16,4 +18,17 @@
   color: var.$color-grey-6;
   // Assure that the spinner SVG is sized proportinally to local font-size
   font-size: $-size;
+}
+
+/**
+ * Style a container with an svg.&__spinner as a full-screen loading spinner,
+ * by applying an overlay to the container and fixed-centered positioning to
+ * the contained svg icon
+ */
+@mixin full-screen-spinner() {
+  @include layout.overlay($variant: 'light');
+
+  &__spinner {
+    @include layout.fixed-centered;
+  }
 }

--- a/styles/patterns/_spinners.scss
+++ b/styles/patterns/_spinners.scss
@@ -12,3 +12,7 @@
 .hyp-spinner--large {
   @include spinners.spinner($size: 'large');
 }
+
+.hyp-full-screen-spinner {
+  @include spinners.full-screen-spinner;
+}

--- a/styles/variables/_colors.scss
+++ b/styles/variables/_colors.scss
@@ -39,5 +39,6 @@ $link: $brand;
 $link--hover: $brand--dark;
 
 $overlay: color.scale($black, $alpha: -50%);
+$overlay--light: color.scale($white, $alpha: -50%);
 $shadow: color.scale($black, $alpha: -90%);
 $shadow--dark: color.scale($black, $alpha: -85%);


### PR DESCRIPTION
This PR updates `Spinner` to use `Icon` instead of `SvgIcon` and adds a new `FullScreenSpinner` component and associated pattern, as well as examples in the pattern library.

Motivation: LMS' local `FullScreenSpinner` is the last use of `SvgIcon` in that project, and updating components here to use `Icon` instead of `SvgIcon` is part of icon-transition work.

Fixes https://github.com/hypothesis/frontend-shared/issues/194
Part of https://github.com/hypothesis/frontend-shared/issues/229

To see the new pattern and component in action, spin up your local and visit the [new pattern page](http://localhost:4001/patterns-spinners) and the [new component page](http://localhost:4001/components-spinner).