### PR TITLE
Update node setup action and version

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -10,9 +10,9 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
     - name: Setup Nodejs
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v2
       with:
-        node-version: '12.x'
+        node-version: '16'
         registry-url: 'https://registry.npmjs.org'
     - name: Install
       run: yarn install --frozen-lockfile


### PR DESCRIPTION
Use `@v2` of `setup-node` and update version to `16`. We can debate perhaps using an `lts` alias instead of a specific version at some point...