### PR TITLE
Enable tailwind for local pattern-library

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -2,6 +2,7 @@ import { buildCSS, run, runTests, watchJS } from '@hypothesis/frontend-build';
 import gulp from 'gulp';
 
 import { servePatternLibrary } from './scripts/serve-pattern-library.js';
+import tailwindConfig from './tailwind.config.js';
 
 /**
  * Task to output a draft changelog to be appended to CHANGELOG.md at the
@@ -32,12 +33,21 @@ gulp.task('serve-pattern-library', () => {
 // The following tasks bundle assets for the pattern library for use locally
 // during development. Bundled JS and CSS are not published with the package.
 
-gulp.task('bundle-css', () => buildCSS(['./styles/pattern-library.scss']));
+gulp.task('bundle-css', () =>
+  buildCSS(['./styles/pattern-library.scss'], { tailwindConfig })
+);
 
 gulp.task(
   'watch-css',
   gulp.series('bundle-css', () =>
-    gulp.watch('./styles/**/*.scss', gulp.task('bundle-css'))
+    gulp.watch(
+      [
+        './styles/**/*.scss',
+        './src/components/**/*.js',
+        './src/pattern-library/**/*.js',
+      ],
+      gulp.task('bundle-css')
+    )
   )
 );
 
@@ -53,7 +63,9 @@ gulp.task(
  *
  * nb. This is only used for unit tests that need CSS to verify accessibility requirements.
  */
-gulp.task('build-test-css', () => buildCSS(['styles/index.scss']));
+gulp.task('build-test-css', () =>
+  buildCSS(['styles/index.scss'], { tailwindConfig })
+);
 
 // Some (eg. a11y) tests rely on CSS bundles. We assume that JS will always take
 // longer to build than CSS, so build in parallel.

--- a/styles/pattern-library.scss
+++ b/styles/pattern-library.scss
@@ -4,8 +4,10 @@
  * styles and pattern styles.
  */
 @use 'base';
+@use 'tailwindcss/base' as tw_base;
 @use 'index'; // component styles
 @use 'patterns';
 @use 'util';
+@use 'tailwindcss/utilities';
 
 @use 'library';

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -3,4 +3,7 @@ import tailwindPreset from './src/tailwind.preset.js';
 export default {
   presets: [tailwindPreset],
   content: ['./src/**/*.js', './templates/**/*.mustache'],
+  corePlugins: {
+    preflight: false,
+  },
 };


### PR DESCRIPTION
Update gulp tasks and pattern-library SCSS entry point to enable tailwind and the `base` and `utilities` layers. This follows how we enabled tailwind on other projects.

Disable `preflight` (CSS normalize/reset) just for the moment. We'll get there soon.

This has no net effect on anything visible yet. It will eliminate the `darkMode` warning in the console that is currently on `master` (it's being fixed upstream in `frontend-build` but these changes also "fix" it).