### PR TITLE
Extend tailwind preset with more goodies and support

### DIFF
--- a/src/tailwind.preset.js
+++ b/src/tailwind.preset.js
@@ -1,3 +1,5 @@
+import plugin from 'tailwindcss/plugin.js';
+
 import colors from 'tailwindcss/colors.js';
 
 export default {
@@ -34,4 +36,13 @@ export default {
       },
     },
   },
+  plugins: [
+    plugin(({ addVariant }) => {
+      // Add a custom variant such that the `theme-clean:` modifier is available
+      // for all tailwind utility classes. e.g. `.theme-clean:bg-white` would
+      // only apply (set the element's background color to white) if a parent
+      // element had the `.theme-clean` class.
+      addVariant('theme-clean', '.theme-clean &');
+    }),
+  ],
 };

--- a/src/tailwind.preset.js
+++ b/src/tailwind.preset.js
@@ -3,6 +3,9 @@ import colors from 'tailwindcss/colors.js';
 export default {
   theme: {
     extend: {
+      borderColor: {
+        DEFAULT: '#dbdbdb',
+      },
       colors: {
         transparent: 'transparent',
         current: 'currentColor',

--- a/src/tailwind.preset.js
+++ b/src/tailwind.preset.js
@@ -23,13 +23,19 @@ export default {
         'grey-7': '#595959',
         'grey-8': '#3f3f3f',
         'grey-9': '#202020',
+        green: {
+          success: '#00a36d',
+        },
+        yellow: {
+          notice: '#fbc168',
+        },
+        red: {
+          error: '#d93c3f',
+        },
         brand: {
           dark: '#84141e',
           DEFAULT: '#bd1c2b',
         },
-        success: '#00a36d',
-        notice: '#fbc168',
-        error: '#d93c3f',
       },
       spacing: {
         'touch-minimum': '44px', // Equivalent to spacing 11; minimum touch-target size

--- a/src/tailwind.preset.js
+++ b/src/tailwind.preset.js
@@ -2,31 +2,33 @@ import colors from 'tailwindcss/colors.js';
 
 export default {
   theme: {
-    colors: {
-      transparent: 'transparent',
-      current: 'currentColor',
-      white: colors.white,
-      black: colors.black,
-      'grey-0': '#fafafa',
-      'grey-1': '#f2f2f2',
-      'grey-2': '#ececec',
-      'grey-3': '#dbdbdb',
-      'grey-4': '#a6a6a6',
-      'grey-5': '#9c9c9c',
-      'grey-6': '#737373',
-      'grey-7': '#595959',
-      'grey-8': '#3f3f3f',
-      'grey-9': '#202020',
-      brand: {
-        dark: '#84141e',
-        DEFAULT: '#bd1c2b',
+    extend: {
+      colors: {
+        transparent: 'transparent',
+        current: 'currentColor',
+        white: colors.white,
+        black: colors.black,
+        'grey-0': '#fafafa',
+        'grey-1': '#f2f2f2',
+        'grey-2': '#ececec',
+        'grey-3': '#dbdbdb',
+        'grey-4': '#a6a6a6',
+        'grey-5': '#9c9c9c',
+        'grey-6': '#737373',
+        'grey-7': '#595959',
+        'grey-8': '#3f3f3f',
+        'grey-9': '#202020',
+        brand: {
+          dark: '#84141e',
+          DEFAULT: '#bd1c2b',
+        },
+        success: '#00a36d',
+        notice: '#fbc168',
+        error: '#d93c3f',
       },
-      success: '#00a36d',
-      notice: '#fbc168',
-      error: '#d93c3f',
-    },
-    spacing: {
-      'touch-minimum': '44px', // Equivalent to spacing 11; minimum touch-target size
+      spacing: {
+        'touch-minimum': '44px', // Equivalent to spacing 11; minimum touch-target size
+      },
     },
   },
 };


### PR DESCRIPTION
This PR fleshes out the shared tailwind preset (design token/value definitions):

* Extends instead of replaces theme values to make sure all tailwind utilities are available
* Adds a default `borderColor` such that using Tailwind's `border` utility class alone without modification will have the same net effect as the current `hyp-u-border` (applies correct border width and color)
* Adds a variant to allow for styling the clean theme
* Renames state-related colors in the same manner as https://github.com/hypothesis/lms/pull/3554

These changes are _additive_ and don't cause any visible changes. Just getting ducks in a row. The next set of PRs will show these in action.