### PR TITLE
Pattern library: Add package usage docs and customization guide

### DIFF
--- a/src/pattern-library/components/LibraryNext.js
+++ b/src/pattern-library/components/LibraryNext.js
@@ -58,6 +58,37 @@ function ChangelogItem({ status, children }) {
 }
 
 /**
+ * Render provided `content` as a "code block" example.
+ *
+ * @param {object} props
+ *   @param {string} props.content - Code content
+ *   @param {'sm'|'md'|'lg'} [props.size]
+ *   @param {string} [props.title] - Caption (e.g. filename, description) of
+ *     code block
+ */
+function Code({ content, size, title }) {
+  return (
+    <figure className="space-y-2">
+      <div
+        className={classnames(
+          'unstyled-text bg-slate-7 text-color-text-inverted p-4 rounded-md',
+          { 'text-sm': size === 'sm' }
+        )}
+      >
+        <code className="text-color-text-inverted">
+          <pre className="whitespace-pre-wrap">{jsxToString(content)}</pre>
+        </code>
+      </div>
+      {title && (
+        <figcaption className="flex justify-end">
+          <span className="italic">{title}</span>
+        </figcaption>
+      )}
+    </figure>
+  );
+}
+
+/**
  * Render import "usage" of a given `componentName`
  *
  * @param {object} props
@@ -70,18 +101,16 @@ function Usage({ componentName, generation = 'next' }) {
       ? '@hypothesis/frontend-shared/lib/next'
       : '@hypothesis/frontend-shared';
   return (
-    <div className="unstyled-text bg-slate-7 text-color-text-inverted p-4 rounded-md">
-      <code>
-        {jsxToString(`
-import { ${componentName} } from '${importPath}';
-`)}
-      </code>
-    </div>
+    <Code
+      content={`import { ${componentName} } from '${importPath}';
+`}
+    />
   );
 }
 
 export default {
   Changelog,
   ChangelogItem,
+  Code,
   Usage,
 };

--- a/src/pattern-library/components/patterns/CustomizingComponents.js
+++ b/src/pattern-library/components/patterns/CustomizingComponents.js
@@ -1,0 +1,71 @@
+import Library from '../Library';
+
+export default function CustomizingComponentsPage() {
+  return (
+    <Library.Page
+      title="Customizing components"
+      intro={
+        <>
+          <p>
+            Here are the steps to take when you find yourself wanting to
+            customize the styling of a component.
+          </p>
+          <p>This guide applies to updated ({'"next"'}) components only.</p>
+        </>
+      }
+    >
+      <Library.Pattern title="How to customize a component">
+        <p>
+          These steps should be taken in order when design or layout
+          customization of a component is necessary.
+        </p>
+        <ol>
+          <li>
+            Use a <strong>different variant</strong> of the component. Check the{' '}
+            {"component's"} documentation in this library to see what variants
+            are available.
+          </li>
+          <li>
+            Use <strong>component styling props</strong>, e.g.{' '}
+            <code>color</code>, <code>underline</code> or <code>size</code>.
+            These differ per component and define styling aspects that are
+            intended to be adjusted.
+          </li>
+          <li>
+            Use an <strong>unstyled component</strong>, e.g.{' '}
+            <code>LinkUnstyled</code>. This is appropriate if you want to do
+            considerable customization of a component.
+          </li>
+          <li>
+            Use the{' '}
+            <strong>
+              <code>classes</code> prop
+            </strong>
+            . This allows authors to append arbitrary classes to the{' '}
+            {"component's"} outermost element but should be used with
+            consideration.
+          </li>
+          <li>
+            Use a <strong>different component</strong>, or create a new one.
+          </li>
+          <li>
+            Emergency escape hatch: Use{' '}
+            <strong>
+              <code>!important</code> CSS rules
+            </strong>{' '}
+            (these class names are prefixed with a <code>!</code> in
+            <code>tailwindcss</code>) . This should be a last-ditch tactic.
+          </li>
+        </ol>
+
+        <Library.Example title="Stop and reflect">
+          <p>
+            Any time you use <code>classes</code> and especially if you use{' '}
+            <code>!important</code> hacks, raise the issue. It may be that the
+            component needs adjustment, or that a new component is called for.
+          </p>
+        </Library.Example>
+      </Library.Pattern>
+    </Library.Page>
+  );
+}

--- a/src/pattern-library/components/patterns/GettingStarted.js
+++ b/src/pattern-library/components/patterns/GettingStarted.js
@@ -1,0 +1,79 @@
+import Library from '../Library';
+import Next from '../LibraryNext';
+
+export default function GettingStartedPage() {
+  return (
+    <Library.Page
+      title="Getting started"
+      intro={
+        <p>
+          The <code>@hypothesis/frontend-shared</code> package provides reusable
+          UI components for Hypothesis front-end applications.
+        </p>
+      }
+    >
+      <div className="space-y-8">
+        <p>This package provides two sets of components:</p>
+        <ul>
+          <li>
+            <strong>Updated, standalone components</strong>. These components
+            require <code>tailwindcss</code>. Use of these components is
+            preferred.
+          </li>
+          <li>
+            <strong>Legacy components</strong> with external assets (SASS and
+            SVG source, e.g.). These are being deprecated as their updated
+            counterparts are implemented, and are slated for removal in v6.0 of
+            this package.
+          </li>
+        </ul>
+      </div>
+      <Library.Pattern title="Installation">
+        <Next.Code
+          content={`$ yarn add tailwindcss @hypothesis/frontend-shared`}
+        />
+      </Library.Pattern>
+      <Library.Pattern title="Configuring and using updated components">
+        <Library.Example title="Configure tailwindcss">
+          <p>Configure your {"project's"} tailwind configuration object:</p>
+          <ul>
+            <li>Use this {"package's"} tailwind preset</li>
+            <li>
+              Add this {"package's"} JS source to the {"configuration's"}{' '}
+              <code>content</code> globs
+            </li>
+          </ul>
+          <Next.Code
+            size="sm"
+            title="Your project's tailwind config"
+            content={`import tailwindConfig from '@hypothesis/frontend-shared/lib/tailwind.preset.js';
+
+export default {
+  presets: [tailwindConfig],
+  content: [
+    './node_modules/@hypothesis/frontend-shared/lib/**/*.js',
+    // ...
+  ],
+  // ...`}
+          />
+        </Library.Example>
+        <Library.Example title="Usage">
+          <Next.Usage componentName="Card, Link" />
+        </Library.Example>
+      </Library.Pattern>
+
+      <Library.Pattern title="Configuring and using legacy components">
+        <Library.Example title="Import SASS">
+          <Next.Code
+            size="sm"
+            title="Your project's SASS entry point"
+            content={`@use '@hypothesis/frontend-shared/styles';`}
+          />
+        </Library.Example>
+        <Library.Example title="Usage">
+          <Next.Usage generation="legacy" componentName="Card, Link" />
+        </Library.Example>
+      </Library.Pattern>
+    </Library.Page>
+  );
+}

--- a/src/pattern-library/routes.js
+++ b/src/pattern-library/routes.js
@@ -62,6 +62,10 @@ const routes = [
     route: '/getting-started',
   },
   {
+    title: 'Using components',
+    group: 'foundations',
+  },
+  {
     route: '/foundations-colors',
     title: 'Colors',
     component: ColorFoundations,

--- a/src/pattern-library/routes.js
+++ b/src/pattern-library/routes.js
@@ -23,6 +23,7 @@ import TableComponents from './components/patterns/TableComponents';
 import ThumbnailComponents from './components/patterns/ThumbnailComponents';
 
 import GettingStartedPage from './components/patterns/GettingStarted';
+import CustomizingComponentsPage from './components/patterns/CustomizingComponents';
 
 import LinkPage from './components/patterns/navigation/Link';
 
@@ -61,10 +62,6 @@ const routes = [
     route: '/getting-started',
   },
   {
-    title: 'Customizing',
-    group: 'foundations',
-  },
-  {
     route: '/foundations-colors',
     title: 'Colors',
     component: ColorFoundations,
@@ -82,6 +79,12 @@ const routes = [
     title: 'Utilities',
     component: UtilityFoundations,
     group: 'foundations',
+  },
+  {
+    title: 'Customizing components',
+    group: 'foundations',
+    component: CustomizingComponentsPage,
+    route: '/customizing-components',
   },
   {
     route: '/foundations-layout',

--- a/src/pattern-library/routes.js
+++ b/src/pattern-library/routes.js
@@ -22,6 +22,8 @@ import SpinnerComponents from './components/patterns/SpinnerComponents';
 import TableComponents from './components/patterns/TableComponents';
 import ThumbnailComponents from './components/patterns/ThumbnailComponents';
 
+import GettingStartedPage from './components/patterns/GettingStarted';
+
 import LinkPage from './components/patterns/navigation/Link';
 
 export const componentGroups = {
@@ -55,6 +57,8 @@ const routes = [
   {
     title: 'Getting started',
     group: 'foundations',
+    component: GettingStartedPage,
+    route: '/getting-started',
   },
   {
     title: 'Customizing',

--- a/src/tailwind.preset.js
+++ b/src/tailwind.preset.js
@@ -39,7 +39,7 @@ export default /** @type {Partial<import('tailwindcss').Config>} */ ({
           1: '#e3e3e5',
           3: '#babac4',
           5: '#9c9cab',
-          7: '#595969',
+          7: '#575768',
           9: '#131316',
         },
         blue: {

--- a/styles/library.scss
+++ b/styles/library.scss
@@ -11,7 +11,11 @@
     }
 
     :where(ul):not(:where([class~='unstyled-text'] *)) {
-      @apply list-disc list-outside pl-4 space-y-2;
+      @apply list-disc list-outside ml-8 space-y-2;
+    }
+
+    :where(ol):not(:where([class~='unstyled-text'] *)) {
+      @apply list-decimal list-outside ml-8 space-y-2;
     }
 
     :where(li):not(:where([class~='unstyled-text'] *)) {


### PR DESCRIPTION
This PR adds some pattern-library content for how to install/configure the package and how to customize components. It also adds a placeholder for a future page to describe the common API of components.

Depends on #491 (for pattern-library components added in that PR).

### Check it out...

Check out this branch and run `make dev` and visit http://localhost:4001/getting-started or http://localhost:4001/customizing-components

Screen shots:

<img width="1230" alt="Screen Shot 2022-07-14 at 3 50 21 PM" src="https://user-images.githubusercontent.com/439947/179071038-49531976-0635-4e38-ad28-d028eb83798c.png">

<img width="1260" alt="image" src="https://user-images.githubusercontent.com/439947/179071118-bf3e45ff-ef32-4546-8262-9cf895c32492.png">
