### PR TITLE
Add a few slate greys to the preset colors

### DIFF
--- a/src/pattern-library/components/patterns/ColorFoundations.js
+++ b/src/pattern-library/components/patterns/ColorFoundations.js
@@ -36,6 +36,14 @@ const greyExamples = (
   </>
 );
 
+const slateExamples = (
+  <>
+    <ColorSwatch colorClass="bg-slate-1" colorName="slate-1" />
+    <ColorSwatch colorClass="bg-slate-3" colorName="slate-3" />
+    <ColorSwatch colorClass="bg-slate-7" colorName="slate-7" />
+  </>
+);
+
 const stateExamples = (
   <>
     <ColorSwatch colorClass="bg-green-success" colorName="green-success" />
@@ -53,6 +61,14 @@ export default function ColorFoundations() {
 
       <Library.Pattern title="Greys">
         <div className="flex flex-row flex-wrap gap-4">{greyExamples}</div>
+      </Library.Pattern>
+
+      <Library.Pattern title="Slates">
+        <p>
+          These slightly blue greys may be used sparingly to help with
+          differentiation and clarity within interfaces.
+        </p>
+        <div className="flex flex-row flex-wrap gap-4">{slateExamples}</div>
       </Library.Pattern>
 
       <Library.Pattern title="State indicators">

--- a/src/pattern-library/components/patterns/ColorFoundations.js
+++ b/src/pattern-library/components/patterns/ColorFoundations.js
@@ -40,6 +40,7 @@ const slateExamples = (
   <>
     <ColorSwatch colorClass="bg-slate-1" colorName="slate-1" />
     <ColorSwatch colorClass="bg-slate-3" colorName="slate-3" />
+    <ColorSwatch colorClass="bg-slate-5" colorName="slate-5" />
     <ColorSwatch colorClass="bg-slate-7" colorName="slate-7" />
   </>
 );

--- a/src/pattern-library/components/patterns/IconFoundations.js
+++ b/src/pattern-library/components/patterns/IconFoundations.js
@@ -19,7 +19,7 @@ export default function IconFoundations() {
           {Object.keys(icons).map(iconName => (
             <Card
               key={iconName}
-              classes="flex flex-col items-center bg-grey-0 border-[#9c9cab] space-y-3 rounded-lg"
+              classes="flex flex-col items-center bg-grey-0 border-slate-5 space-y-3 rounded-lg"
             >
               <div style="text-lg">
                 <Icon name={icons[iconName]} />

--- a/src/tailwind.preset.js
+++ b/src/tailwind.preset.js
@@ -29,7 +29,7 @@ export default {
           //0: '#f4f4f6', Proposed
           1: '#e3e3e5',
           3: '#babac4',
-          //5: '#9c9cab', Proposed
+          5: '#9c9cab',
           7: '#595969',
           //9: '#131316', Proposed
         },

--- a/src/tailwind.preset.js
+++ b/src/tailwind.preset.js
@@ -13,16 +13,26 @@ export default {
         current: 'currentColor',
         white: colors.white,
         black: colors.black,
-        'grey-0': '#fafafa',
-        'grey-1': '#f2f2f2',
-        'grey-2': '#ececec',
-        'grey-3': '#dbdbdb',
-        'grey-4': '#a6a6a6',
-        'grey-5': '#9c9c9c',
-        'grey-6': '#737373',
-        'grey-7': '#595959',
-        'grey-8': '#3f3f3f',
-        'grey-9': '#202020',
+        grey: {
+          0: '#fafafa',
+          1: '#f2f2f2',
+          2: '#ececec',
+          3: '#dbdbdb',
+          4: '#a6a6a6',
+          5: '#9c9c9c',
+          6: '#737373',
+          7: '#595959',
+          8: '#3f3f3f',
+          9: '#202020',
+        },
+        slate: {
+          //0: '#f4f4f6', Proposed
+          1: '#e3e3e5',
+          3: '#babac4',
+          //5: '#9c9cab', Proposed
+          7: '#595969',
+          //9: '#131316', Proposed
+        },
         green: {
           success: '#00a36d',
         },


### PR DESCRIPTION
A few years ago, Jared introduced some proposed slatey blue-greys to our proposed color palette: https://hypothesis-pattern-library.netlify.app/helpers (the "base" colors here).

There are just a few component patterns that have started making use of these colors (most specifically: `Table`). I'd like to get them sorted out and in our defined palette.

This PR defines slate colors for "values" 1, 3, 5 and 7. These slates are still nascent and only used in a few places.

Pattern library after these changes:

![image](https://user-images.githubusercontent.com/439947/152171840-91f2e418-4cd7-49a1-ac0f-4e7f9aa85e87.png)
