### PR TITLE
Add updated button components

### DIFF
--- a/rollup-tests.config.js
+++ b/rollup-tests.config.js
@@ -64,7 +64,11 @@ export default {
         [
           'babel-plugin-istanbul',
           {
-            exclude: ['**/test/**/*.js', '**/test-util/**'],
+            exclude: [
+              '**/test/**/*.js',
+              '**/test-util/**',
+              'src/components/icons/**/*.js',
+            ],
           },
         ],
       ],

--- a/src/components/buttons.js
+++ b/src/components/buttons.js
@@ -100,6 +100,7 @@ function ButtonBase({
 /**
  * An icon-only button
  *
+ * @deprecated - Use re-implemented component in the input group
  * @param {IconButtonProps} props
  */
 export function IconButton({ className = 'Hyp-IconButton', ...restProps }) {
@@ -114,6 +115,7 @@ export function IconButton({ className = 'Hyp-IconButton', ...restProps }) {
 /**
  * A labeled button, with or without an icon
  *
+ * @deprecated - Use re-implemented component in the input group
  * @param {ButtonBaseProps} props
  */
 export function LabeledButton({

--- a/src/components/input/Button.js
+++ b/src/components/input/Button.js
@@ -14,7 +14,7 @@ import ButtonBase from './ButtonBase';
  * @typedef ButtonProps
  * @prop {'sm'|'md'|'lg'} [size='md'] - Adjusts padding on button
  * @prop {'primary'|'secondary'} [variant='secondary']
- * @prop {IconComponent} [Icon] - Optional icon to display at left
+ * @prop {IconComponent} [icon] - Optional icon to display at left
  *   of button label text. Will be sized proportional to local font size.
  */
 
@@ -32,7 +32,7 @@ export default function Button({
   pressed,
   title,
 
-  Icon,
+  icon: Icon,
   size = 'md',
   variant = 'secondary',
 

--- a/src/components/input/Button.js
+++ b/src/components/input/Button.js
@@ -1,0 +1,71 @@
+import classnames from 'classnames';
+
+import { downcastRef } from '../../util/typing';
+
+import ButtonBase from './ButtonBase';
+
+/**
+ * @typedef {import('../../types').IconComponent} IconComponent
+ *
+ * @typedef {import('../../types').PresentationalProps} CommonProps
+ * @typedef {import('./ButtonBase').ButtonCommonProps} ButtonCommonProps
+ * @typedef {import('./ButtonBase').HTMLButtonAttributes} HTMLButtonAttributes
+ *
+ * @typedef ButtonProps
+ * @prop {'sm'|'md'|'lg'} [size='md'] - Adjusts padding on button
+ * @prop {'primary'|'secondary'} [variant='secondary']
+ * @prop {IconComponent} [Icon] - Optional icon to display at left
+ *   of button label text. Will be sized proportional to local font size.
+ */
+
+/**
+ * Render a button with a label (`children`) and optional icon
+ *
+ * @param {CommonProps & ButtonCommonProps & ButtonProps & HTMLButtonAttributes} props
+ */
+export default function Button({
+  children,
+  classes,
+  elementRef,
+
+  expanded,
+  pressed,
+  title,
+
+  Icon,
+  size = 'md',
+  variant = 'secondary',
+
+  ...htmlAttributes
+}) {
+  return (
+    <ButtonBase
+      {...htmlAttributes}
+      className={classnames(
+        'focus-visible-ring transition-colors whitespace-nowrap rounded-sm',
+        'flex items-center font-semibold',
+        {
+          // Variants
+          'text-grey-7 bg-grey-1 enabled:hover:text-grey-9 enabled:hover:bg-grey-2 aria-pressed:text-grey-9 aria-expanded:text-grey-9':
+            variant === 'secondary', // default
+          'text-grey-1 bg-grey-7 enabled:hover:bg-grey-8 disabled:text-grey-4':
+            variant === 'primary',
+        },
+        {
+          // Sizes
+          'p-2 gap-x-2': size === 'md', // default
+          'px-1.5 py-1 gap-x-1.5': size === 'sm',
+          'px-3 py-2.5 gap-x-2.5': size === 'lg',
+        },
+        classes
+      )}
+      elementRef={downcastRef(elementRef)}
+      expanded={expanded}
+      pressed={pressed}
+      title={title}
+    >
+      {Icon && <Icon className="w-em h-em" />}
+      {children}
+    </ButtonBase>
+  );
+}

--- a/src/components/input/ButtonBase.js
+++ b/src/components/input/ButtonBase.js
@@ -7,7 +7,6 @@ import { downcastRef } from '../../util/typing';
  * @prop {boolean} [expanded] - Is the element associated with this button
  *   expanded? (set `aria-expanded`)
  * @prop {never} [aria-expanded] - Use `expanded` prop instead
- * @prop {never} [icon] - Use `Icon` with button components that support it
  * @prop {boolean} [pressed] - Is this button currently "active?" (set
  *   `aria-pressed` or `aria-selected` depending on button `role`)
  * @prop {never} [aria-pressed] - Use `pressed` prop instead

--- a/src/components/input/ButtonBase.js
+++ b/src/components/input/ButtonBase.js
@@ -1,0 +1,68 @@
+import { downcastRef } from '../../util/typing';
+
+/**
+ * Common props used for Button components.
+ *
+ * @typedef ButtonCommonProps
+ * @prop {boolean} [expanded] - Is the element associated with this button
+ *   expanded? (set `aria-expanded`)
+ * @prop {never} [aria-expanded] - Use `expanded` prop instead
+ * @prop {never} [icon] - Use `Icon` with button components that support it
+ * @prop {boolean} [pressed] - Is this button currently "active?" (set
+ *   `aria-pressed` or `aria-selected` depending on button `role`)
+ * @prop {never} [aria-pressed] - Use `pressed` prop instead
+ * @prop {string} [title] - Button title; used for `aria-label` attribute
+ * @prop {never} [aria-label] - Use `title` prop instead
+ *
+ * HTML attributes accepted by button components. This eliminates conflicting
+ * `icon` and `size` attributes.
+ *
+ * @typedef {Omit<import('preact').JSX.HTMLAttributes<HTMLButtonElement>, 'icon'|'size'>} HTMLButtonAttributes
+ *
+ */
+
+/**
+ * @typedef {import('../../types').BaseProps} BaseProps
+ *
+ * Base component for Button components. Applies common attributes.
+ *
+ * @param {BaseProps & ButtonCommonProps & HTMLButtonAttributes} props
+ */
+export default function ButtonBase({
+  elementRef,
+  children,
+  className,
+
+  expanded,
+  pressed,
+  title,
+
+  role,
+  ...htmlAttributes
+}) {
+  const ariaProps = {
+    'aria-label': title,
+  };
+
+  // aria-pressed and aria-expanded are not allowed for buttons with
+  // an aria role of `tab`. Instead, the aria-selected attribute is expected.
+  if (role === 'tab') {
+    ariaProps['aria-selected'] = pressed;
+  } else {
+    ariaProps['aria-pressed'] = pressed;
+    ariaProps['aria-expanded'] = expanded;
+  }
+
+  return (
+    <button
+      role={role ?? 'button'}
+      {...ariaProps}
+      {...htmlAttributes}
+      className={className}
+      title={title}
+      ref={downcastRef(elementRef)}
+    >
+      {children}
+    </button>
+  );
+}

--- a/src/components/input/ButtonUnstyled.js
+++ b/src/components/input/ButtonUnstyled.js
@@ -1,0 +1,39 @@
+import classnames from 'classnames';
+
+import { downcastRef } from '../../util/typing';
+
+import ButtonBase from './ButtonBase';
+
+/**
+ * @typedef {import('../../types').PresentationalProps} CommonProps
+ * @typedef {import('./ButtonBase').ButtonCommonProps} ButtonCommonProps
+ */
+
+/**
+ * Render a button with common attributes but no styling
+ *
+ * @param {CommonProps & ButtonCommonProps} props
+ */
+export default function ButtonUnstyled({
+  children,
+  classes,
+  elementRef,
+
+  expanded,
+  pressed,
+  title,
+  ...htmlAttributes
+}) {
+  return (
+    <ButtonBase
+      {...htmlAttributes}
+      className={classnames(classes)}
+      elementRef={downcastRef(elementRef)}
+      expanded={expanded}
+      pressed={pressed}
+      title={title}
+    >
+      {children}
+    </ButtonBase>
+  );
+}

--- a/src/components/input/IconButton.js
+++ b/src/components/input/IconButton.js
@@ -1,0 +1,78 @@
+import classnames from 'classnames';
+
+import { downcastRef } from '../../util/typing';
+
+import ButtonBase from './ButtonBase';
+
+/**
+ * @typedef {import('../../types').IconComponent} IconComponent
+ * @typedef {import('../../types').PresentationalProps} CommonProps
+ * @typedef {import('./ButtonBase').ButtonCommonProps} ButtonCommonProps
+ * @typedef {import('./ButtonBase').HTMLButtonAttributes} HTMLButtonAttributes
+ *
+ * @typedef IconButtonProps
+ * @prop {IconComponent} [Icon] - reference to an icon function component
+ *   to render in this button, e.g. CautionIcon
+ * @prop {'sm'|'md'|'lg'} [size='md']
+ * @prop {boolean} [responsive=true] - Apply dimensions for touch
+ *   interfaces to ensure touch target is large enough.
+ * @prop {'primary'|'secondary'|'dark'} [variant='secondary']
+ * @prop {string} title - Required for `IconButton` as there is no text label
+ */
+
+/**
+ * Render a button that only contains an icon.
+ *
+ * @param {CommonProps & ButtonCommonProps & IconButtonProps & HTMLButtonAttributes} props
+ */
+export default function IconButton({
+  children,
+  classes,
+  elementRef,
+
+  pressed,
+  expanded,
+
+  Icon,
+  responsive = true,
+  size = 'md',
+  title,
+  variant = 'secondary',
+
+  ...htmlAttributes
+}) {
+  return (
+    <ButtonBase
+      {...htmlAttributes}
+      className={classnames(
+        'focus-visible-ring transition-colors whitespace-nowrap rounded-sm',
+        'flex items-center justify-center gap-x-2',
+        {
+          // variant
+          'text-grey-7 bg-transparent enabled:hover:text-grey-9 aria-pressed:text-brand aria-expanded:text-brand':
+            variant === 'secondary', //default
+          'text-brand bg-transparent enabled:hover:text-grey-9 disabled:text-grey-7':
+            variant === 'primary',
+          'text-grey-7 bg-grey-2 enabled:hover:text-grey-9 enabled:hover:bg-grey-3 disabled:text-grey-5 aria-pressed:bg-grey-3 aria-expanded:bg-grey-3':
+            variant === 'dark',
+
+          // size
+          'p-2': size === 'md', // Default
+          'p-1': size === 'sm',
+          'p-3': size === 'lg',
+
+          // Responsive
+          'touch:min-w-touch-minimum touch:min-h-touch-minimum': responsive,
+        },
+        classes
+      )}
+      elementRef={downcastRef(elementRef)}
+      title={title}
+      pressed={pressed}
+      expanded={expanded}
+    >
+      {Icon && <Icon className="w-em h-em" />}
+      {children}
+    </ButtonBase>
+  );
+}

--- a/src/components/input/IconButton.js
+++ b/src/components/input/IconButton.js
@@ -14,8 +14,9 @@ import ButtonBase from './ButtonBase';
  * @prop {IconComponent} [Icon] - reference to an icon function component
  *   to render in this button, e.g. CautionIcon
  * @prop {'sm'|'md'|'lg'} [size='md']
- * @prop {boolean} [responsive=true] - Apply dimensions for touch
- *   interfaces to ensure touch target is large enough.
+ * @prop {boolean} [disableTouchSizing=false] - Disable minimum tap target
+ *   sizing for touch devices. This may be necessary in legacy patterns where
+ *   there isn't enough room in the interface for these larger dimensions.
  * @prop {'primary'|'secondary'|'dark'} [variant='secondary']
  * @prop {string} title - Required for `IconButton` as there is no text label
  */
@@ -34,7 +35,7 @@ export default function IconButton({
   expanded,
 
   Icon,
-  responsive = true,
+  disableTouchSizing = false,
   size = 'md',
   title,
   variant = 'secondary',
@@ -62,7 +63,8 @@ export default function IconButton({
           'p-3': size === 'lg',
 
           // Responsive
-          'touch:min-w-touch-minimum touch:min-h-touch-minimum': responsive,
+          'touch:min-w-touch-minimum touch:min-h-touch-minimum':
+            !disableTouchSizing,
         },
         classes
       )}

--- a/src/components/input/IconButton.js
+++ b/src/components/input/IconButton.js
@@ -11,7 +11,7 @@ import ButtonBase from './ButtonBase';
  * @typedef {import('./ButtonBase').HTMLButtonAttributes} HTMLButtonAttributes
  *
  * @typedef IconButtonProps
- * @prop {IconComponent} [Icon] - reference to an icon function component
+ * @prop {IconComponent} [icon] - reference to an icon function component
  *   to render in this button, e.g. CautionIcon
  * @prop {'sm'|'md'|'lg'} [size='md']
  * @prop {boolean} [disableTouchSizing=false] - Disable minimum tap target
@@ -34,7 +34,7 @@ export default function IconButton({
   pressed,
   expanded,
 
-  Icon,
+  icon: Icon,
   disableTouchSizing = false,
   size = 'md',
   title,

--- a/src/components/input/index.js
+++ b/src/components/input/index.js
@@ -1,0 +1,3 @@
+export { default as Button } from './Button';
+export { default as ButtonUnstyled } from './ButtonUnstyled';
+export { default as IconButton } from './IconButton';

--- a/src/components/input/test/Button-test.js
+++ b/src/components/input/test/Button-test.js
@@ -1,0 +1,25 @@
+import { mount } from 'enzyme';
+
+import { testPresentationalComponent } from '../../test/common-tests';
+
+import Button from '../Button';
+import { CancelIcon } from '../../icons';
+
+describe('Button', () => {
+  const createComponent = (props = {}) => {
+    return mount(
+      <Button {...props}>This is content inside of a Button</Button>
+    );
+  };
+
+  testPresentationalComponent(Button);
+
+  it('renders proportionally-sized icon', () => {
+    const wrapper = createComponent({ Icon: CancelIcon });
+    const icon = wrapper.find('CancelIcon');
+
+    assert.isTrue(icon.exists());
+    assert.isTrue(icon.hasClass('h-em'));
+    assert.isTrue(icon.hasClass('w-em'));
+  });
+});

--- a/src/components/input/test/Button-test.js
+++ b/src/components/input/test/Button-test.js
@@ -15,7 +15,7 @@ describe('Button', () => {
   testPresentationalComponent(Button);
 
   it('renders proportionally-sized icon', () => {
-    const wrapper = createComponent({ Icon: CancelIcon });
+    const wrapper = createComponent({ icon: CancelIcon });
     const icon = wrapper.find('CancelIcon');
 
     assert.isTrue(icon.exists());

--- a/src/components/input/test/ButtonBase-test.js
+++ b/src/components/input/test/ButtonBase-test.js
@@ -1,0 +1,55 @@
+import { mount } from 'enzyme';
+
+import { testBaseComponent } from '../../test/common-tests';
+
+import ButtonBase from '../ButtonBase';
+
+describe('ButtonBase', () => {
+  const createComponent = (props = {}) => {
+    return mount(
+      <ButtonBase {...props}>This is content inside of a Link</ButtonBase>
+    );
+  };
+
+  testBaseComponent(ButtonBase);
+
+  it('applies role="button" by default', () => {
+    const wrapper = createComponent();
+    const outerEl = wrapper.find('button').getDOMNode();
+
+    assert.isTrue(outerEl.hasAttribute('role'));
+    assert.equal(outerEl.getAttribute('role'), 'button');
+  });
+
+  it('applies appropriate ARIA attributes for button state', () => {
+    const pressed = createComponent({ pressed: true });
+    const expanded = createComponent({ expanded: true });
+
+    assert.equal(
+      pressed.find('button').getDOMNode().getAttribute('aria-pressed'),
+      'true'
+    );
+    assert.equal(
+      expanded.find('button').getDOMNode().getAttribute('aria-expanded'),
+      'true'
+    );
+  });
+
+  it('sets appropriate ARIA attributes for tabs', () => {
+    const wrapper = createComponent({ role: 'tab' });
+
+    assert.equal(
+      wrapper.find('button').getDOMNode().getAttribute('role'),
+      'tab'
+    );
+  });
+
+  it('sets aria-label attribute', () => {
+    const wrapper = createComponent({ title: 'Click me' });
+
+    assert.equal(
+      wrapper.find('button').getDOMNode().getAttribute('aria-label'),
+      'Click me'
+    );
+  });
+});

--- a/src/components/input/test/ButtonUnstyled-test.js
+++ b/src/components/input/test/ButtonUnstyled-test.js
@@ -1,0 +1,7 @@
+import { testPresentationalComponent } from '../../test/common-tests';
+
+import ButtonUnstyled from '../ButtonUnstyled';
+
+describe('ButtonUnstyled', () => {
+  testPresentationalComponent(ButtonUnstyled);
+});

--- a/src/components/input/test/IconButton-test.js
+++ b/src/components/input/test/IconButton-test.js
@@ -13,7 +13,7 @@ describe('IconButton', () => {
   testPresentationalComponent(IconButton);
 
   it('renders proportionally-sized icon', () => {
-    const wrapper = createComponent({ Icon: CancelIcon });
+    const wrapper = createComponent({ icon: CancelIcon });
     const icon = wrapper.find('CancelIcon');
 
     assert.isTrue(icon.exists());

--- a/src/components/input/test/IconButton-test.js
+++ b/src/components/input/test/IconButton-test.js
@@ -1,0 +1,23 @@
+import { mount } from 'enzyme';
+
+import { testPresentationalComponent } from '../../test/common-tests';
+
+import IconButton from '../IconButton';
+import { CancelIcon } from '../../icons';
+
+describe('IconButton', () => {
+  const createComponent = (props = {}) => {
+    return mount(<IconButton {...props} />);
+  };
+
+  testPresentationalComponent(IconButton);
+
+  it('renders proportionally-sized icon', () => {
+    const wrapper = createComponent({ Icon: CancelIcon });
+    const icon = wrapper.find('CancelIcon');
+
+    assert.isTrue(icon.exists());
+    assert.isTrue(icon.hasClass('h-em'));
+    assert.isTrue(icon.hasClass('w-em'));
+  });
+});

--- a/src/components/navigation/test/Link-test.js
+++ b/src/components/navigation/test/Link-test.js
@@ -1,75 +1,7 @@
-import { mount } from 'enzyme';
-import { createRef } from 'preact';
+import { testPresentationalComponent } from '../../test/common-tests';
 
 import Link from '../Link';
 
 describe('Link', () => {
-  const createComponent = (props = {}) => {
-    return mount(
-      <Link href="http://www.example.com" {...props}>
-        This is content inside of a Link
-      </Link>
-    );
-  };
-
-  // Tests common to presentational components
-  it('applies extra classes', () => {
-    const wrapper = createComponent({ classes: 'foo bar' });
-    const allClasses = [...wrapper.childAt(0).getDOMNode().classList];
-    assert.equal(allClasses.at(-2), 'foo');
-    assert.equal(allClasses.at(-1), 'bar');
-  });
-
-  it('applies `ref` via `elementRef`', () => {
-    const elementRef = createRef();
-    createComponent({ elementRef });
-
-    assert.instanceOf(elementRef.current, Node);
-  });
-
-  it('overrides disallowed `className` prop', () => {
-    const wrapper = createComponent({ className: 'verboten' });
-
-    assert.isFalse(wrapper.childAt(0).hasClass('verboten'));
-  });
-
-  it('applies HTML attributes to outer element', () => {
-    const wrapperOuterEl = createComponent({ 'data-testid': 'foo-container' })
-      .childAt(0)
-      .getDOMNode();
-
-    assert.isTrue(wrapperOuterEl.hasAttribute('data-testid'));
-    assert.equal(wrapperOuterEl.getAttribute('data-testid'), 'foo-container');
-  });
-
-  // Tests specific to this component
-  it('styles link color', () => {
-    const defaultOuter = createComponent().find('a');
-    const textOuter = createComponent({ color: 'text' }).find('a');
-    const lightOuter = createComponent({ color: 'text-light' }).find('a');
-
-    assert.isTrue(defaultOuter.hasClass('text-brand'));
-    assert.isTrue(defaultOuter.hasClass('hover:text-brand-dark'));
-
-    assert.isTrue(textOuter.hasClass('text-color-text'));
-    assert.isTrue(textOuter.hasClass('hover:text-brand-dark'));
-
-    assert.isTrue(lightOuter.hasClass('text-color-text-light'));
-    assert.isTrue(lightOuter.hasClass('hover:text-brand'));
-  });
-
-  it('styles link underline', () => {
-    const defaultOuter = createComponent().find('a');
-    const hoverOuter = createComponent({ underline: 'hover' }).find('a');
-    const alwaysOuter = createComponent({ underline: 'always' }).find('a');
-
-    assert.isTrue(defaultOuter.hasClass('no-underline'));
-    assert.isTrue(defaultOuter.hasClass('hover:no-underline'));
-
-    assert.isTrue(hoverOuter.hasClass('no-underline'));
-    assert.isTrue(hoverOuter.hasClass('hover:underline'));
-
-    assert.isTrue(alwaysOuter.hasClass('underline'));
-    assert.isTrue(alwaysOuter.hasClass('hover:underline'));
-  });
+  testPresentationalComponent(Link);
 });

--- a/src/components/navigation/test/LinkBase-test.js
+++ b/src/components/navigation/test/LinkBase-test.js
@@ -1,5 +1,6 @@
 import { mount } from 'enzyme';
-import { createRef } from 'preact';
+
+import { testBaseComponent } from '../../test/common-tests';
 
 import LinkBase from '../LinkBase';
 
@@ -13,29 +14,7 @@ describe('LinkBase', () => {
   };
 
   // Tests common to base components
-  it('applies `ref` via `elementRef`', () => {
-    const elementRef = createRef();
-    createComponent({ elementRef });
-
-    assert.instanceOf(elementRef.current, Node);
-  });
-
-  it('applies supplied `className`', () => {
-    const wrapper = createComponent({ className: 'testClass' });
-
-    const allClasses = [...wrapper.childAt(0).getDOMNode().classList];
-
-    assert.deepEqual(allClasses, ['testClass']);
-  });
-
-  it('applies HTML attributes to outer element', () => {
-    const wrapperOuterEl = createComponent({ 'data-testid': 'foo-container' })
-      .childAt(0)
-      .getDOMNode();
-
-    assert.isTrue(wrapperOuterEl.hasAttribute('data-testid'));
-    assert.equal(wrapperOuterEl.getAttribute('data-testid'), 'foo-container');
-  });
+  testBaseComponent(LinkBase);
 
   // Tests specific to this base component
   it('adds common `rel` attributes', () => {

--- a/src/components/navigation/test/LinkUnstyled-test.js
+++ b/src/components/navigation/test/LinkUnstyled-test.js
@@ -1,44 +1,7 @@
-import { mount } from 'enzyme';
-import { createRef } from 'preact';
+import { testPresentationalComponent } from '../../test/common-tests';
 
 import LinkUnstyled from '../LinkUnstyled';
 
 describe('LinkUnstyled', () => {
-  const createComponent = (props = {}) => {
-    return mount(
-      <LinkUnstyled href="http://www.example.com" {...props}>
-        This is content inside of a Link
-      </LinkUnstyled>
-    );
-  };
-
-  // Tests common to presentational components
-  it('applies extra classes', () => {
-    const wrapper = createComponent({ classes: 'foo bar' });
-    const allClasses = [...wrapper.childAt(0).getDOMNode().classList];
-    assert.equal(allClasses.at(-2), 'foo');
-    assert.equal(allClasses.at(-1), 'bar');
-  });
-
-  it('applies `ref` via `elementRef`', () => {
-    const elementRef = createRef();
-    createComponent({ elementRef });
-
-    assert.instanceOf(elementRef.current, Node);
-  });
-
-  it('overrides disallowed `className` prop', () => {
-    const wrapper = createComponent({ className: 'verboten' });
-
-    assert.isFalse(wrapper.childAt(0).hasClass('verboten'));
-  });
-
-  it('applies HTML attributes to outer element', () => {
-    const wrapperOuterEl = createComponent({ 'data-testid': 'foo-container' })
-      .childAt(0)
-      .getDOMNode();
-
-    assert.isTrue(wrapperOuterEl.hasAttribute('data-testid'));
-    assert.equal(wrapperOuterEl.getAttribute('data-testid'), 'foo-container');
-  });
+  testPresentationalComponent(LinkUnstyled);
 });

--- a/src/components/test/common-tests.js
+++ b/src/components/test/common-tests.js
@@ -1,0 +1,81 @@
+import { mount } from 'enzyme';
+import { createRef } from 'preact';
+
+const createComponent = (Component, props = {}) => {
+  return mount(<Component {...props}>This is child content</Component>);
+};
+
+/**
+ * Set of tests common to all presentational components
+ *
+ * @param {import('preact').FunctionComponent} Component
+ */
+export function testPresentationalComponent(Component) {
+  describe('Common presentational functionality', () => {
+    it('applies extra classes', () => {
+      const wrapper = createComponent(Component, { classes: 'foo bar' });
+      const allClasses = [...wrapper.childAt(0).getDOMNode().classList];
+      assert.equal(allClasses.at(-2), 'foo');
+      assert.equal(allClasses.at(-1), 'bar');
+    });
+
+    it('applies `ref` via `elementRef`', () => {
+      const elementRef = createRef();
+      createComponent(Component, { elementRef });
+
+      assert.instanceOf(elementRef.current, Node);
+    });
+
+    it('overrides disallowed `className` prop', () => {
+      const wrapper = createComponent(Component, { className: 'verboten' });
+
+      assert.isFalse(wrapper.childAt(0).hasClass('verboten'));
+    });
+
+    it('applies HTML attributes to outer element', () => {
+      const wrapperOuterEl = createComponent(Component, {
+        'data-testid': 'foo-container',
+      })
+        .childAt(0)
+        .getDOMNode();
+
+      assert.isTrue(wrapperOuterEl.hasAttribute('data-testid'));
+      assert.equal(wrapperOuterEl.getAttribute('data-testid'), 'foo-container');
+    });
+  });
+}
+
+/**
+ * Set of tests common to all base components
+ *
+ * @param {import('preact').FunctionComponent} Component
+ */
+export function testBaseComponent(Component) {
+  describe('Common base component functionality', () => {
+    it('applies `ref` via `elementRef`', () => {
+      const elementRef = createRef();
+      createComponent(Component, { elementRef });
+
+      assert.instanceOf(elementRef.current, Node);
+    });
+
+    it('applies supplied `className`', () => {
+      const wrapper = createComponent(Component, { className: 'testClass' });
+
+      const allClasses = [...wrapper.childAt(0).getDOMNode().classList];
+
+      assert.deepEqual(allClasses, ['testClass']);
+    });
+
+    it('applies HTML attributes to outer element', () => {
+      const wrapperOuterEl = createComponent(Component, {
+        'data-testid': 'foo-container',
+      })
+        .childAt(0)
+        .getDOMNode();
+
+      assert.isTrue(wrapperOuterEl.hasAttribute('data-testid'));
+      assert.equal(wrapperOuterEl.getAttribute('data-testid'), 'foo-container');
+    });
+  });
+}

--- a/src/next.js
+++ b/src/next.js
@@ -1,2 +1,3 @@
 export * from './components/icons';
+export { Button, ButtonUnstyled, IconButton } from './components/input';
 export { Link, LinkUnstyled } from './components/navigation/';

--- a/src/pattern-library/components/Library.js
+++ b/src/pattern-library/components/Library.js
@@ -171,6 +171,8 @@ function DemoButton({ children, onClick, pressed }) {
 /**
  * @typedef DemoProps
  * @prop {import("preact").ComponentChildren} [children]
+ * @prop {string} [classes] - Extra CSS classes for the demo content's immediate
+ *   parent container
  * @prop {boolean} [withSource=false] - Should the demo also render the source?
  *   When true, a "Source" tab will be rendered, which will display the JSX
  *   source of the Demo's children
@@ -186,7 +188,7 @@ function DemoButton({ children, onClick, pressed }) {
  *
  * @param {DemoProps} props
  */
-function Demo({ children, withSource = false, style = {}, title }) {
+function Demo({ children, classes, withSource = false, style = {}, title }) {
   const [visibleTab, setVisibleTab] = useState('demo');
   const source = toChildArray(children).map((child, idx) => {
     return (
@@ -227,7 +229,12 @@ function Demo({ children, withSource = false, style = {}, title }) {
       <div className="bg-slate-0 p-2 rounded-md unstyled-text">
         {visibleTab === 'demo' && (
           <div className="w-full bg-white p-8 rounded-md" style={style}>
-            <div className="h-full flex flex-row items-center justify-center gap-2">
+            <div
+              className={classnames(
+                'h-full flex flex-row items-center justify-center gap-2',
+                classes
+              )}
+            >
               {children}
             </div>
           </div>

--- a/src/pattern-library/components/PlaygroundApp.js
+++ b/src/pattern-library/components/PlaygroundApp.js
@@ -69,7 +69,7 @@ export default function PlaygroundApp({
                 activeRoute?.route === route.route,
               'border-transparent': activeRoute?.route !== route.route,
             })}
-            href={route.toString()}
+            href={route.route.toString()}
             onClick={e => navigate(e, route.route)}
           >
             {route.title}

--- a/src/pattern-library/components/patterns/ButtonComponents.js
+++ b/src/pattern-library/components/patterns/ButtonComponents.js
@@ -1,9 +1,37 @@
 import { IconButton, LabeledButton, LinkButton } from '../../../';
 import Library from '../Library';
+import Next from '../LibraryNext';
 
 export default function ButtonComponents() {
   return (
     <Library.Page title="Buttons">
+      <Library.Pattern title="Status">
+        <Next.Changelog>
+          <Next.ChangelogItem status="deprecated">
+            The legacy implementation of
+            <s>
+              <code>Button</code>
+            </s>{' '}
+            is deprecated and slated for removal in v6 of{' '}
+            <code>frontend-shared</code>. Use re-implemented
+            <code>Button</code> component in the input group instead.
+          </Next.ChangelogItem>
+          <Next.ChangelogItem status="deprecated">
+            The legacy implementation of
+            <s>
+              <code>IconButton</code>
+            </s>{' '}
+            is deprecated and slated for removal in v6 of{' '}
+            <code>frontend-shared</code>. Use re-implemented
+            <code>IconButton</code> component in the input group instead.
+          </Next.ChangelogItem>
+        </Next.Changelog>
+      </Library.Pattern>
+      <Library.Pattern title="Usage">
+        <Next.Usage componentName="Button" generation="legacy" />
+        <Next.Usage componentName="IconButton" generation="legacy" />
+        <Next.Usage componentName="LinkButton" generation="legacy" />
+      </Library.Pattern>
       <Library.Pattern title="Button variants">
         <p>
           Button components support the following <strong>variants</strong>:

--- a/src/pattern-library/components/patterns/input/Button.js
+++ b/src/pattern-library/components/patterns/input/Button.js
@@ -1,0 +1,184 @@
+import { Button, ButtonUnstyled } from '../../../../next';
+import { CancelIcon, CheckIcon, EditIcon, ReplyIcon } from '../../../../next';
+import Library from '../../Library';
+import Next from '../../LibraryNext';
+
+export default function ButtonPage() {
+  return (
+    <Library.Page
+      title="Button"
+      intro={
+        <p>
+          <code>Button</code> is a presentational component for{' '}
+          <code>button</code> elements that have a text label. A{' '}
+          <code>Button</code> may have an icon.{' '}
+        </p>
+      }
+    >
+      <Library.Pattern title="Status">
+        <p>
+          <code>Button</code> is a new component that re-implements the{' '}
+          <code>LabeledButton</code> legacy component.{' '}
+          <code>ButtonUnstyled</code> is a new component.
+        </p>
+
+        <Library.Example title="Migrating to this component (from LabeledButton)">
+          <Next.Changelog>
+            <Next.ChangelogItem status="breaking">
+              Prop name:{' '}
+              <s>
+                <code>buttonRef</code>
+              </s>{' '}
+              ➜ <code>elementRef</code>
+            </Next.ChangelogItem>
+            <Next.ChangelogItem status="breaking">
+              Prop:{' '}
+              <s>
+                <code>icon</code>
+              </s>
+              ,{' '}
+              <s>
+                <code>iconPosition</code>
+              </s>{' '}
+              ➜ Use <code>Icon</code> prop instead. Icons are always positioned
+              left.
+            </Next.ChangelogItem>
+            <Next.ChangelogItem status="breaking">
+              Prop: <code>variant</code> value{' '}
+              <s>
+                <code>{"'dark'"}</code>:
+              </s>{' '}
+              This is no longer a standard variant ➜ Use{' '}
+              <code>ButtonUnstyled</code> instead.
+            </Next.ChangelogItem>
+            <Next.ChangelogItem status="breaking">
+              Prop: <code>variant</code> default value{' '}
+              <s>
+                <code>{"'normal'"}</code>
+              </s>{' '}
+              ➜ <code>{"'secondary'"}</code>
+            </Next.ChangelogItem>
+          </Next.Changelog>
+        </Library.Example>
+      </Library.Pattern>
+      <Library.Pattern title="Usage">
+        <Next.Usage componentName="Button" />
+        <Library.Example>
+          <Library.Demo title="Basic Button" withSource>
+            <Button onClick={() => alert('You clicked the button')}>
+              Click me
+            </Button>
+          </Library.Demo>
+        </Library.Example>
+      </Library.Pattern>
+
+      <Library.Pattern title="Icons">
+        <Library.Example>
+          <p>
+            The <code>Button</code>
+            {"'s"} <code>Icon</code> prop accepts an icon component and will
+            render it to the left of content, sized proportionally to the local
+            font size.
+          </p>
+          <Library.Demo
+            title="Icons are sized proportionally to button label content"
+            withSource
+          >
+            <span className="text-xl">
+              <Button Icon={CancelIcon}>Cancel</Button>
+            </span>
+            <Button Icon={CancelIcon}>Cancel</Button>
+            <span className="text-xs">
+              <Button Icon={CancelIcon}>Cancel</Button>
+            </span>
+          </Library.Demo>
+        </Library.Example>
+      </Library.Pattern>
+
+      <Library.Pattern title="Variant">
+        <p>
+          These examples show each variant in each of the supported states, as
+          well as an example with an icon. These states are associated with the{' '}
+          <code>pressed</code>, <code>expanded</code> and <code>disabled</code>{' '}
+          boolean props.
+        </p>
+        <Library.Example title="variant: 'secondary' (default)">
+          <Library.Demo withSource>
+            <Button variant="secondary">Default</Button>
+            <Button variant="secondary">
+              <CancelIcon />
+              Default
+            </Button>
+            <Button variant="secondary" pressed>
+              Pressed
+            </Button>
+            <Button variant="secondary" expanded>
+              Expanded
+            </Button>
+            <Button variant="secondary" disabled>
+              Disabled
+            </Button>
+          </Library.Demo>
+        </Library.Example>
+
+        <Library.Example title="variant: 'primary'">
+          <Library.Demo withSource>
+            <Button variant="primary">Default</Button>
+            <Button variant="primary">
+              <EditIcon />
+              Default
+            </Button>
+            <Button variant="primary" pressed>
+              Pressed
+            </Button>
+            <Button variant="primary" expanded>
+              Expanded
+            </Button>
+            <Button variant="primary" disabled>
+              Disabled
+            </Button>
+          </Library.Demo>
+        </Library.Example>
+      </Library.Pattern>
+
+      <Library.Pattern title="Size">
+        <p>
+          The <code>size</code> prop affects padding and spacing within the{' '}
+          <code>Button</code>, but other sizing (e.g. font size) is inherited.
+        </p>
+        <Library.Example>
+          <Library.Demo withSource>
+            <Button Icon={EditIcon} size="sm">
+              Small (sm)
+            </Button>
+            <Button Icon={ReplyIcon} size="md">
+              Medium (md, default)
+            </Button>
+            <Button Icon={CheckIcon} size="lg">
+              Large (lg)
+            </Button>
+          </Library.Demo>
+        </Library.Example>
+      </Library.Pattern>
+
+      <Library.Pattern title="ButtonUnstyled">
+        <p>
+          <code>ButtonUnstyled</code> does not apply any styling. Use the{' '}
+          <code>classes</code> prop to style the component.
+        </p>
+        <p>
+          To enable a focus ring consistent with other interactive elements, use
+          the <code>.focus-visible-ring</code> utility class.
+        </p>
+        <Library.Example title="Usage">
+          <Next.Usage componentName="ButtonUnstyled" />
+          <Library.Demo withSource>
+            <ButtonUnstyled classes="focus-visible-ring bg-slate-0 p-2">
+              My custom button
+            </ButtonUnstyled>
+          </Library.Demo>
+        </Library.Example>
+      </Library.Pattern>
+    </Library.Page>
+  );
+}

--- a/src/pattern-library/components/patterns/input/Button.js
+++ b/src/pattern-library/components/patterns/input/Button.js
@@ -34,14 +34,16 @@ export default function ButtonPage() {
             <Next.ChangelogItem status="breaking">
               Prop:{' '}
               <s>
-                <code>icon</code>
-              </s>
-              ,{' '}
-              <s>
                 <code>iconPosition</code>
               </s>{' '}
-              ➜ Use <code>Icon</code> prop instead. Icons are always positioned
-              left.
+              ➜ Icons are always positioned left
+            </Next.ChangelogItem>
+            <Next.ChangelogItem status="breaking">
+              Prop: <code>icon</code>,{' '}
+              <s>
+                <code>{'{string}'}</code>
+              </s>{' '}
+              ➜ Now takes <code>{'{IconComponent}'}</code>
             </Next.ChangelogItem>
             <Next.ChangelogItem status="breaking">
               Prop: <code>variant</code> value{' '}
@@ -76,7 +78,7 @@ export default function ButtonPage() {
         <Library.Example>
           <p>
             The <code>Button</code>
-            {"'s"} <code>Icon</code> prop accepts an icon component and will
+            {"'s"} <code>icon</code> prop accepts an icon component and will
             render it to the left of content, sized proportionally to the local
             font size.
           </p>
@@ -85,11 +87,11 @@ export default function ButtonPage() {
             withSource
           >
             <span className="text-xl">
-              <Button Icon={CancelIcon}>Cancel</Button>
+              <Button icon={CancelIcon}>Cancel</Button>
             </span>
-            <Button Icon={CancelIcon}>Cancel</Button>
+            <Button icon={CancelIcon}>Cancel</Button>
             <span className="text-xs">
-              <Button Icon={CancelIcon}>Cancel</Button>
+              <Button icon={CancelIcon}>Cancel</Button>
             </span>
           </Library.Demo>
         </Library.Example>
@@ -148,13 +150,13 @@ export default function ButtonPage() {
         </p>
         <Library.Example>
           <Library.Demo withSource>
-            <Button Icon={EditIcon} size="sm">
+            <Button icon={EditIcon} size="sm">
               Small (sm)
             </Button>
-            <Button Icon={ReplyIcon} size="md">
+            <Button icon={ReplyIcon} size="md">
               Medium (md, default)
             </Button>
-            <Button Icon={CheckIcon} size="lg">
+            <Button icon={CheckIcon} size="lg">
               Large (lg)
             </Button>
           </Library.Demo>

--- a/src/pattern-library/components/patterns/input/IconButton.js
+++ b/src/pattern-library/components/patterns/input/IconButton.js
@@ -30,11 +30,11 @@ export default function IconButtonPage() {
               ➜ <code>elementRef</code>
             </Next.ChangelogItem>
             <Next.ChangelogItem status="breaking">
-              Prop:{' '}
+              Prop: <code>icon</code>,{' '}
               <s>
-                <code>icon</code>
-              </s>
-              , ➜ Use <code>Icon</code> prop instead
+                <code>{'{string}'}</code>
+              </s>{' '}
+              ➜ Now takes <code>{'{IconComponent}'}</code>
             </Next.ChangelogItem>
             <Next.ChangelogItem status="breaking">
               Prop: <code>variant</code> value{' '}
@@ -60,7 +60,7 @@ export default function IconButtonPage() {
           <Library.Demo title="Basic IconButton" withSource>
             <IconButton
               onClick={() => alert('You clicked the button')}
-              Icon={ReplyIcon}
+              icon={ReplyIcon}
               title="Reply"
             />
           </Library.Demo>
@@ -71,16 +71,16 @@ export default function IconButtonPage() {
         <Library.Example>
           <p>
             The <code>IconButton</code>
-            {"'s"} <code>Icon</code> prop accepts an icon component and will
+            {"'s"} <code>icon</code> prop accepts an icon component and will
             render it sized proportionally to the local font size.
           </p>
           <Library.Demo withSource>
             <span className="text-xl">
-              <IconButton Icon={ShareIcon} title="Share" />
+              <IconButton icon={ShareIcon} title="Share" />
             </span>
-            <IconButton Icon={ShareIcon} title="Share" />
+            <IconButton icon={ShareIcon} title="Share" />
             <span className="text-xs">
-              <IconButton Icon={ShareIcon} title="Share" />
+              <IconButton icon={ShareIcon} title="Share" />
             </span>
           </Library.Demo>
         </Library.Example>
@@ -115,24 +115,24 @@ export default function IconButtonPage() {
             <IconButton
               variant="secondary"
               title="Watch out!"
-              Icon={CautionIcon}
+              icon={CautionIcon}
             />
             <IconButton
               variant="secondary"
               title="Watch out!"
-              Icon={CautionIcon}
+              icon={CautionIcon}
               pressed
             />
             <IconButton
               variant="secondary"
               title="Watch out!"
-              Icon={CautionIcon}
+              icon={CautionIcon}
               expanded
             />
             <IconButton
               variant="secondary"
               title="Watch out!"
-              Icon={CautionIcon}
+              icon={CautionIcon}
               disabled
             />
           </Library.Demo>
@@ -143,24 +143,24 @@ export default function IconButtonPage() {
             <IconButton
               variant="primary"
               title="Watch out!"
-              Icon={CautionIcon}
+              icon={CautionIcon}
             />
             <IconButton
               variant="primary"
               title="Watch out!"
-              Icon={CautionIcon}
+              icon={CautionIcon}
               pressed
             />
             <IconButton
               variant="primary"
               title="Watch out!"
-              Icon={CautionIcon}
+              icon={CautionIcon}
               expanded
             />
             <IconButton
               variant="primary"
               title="Watch out!"
-              Icon={CautionIcon}
+              icon={CautionIcon}
               disabled
             />
           </Library.Demo>
@@ -172,23 +172,23 @@ export default function IconButtonPage() {
             title="default, pressed, expanded, disabled"
             withSource
           >
-            <IconButton variant="dark" title="Watch out!" Icon={CautionIcon} />
+            <IconButton variant="dark" title="Watch out!" icon={CautionIcon} />
             <IconButton
               variant="dark"
               title="Watch out!"
-              Icon={CautionIcon}
+              icon={CautionIcon}
               pressed
             />
             <IconButton
               variant="dark"
               title="Watch out!"
-              Icon={CautionIcon}
+              icon={CautionIcon}
               expanded
             />
             <IconButton
               variant="dark"
               title="Watch out!"
-              Icon={CautionIcon}
+              icon={CautionIcon}
               disabled
             />
           </Library.Demo>
@@ -202,9 +202,9 @@ export default function IconButtonPage() {
         </p>
         <Library.Example>
           <Library.Demo withSource>
-            <IconButton Icon={EditIcon} size="sm" title="Edit" />
-            <IconButton Icon={EditIcon} size="md" title="Edit" />
-            <IconButton Icon={EditIcon} size="lg" title="Edit" />
+            <IconButton icon={EditIcon} size="sm" title="Edit" />
+            <IconButton icon={EditIcon} size="md" title="Edit" />
+            <IconButton icon={EditIcon} size="lg" title="Edit" />
           </Library.Demo>
         </Library.Example>
 
@@ -218,7 +218,7 @@ export default function IconButtonPage() {
           </p>
 
           <Library.Demo withSource>
-            <IconButton Icon={EditIcon} title="Edit" disableTouchSizing />
+            <IconButton icon={EditIcon} title="Edit" disableTouchSizing />
           </Library.Demo>
         </Library.Example>
       </Library.Pattern>

--- a/src/pattern-library/components/patterns/input/IconButton.js
+++ b/src/pattern-library/components/patterns/input/IconButton.js
@@ -208,17 +208,17 @@ export default function IconButtonPage() {
           </Library.Demo>
         </Library.Example>
 
-        <Library.Example title="Disabling responsive sizing">
+        <Library.Example title="Disabling touch-target sizing">
           <p>
             By default, <code>IconButton</code> will apply styles for touch
             devices (<code>pointer: coarse</code>) to ensure the minimum
             dimensions are equal or greater to our defined touch-target minimums
-            (<code>44×44</code>). In some cases that is undesirable. Disable
-            with the <code>responsive</code> boolean prop.
+            (44×44px). In some cases that is undesirable. Disable with the{' '}
+            <code>disableTouchSizing</code> boolean prop.
           </p>
 
           <Library.Demo withSource>
-            <IconButton Icon={EditIcon} title="Edit" responsive={false} />
+            <IconButton Icon={EditIcon} title="Edit" disableTouchSizing />
           </Library.Demo>
         </Library.Example>
       </Library.Pattern>

--- a/src/pattern-library/components/patterns/input/IconButton.js
+++ b/src/pattern-library/components/patterns/input/IconButton.js
@@ -1,0 +1,227 @@
+import { IconButton } from '../../../../next';
+import { CautionIcon, EditIcon, ReplyIcon, ShareIcon } from '../../../../next';
+import Library from '../../Library';
+import Next from '../../LibraryNext';
+
+export default function IconButtonPage() {
+  return (
+    <Library.Page
+      title="IconButton"
+      intro={
+        <p>
+          <code>IconButton</code> is a presentational component for{' '}
+          <code>button</code> elements that contain solely an icon.
+        </p>
+      }
+    >
+      <Library.Pattern title="Status">
+        <p>
+          <code>IconButton</code> is a reimplementation of an existing legacy
+          component with the same name.
+        </p>
+
+        <Library.Example title="Migrating to this component">
+          <Next.Changelog>
+            <Next.ChangelogItem status="breaking">
+              Prop name:{' '}
+              <s>
+                <code>buttonRef</code>
+              </s>{' '}
+              ➜ <code>elementRef</code>
+            </Next.ChangelogItem>
+            <Next.ChangelogItem status="breaking">
+              Prop:{' '}
+              <s>
+                <code>icon</code>
+              </s>
+              , ➜ Use <code>Icon</code> prop instead
+            </Next.ChangelogItem>
+            <Next.ChangelogItem status="breaking">
+              Prop: <code>variant</code> value{' '}
+              <s>
+                <code>{"'light'"}</code>:
+              </s>{' '}
+              This is no longer a standard variant ➜ Use{' '}
+              <code>ButtonUnstyled</code> instead
+            </Next.ChangelogItem>
+            <Next.ChangelogItem status="breaking">
+              Prop: <code>variant</code> default value{' '}
+              <s>
+                <code>{"'normal'"}</code>
+              </s>{' '}
+              ➜ <code>{"'secondary'"}</code>
+            </Next.ChangelogItem>
+          </Next.Changelog>
+        </Library.Example>
+      </Library.Pattern>
+      <Library.Pattern title="Usage">
+        <Next.Usage componentName="IconButton" />
+        <Library.Example>
+          <Library.Demo title="Basic IconButton" withSource>
+            <IconButton
+              onClick={() => alert('You clicked the button')}
+              Icon={ReplyIcon}
+              title="Reply"
+            />
+          </Library.Demo>
+        </Library.Example>
+      </Library.Pattern>
+
+      <Library.Pattern title="Icons">
+        <Library.Example>
+          <p>
+            The <code>IconButton</code>
+            {"'s"} <code>Icon</code> prop accepts an icon component and will
+            render it sized proportionally to the local font size.
+          </p>
+          <Library.Demo withSource>
+            <span className="text-xl">
+              <IconButton Icon={ShareIcon} title="Share" />
+            </span>
+            <IconButton Icon={ShareIcon} title="Share" />
+            <span className="text-xs">
+              <IconButton Icon={ShareIcon} title="Share" />
+            </span>
+          </Library.Demo>
+        </Library.Example>
+        <Library.Example title="Custom icon styling">
+          <p>
+            If you need more control over icon styles, use an icon component
+            directly in the content instead.
+          </p>
+          <Library.Demo withSource>
+            <IconButton title="Share">
+              <ShareIcon className="w-8 h-8" />
+            </IconButton>
+            <IconButton title="Share">
+              <ShareIcon className="w-3 h-3" />
+            </IconButton>
+          </Library.Demo>
+        </Library.Example>
+      </Library.Pattern>
+
+      <Library.Pattern title="Variant">
+        <p>
+          These examples show each variant in each of the supported states.
+          These states are associated with the <code>pressed</code>,{' '}
+          <code>expanded</code> and <code>disabled</code> boolean props.
+        </p>
+
+        <p>
+          For customization, use <code>ButtonUnstyled</code>.
+        </p>
+        <Library.Example title="variant: 'secondary' (default)">
+          <Library.Demo title="default, pressed, expanded, disabled" withSource>
+            <IconButton
+              variant="secondary"
+              title="Watch out!"
+              Icon={CautionIcon}
+            />
+            <IconButton
+              variant="secondary"
+              title="Watch out!"
+              Icon={CautionIcon}
+              pressed
+            />
+            <IconButton
+              variant="secondary"
+              title="Watch out!"
+              Icon={CautionIcon}
+              expanded
+            />
+            <IconButton
+              variant="secondary"
+              title="Watch out!"
+              Icon={CautionIcon}
+              disabled
+            />
+          </Library.Demo>
+        </Library.Example>
+
+        <Library.Example title="variant: 'primary'">
+          <Library.Demo title="default, pressed, expanded, disabled" withSource>
+            <IconButton
+              variant="primary"
+              title="Watch out!"
+              Icon={CautionIcon}
+            />
+            <IconButton
+              variant="primary"
+              title="Watch out!"
+              Icon={CautionIcon}
+              pressed
+            />
+            <IconButton
+              variant="primary"
+              title="Watch out!"
+              Icon={CautionIcon}
+              expanded
+            />
+            <IconButton
+              variant="primary"
+              title="Watch out!"
+              Icon={CautionIcon}
+              disabled
+            />
+          </Library.Demo>
+        </Library.Example>
+
+        <Library.Example title="variant: 'dark'">
+          <Library.Demo
+            classes="bg-slate-0 p-4"
+            title="default, pressed, expanded, disabled"
+            withSource
+          >
+            <IconButton variant="dark" title="Watch out!" Icon={CautionIcon} />
+            <IconButton
+              variant="dark"
+              title="Watch out!"
+              Icon={CautionIcon}
+              pressed
+            />
+            <IconButton
+              variant="dark"
+              title="Watch out!"
+              Icon={CautionIcon}
+              expanded
+            />
+            <IconButton
+              variant="dark"
+              title="Watch out!"
+              Icon={CautionIcon}
+              disabled
+            />
+          </Library.Demo>
+        </Library.Example>
+      </Library.Pattern>
+
+      <Library.Pattern title="Size">
+        <p>
+          The <code>size</code> prop affects padding and spacing within the{' '}
+          <code>IconButton</code>.
+        </p>
+        <Library.Example>
+          <Library.Demo withSource>
+            <IconButton Icon={EditIcon} size="sm" title="Edit" />
+            <IconButton Icon={EditIcon} size="md" title="Edit" />
+            <IconButton Icon={EditIcon} size="lg" title="Edit" />
+          </Library.Demo>
+        </Library.Example>
+
+        <Library.Example title="Disabling responsive sizing">
+          <p>
+            By default, <code>IconButton</code> will apply styles for touch
+            devices (<code>pointer: coarse</code>) to ensure the minimum
+            dimensions are equal or greater to our defined touch-target minimums
+            (<code>44×44</code>). In some cases that is undesirable. Disable
+            with the <code>responsive</code> boolean prop.
+          </p>
+
+          <Library.Demo withSource>
+            <IconButton Icon={EditIcon} title="Edit" responsive={false} />
+          </Library.Demo>
+        </Library.Example>
+      </Library.Pattern>
+    </Library.Page>
+  );
+}

--- a/src/pattern-library/routes.js
+++ b/src/pattern-library/routes.js
@@ -27,6 +27,9 @@ import CustomizingComponentsPage from './components/patterns/CustomizingComponen
 
 import IconsPage from './components/patterns/data/Icons';
 
+import ButtonsPage from './components/patterns/input/Button';
+import IconButtonPage from './components/patterns/input/IconButton';
+
 import LinkPage from './components/patterns/navigation/Link';
 
 export const componentGroups = {
@@ -193,9 +196,19 @@ const routes = [
   { title: 'Table', group: 'data' },
   { title: 'Dialog', group: 'feedback' },
   { title: 'Spinner', group: 'feedback' },
-  { title: 'Button', group: 'input' },
+  {
+    title: 'Button',
+    group: 'input',
+    component: ButtonsPage,
+    route: '/input-button',
+  },
   { title: 'Checkbox', group: 'input' },
-  { title: 'IconButton', group: 'input' },
+  {
+    title: 'IconButton',
+    group: 'input',
+    component: IconButtonPage,
+    route: '/input-iconbutton',
+  },
   { title: 'LinkButton', group: 'input' },
   { title: 'TextField', group: 'input' },
   { title: 'Card', group: 'layout' },

--- a/src/pattern-library/util/jsx-to-string.js
+++ b/src/pattern-library/util/jsx-to-string.js
@@ -60,10 +60,11 @@ export function jsxToString(vnode) {
           return '';
         }
 
-        // Boolean props are assumed to default to `false`, in which case they
-        // can be omitted.
+        // When a boolean property is present, render:
+        // 'booleanPropName' => when true
+        // 'booleanPropName={false}' => when false
         if (typeof value === 'boolean') {
-          return value ? name : '';
+          return value ? name : `${name}={false}`;
         }
 
         let valueStr;

--- a/src/tailwind.preset.js
+++ b/src/tailwind.preset.js
@@ -108,6 +108,9 @@ export default /** @type {Partial<import('tailwindcss').Config>} */ ({
       // only apply (set the element's background color to white) if a parent
       // element had the `.theme-clean` class.
       addVariant('theme-clean', '.theme-clean &');
+      // Tailwind does not provide variants for ARIA-attributes out of the box
+      addVariant('aria-pressed', '&[aria-pressed="true"]');
+      addVariant('aria-expanded', '&[aria-expanded="true"]');
     }),
   ],
 });

--- a/src/types.js
+++ b/src/types.js
@@ -23,5 +23,11 @@
  * @prop {import('preact').Ref<HTMLElement>} [elementRef]
  */
 
+/**
+ * A type describing any of the standalone icon components, which take any
+ * valid `<svg>` element attribute as props.
+ *
+ *  @typedef {import('preact').FunctionComponent<import('preact').JSX.SVGAttributes<SVGSVGElement>>} IconComponent
+ */
 // Make TypeScript treat this file as a module.
 export const unused = {};


### PR DESCRIPTION
This PR adds updated `Button`, `IconButton` and `ButtonUnstyled` components to the package and documents them thoroughly in the pattern library.

It also extracts common presentational- and base-component tests. The most efficient test structuring is still coalescing, but at least tests are DRY now.

### How and what to review

Check out this branch and run `make dev`; visit http://localhost:4001/input-button and http://localhost:4001/input-iconbutton for documentation.

Commits are organized carefully to isolate large-diff changes (pattern-library docs) from functionality changes.

Much of the work here mirrors established patterns. Of note is the introduction of capitalized props for passing function components (`Icon` in `Button` and `IconButton`).

<img width="1221" alt="image" src="https://user-images.githubusercontent.com/439947/180233879-ac3df839-5246-486c-9f15-3fb958821af5.png">


### Implementation checklist

The follow items are to be completed for each component or component set in this project:

- [x] component(s) implementation
- [x] component tests
- [x] exports in package
- [x] test against `client` or `lms`
- [x] document in pattern library
- [x] deprecate associated legacy component(s)
- [x] remove any associated patterns