### PR TITLE
Forward HTML attributes for div-based presentational components

### DIFF
--- a/src/components/Table.js
+++ b/src/components/Table.js
@@ -165,7 +165,7 @@ export function Table({
     <Scrollbox
       withHeader
       classes={classnames('Hyp-Table-Scrollbox', containerClasses)}
-      containerRef={scrollboxRef}
+      elementRef={scrollboxRef}
     >
       <table
         aria-label={accessibleLabel}

--- a/src/components/containers.js
+++ b/src/components/containers.js
@@ -1,31 +1,46 @@
-/**
- * Components for laying out content within a consistently-styled container
- */
-
 import classnames from 'classnames';
 
 import { downcastRef } from '../util/typing';
 
 /**
+ * Components for laying out content within a consistently-styled container
+ */
+
+/**
  * @typedef {import('preact').ComponentChildren} Children
+ * @typedef {import('preact').JSX.HTMLAttributes<HTMLDivElement>} HTMLDivAttributes
+ * @typedef {import('preact').Ref<HTMLElement>} ElementRef
+ */
+
+/**
+ * @typedef CommonPresentationalProps
+ * @prop {Children} [children]
+ * @prop {string|string[]} [classes] - Optional extra CSS classes to append to
+ *   the component's default classes
+ * @prop {ElementRef} [containerRef] - Deprecated; use
+ *   `elementRef` instead.
+ * @prop {ElementRef} [elementRef]
  *
- * @typedef ContainerProps
- * @prop {Children} children
- * @prop {string} [classes] - Additional CSS classes to apply
- * @prop {import('preact').Ref<HTMLElement>} [containerRef] - Access to the
- *  wrapping element.
+ * @typedef {HTMLDivAttributes & CommonPresentationalProps} PresentationalProps
  */
 
 /**
  * Render content inside of a "frame"
  *
- * @param {ContainerProps} props
+ * @param {PresentationalProps} props
  */
-export function Frame({ children, classes = '', containerRef }) {
+export function Frame({
+  children,
+  classes,
+  containerRef,
+  elementRef,
+  ...restProps
+}) {
   return (
     <div
       className={classnames('Hyp-Frame', classes)}
-      ref={downcastRef(containerRef)}
+      {...restProps}
+      ref={downcastRef(elementRef ?? containerRef)}
     >
       {children}
     </div>
@@ -35,43 +50,46 @@ export function Frame({ children, classes = '', containerRef }) {
 /**
  * Render content inside of a "card"
  *
- * @param {ContainerProps} props
+ * @param {PresentationalProps} props
  */
-export function Card({ children, classes = '', containerRef }) {
+export function Card({
+  children,
+  classes,
+  containerRef,
+  elementRef,
+  ...restProps
+}) {
   return (
     <div
       className={classnames('Hyp-Card', classes)}
-      ref={downcastRef(containerRef)}
+      {...restProps}
+      ref={downcastRef(elementRef ?? containerRef)}
     >
       {children}
     </div>
   );
 }
-
-/**
- *
- * @typedef ActionBaseProps
- * @prop {'row'|'column'} [direction='row'] - Lay out the actions horizontally (row)
- *   or vertically (column)
- */
 
 /**
  * Render a set of actions (typically buttons) laid out either horizontally
  * by default or vertically.
  *
- * @param {ActionBaseProps & ContainerProps} props
+ * @param {{ direction?: 'row'|'column'} & PresentationalProps} props
  */
 export function Actions({
   children,
   direction = 'row',
-  classes = '',
+  classes,
   containerRef,
+  elementRef,
+  ...restProps
 }) {
   const baseClass = `Hyp-Actions--${direction}`;
   return (
     <div
       className={classnames(baseClass, classes)}
-      ref={downcastRef(containerRef)}
+      {...restProps}
+      ref={downcastRef(elementRef ?? containerRef)}
     >
       {children}
     </div>
@@ -79,28 +97,25 @@ export function Actions({
 }
 
 /**
- *
- * @typedef ScrollboxBaseProps
- * @prop {boolean} [withHeader=false] - Provide layout affordances for a sticky
- *   header in the scrollable content
- */
-
-/**
  * Render a scrollable container to contain content that might overflow.
+ * Optionally provide styling affordances for a sticky header (`withHeader`).
  *
- * @param {ScrollboxBaseProps & ContainerProps} props
+ * @param {{withHeader?: boolean} & PresentationalProps} props
  */
 export function Scrollbox({
   children,
-  classes = '',
+  classes,
   containerRef,
+  elementRef,
   withHeader = false,
+  ...restProps
 }) {
   const baseClass = withHeader ? 'Hyp-Scrollbox--with-header' : 'Hyp-Scrollbox';
   return (
     <div
       className={classnames(baseClass, classes)}
-      ref={downcastRef(containerRef)}
+      {...restProps}
+      ref={downcastRef(elementRef ?? containerRef)}
     >
       {children}
     </div>

--- a/src/components/test/containers-test.js
+++ b/src/components/test/containers-test.js
@@ -32,11 +32,28 @@ describe('Container components', () => {
       );
     });
 
-    it('passes along a `ref` to the input element through `containerRef`', () => {
+    it('passes along a `ref` to the input element through `elementRef`', () => {
+      const elementRef = createRef();
+      createComponent(Component, { elementRef });
+
+      assert.instanceOf(elementRef.current, Node);
+    });
+
+    it('passes along a `ref` to the input element through deprecated `containerRef`', () => {
       const containerRef = createRef();
       createComponent(Component, { containerRef });
 
       assert.instanceOf(containerRef.current, Node);
+    });
+
+    it('forwards HTML attributes', () => {
+      const wrapper = createComponent(Component, {
+        'data-testid': 'test-identifier',
+      });
+
+      const divEl = wrapper.find('div').first().getDOMNode();
+
+      assert.equal(divEl.getAttribute('data-testid'), 'test-identifier');
     });
   };
 


### PR DESCRIPTION
I had hoped to defer updates to this package's components until "Phase IV" of the current "applied design updates" (we're in "Phase III", in which _application_ components are being converted to Tailwind, etc.), but I have a need to use the `Card` component from this package in a place where it wouldn't be be usable without HTML attribute forwarding (specifically, the `ThreadCard` component in the client's sidebar).

This PR attempts to:

- Add attribute forwarding for `div`-based "container" components in this package
- Prefer naming `elementRef` to `containerRef` for ref forwarding
- Adjust typing and a few bits and bobs to reflect more recent conventions (i.e. "what we've learned lately")

Out of scope for now, in order to keep this quick and allow for more "learning" before we cast any of this in stone:

- DRYing out these components. I acknowledge there is a fair amount of boilerplate and repeated props. I am OK with this for now as it is contained within a single component module.
- Likewise, generating these components with another mechanism as we're exploring in the `client` right now...
- Anything to do with Tailwind whatsoever. These components still use SASS styling. We'll get to that later!