### PR TITLE
Update READMEs pertaining to usage and API

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,35 @@ Your project must have Preact installed as a dependency.
 $ npm install @hypothesis/frontend-shared --save
 ```
 
-### SASS
+### Components (preact)
+
+```js
+import { LabeledButton } from '@hypothesis/frontend-shared';
+```
+
+### Icons
+
+```js
+import {
+  profile,
+  share,
+  trash,
+} from '@hypothesis/frontend-shared/lib/icons';
+
+import { registerIcons } from '@hypothesis/frontend-shared';
+
+registerIcons({ profile, shareAnnotation: share, trash});
+
+export default function MyComponent() => {
+  return (
+    <div>
+      <Icon name="profile" />
+      <Icon name="shareAnnotation" />
+    </div>
+  );
+```
+
+### Styling (CSS)
 
 Your project must have `sass` and `tailwindcss` dependencies installed.
 
@@ -22,12 +50,6 @@ To add styles for all shared components to your project's SASS:
 
 ```scss
 @use '@hypothesis/frontend-shared/styles';
-```
-
-### In JS
-
-```js
-import { Icon } from '@hypothesis/frontend-shared';
 ```
 
 ## Additional documentation

--- a/styles/README.md
+++ b/styles/README.md
@@ -16,7 +16,7 @@ This package's component styling is still implemented in SASS (with mixins, vari
 
 Until then, consuming applications may continue to use the main SASS entrypoint documented above.
 
-## Deprecated SASS API
+## Deprecated SASS
 
 - `pattern-library.scss` (deprecated):
 
@@ -28,7 +28,6 @@ Until then, consuming applications may continue to use the main SASS entrypoint 
 
   `@use '@hypothesis/frontend-shared/styles/mixins/<mixin-module>';`
 
-  - At this time, the only publicly-available mixins are `focus` and `buttons` (for button customizations only—use only if you know what you're doing). Do not use other mixins.
-  - Mixins may not be available publicly in the future.
+  - Mixins are not part of the public API.
 
 _Note_: `pattern-library.scss` is also used internally by this project to build a CSS bundle for serving the pattern library using `make dev`.


### PR DESCRIPTION
This small PR updates a couple of READMEs in advance of a major version release (removing stuff from the package).

We never did document how to use Icons before, so I added that.

Part of https://github.com/hypothesis/frontend-shared/issues/453