### PR TITLE
Provide `.focus-visible-ring` utility

### DIFF
--- a/src/pattern-library/components/patterns/UtilityFoundations.js
+++ b/src/pattern-library/components/patterns/UtilityFoundations.js
@@ -1,0 +1,26 @@
+import Library from '../Library';
+
+export default function UtilityFoundations() {
+  return (
+    <Library.Page title="Utilities">
+      <Library.Pattern title="Focus rings">
+        <Library.Example title="Custom focus-visible ring">
+          <p>
+            The <code>.focus-visible-ring</code> utility class customizes an
+            interactive element&apos;s focus ring such that it is only visible
+            when the element has <code>:focus-visible</code> or the polyfilled
+            equivalent for browsers that do not support{' '}
+            <code>:focus-visible</code>.
+          </p>
+          <Library.Demo
+            title="input and button with .focus-visible-ring"
+            withSource
+          >
+            <input type="text" className="border focus-visible-ring" />
+            <button className="focus-visible-ring">Button</button>
+          </Library.Demo>
+        </Library.Example>
+      </Library.Pattern>
+    </Library.Page>
+  );
+}

--- a/src/pattern-library/routes.js
+++ b/src/pattern-library/routes.js
@@ -3,6 +3,7 @@ import LibraryHome from './components/LibraryHome';
 import ColorFoundations from './components/patterns/ColorFoundations';
 import IconFoundations from './components/patterns/IconFoundations';
 import LayoutFoundations from './components/patterns/LayoutFoundations';
+import UtilityFoundations from './components/patterns/UtilityFoundations';
 
 import FormPatterns from './components/patterns/FormPatterns';
 import ContainerPatterns from './components/patterns/ContainerPatterns';
@@ -58,6 +59,12 @@ const routes = [
     route: '/foundations-layout',
     title: 'Layout',
     component: LayoutFoundations,
+    group: 'foundations',
+  },
+  {
+    route: '/foundations-util',
+    title: 'Utilities',
+    component: UtilityFoundations,
     group: 'foundations',
   },
   {

--- a/src/tailwind.focus-visible-ring.js
+++ b/src/tailwind.focus-visible-ring.js
@@ -1,0 +1,62 @@
+import plugin from 'tailwindcss/plugin.js';
+
+/**
+ * Provide the `.focus-visible-ring` utility class.
+ *
+ * Add a utility class that will render a focus ring on a focused element
+ * only when it has keyboard focus, or otherwise has `:focus-visible`. Do not
+ * show a focus ring if the element has focus but is not `:focus-visible`.
+ *
+ * This plugin should only be necessary until such a time that we feel browser
+ * support for :focus-visible is acceptable. At that time, what this plugin
+ * does should be achievable with a few standard tailwind utility classes.
+ *
+ * This styling requires the browser to support the :focus-visible
+ * pseudo-selector [1] or for the JS polyfill [2] to be loaded.
+ *
+ * [1] https://developer.mozilla.org/en-US/docs/Web/CSS/:focus-visible
+ * [2] https://github.com/WICG/focus-visible
+ *
+ * This can be combined with other Tailwind utility classes to customize.
+ * Example Usage:
+ *  - <button className="focus-visible-ring">Click me</button>
+ *    Show a focus-visible ring in the theme's `ringColor`
+ * -  <button className="ring-inset focus-visible-ring">No, click me</button>
+ *    Same as above, but explicitly inset
+ * -  <button className="ring-offset-4 focus-visible-ring">Click!</button>
+ *    Set ring shadow offset
+ * -  <button className="ring-grey-3 focus-visible-ring">Click click</button>
+ *    Set ring color
+ *
+ * Ring width is this theme's `ringWidth.DEFAULT`
+ */
+export default plugin(({ addUtilities, theme }) => {
+  const ringWidth = theme('ringWidth.DEFAULT');
+  // Based on TW ring/shadow rules https://tailwindcss.com/docs/ring-width
+  const focusRing = `var(--tw-ring-inset) 0 0 0 calc(${ringWidth} + var(--tw-ring-offset-width)) var(--tw-ring-color)`;
+
+  addUtilities({
+    '.focus-visible-ring': {
+      // 1. set a visible focus ring if this element has focus (fallback)
+      '&:focus': {
+        boxShadow: focusRing,
+        outline: 'none',
+      },
+      // 2. set a visible focus ring if this element has `:focus-visible`
+      '&:focus-visible': {
+        boxShadow: focusRing,
+        outline: 'none',
+      },
+      // 3. Remove focus ring if element is focused but does not have
+      //    `:focus-visible` (in browsers that support `:focus-visible`)
+      '&:focus:not(:focus-visible)': {
+        boxShadow: 'none',
+      },
+      // 4. Remove focus ring if element is focused but does not have
+      //    a focus-visible class set by the polyfill
+      '.js-focus-visible &:focus:not(.focus-visible)': {
+        boxShadow: 'none',
+      },
+    },
+  });
+});

--- a/src/tailwind.preset.js
+++ b/src/tailwind.preset.js
@@ -2,6 +2,8 @@ import plugin from 'tailwindcss/plugin.js';
 
 import colors from 'tailwindcss/colors.js';
 
+import focusVisibleRing from './tailwind.focus-visible-ring.js';
+
 export default {
   theme: {
     extend: {
@@ -53,12 +55,24 @@ export default {
           light: '#737373',
         },
       },
+      ringColor: {
+        DEFAULT: '#59a7e8',
+      },
+      ringOpacity: {
+        // Tailwind's default ring opacity is `0.5`
+        DEFAULT: '1.0',
+      },
+      ringWidth: {
+        DEFAULT: '2px',
+      },
       spacing: {
         'touch-minimum': '44px', // Equivalent to spacing 11; minimum touch-target size
       },
     },
   },
   plugins: [
+    // Make `.focus-visible-ring` an available utility class
+    focusVisibleRing,
     plugin(({ addVariant }) => {
       // Add a custom variant such that the `theme-clean:` modifier is available
       // for all tailwind utility classes. e.g. `.theme-clean:bg-white` would


### PR DESCRIPTION
After the conversion of application UI component styling to updated conventions, there were just a few UI-styling needs that couldn't be fulfilled with a combination of tailwind utility styles or using shared components. This is one of them: our custom focus-ring styling (applied to elements via `:focus-visible` or polyfilled equivalent).

This PR adds a utility class to tailwind: `.focus-visible-ring`, adds some default styling configuration for focus rings and a simple pattern-library page to demonstrate the class in action.

This should be an exact replacement of the current focus-ring styling we use.

Fixes https://github.com/hypothesis/frontend-shared/issues/312