### PR TITLE
Add `Scroll` (presentational) components and `ScrollBox` (composite) component

### DIFF
--- a/src/components/containers.js
+++ b/src/components/containers.js
@@ -100,6 +100,7 @@ export function Actions({
  * Render a scrollable container to contain content that might overflow.
  * Optionally provide styling affordances for a sticky header (`withHeader`).
  *
+ * @deprecated - Use re-implemented ScrollBox component in the data-display group
  * @param {{withHeader?: boolean} & PresentationalProps} props
  */
 export function Scrollbox({

--- a/src/components/data/Scroll.js
+++ b/src/components/data/Scroll.js
@@ -30,8 +30,8 @@ export default function Scroll({
       {...htmlAttributes}
       ref={downcastRef(elementRef)}
       className={classnames(
-        // Prevent vertical flex or grid blowout: keep this contained vertically
-        // to parent by setting a min width
+        // Prevent overflow by overriding `min-height: auto`.
+        // See https://stackoverflow.com/a/66689926/434243.
         'min-h-0',
         'h-full w-full overflow-auto',
         { 'scroll-shadows': variant === 'raised' },

--- a/src/components/data/Scroll.js
+++ b/src/components/data/Scroll.js
@@ -1,0 +1,44 @@
+import classnames from 'classnames';
+
+import { downcastRef } from '../../util/typing';
+
+/**
+ * @typedef {import('../../types').PresentationalProps} CommonProps
+ * @typedef {import('preact').JSX.HTMLAttributes<HTMLElement>} HTMLAttributes
+ *
+ * @typedef ScrollProps
+ * @prop {'raised'|'flat'} [variant='raised'] - Render with scroll-hinting
+ *   shadows ('raised') or without ('flat')
+ */
+
+/**
+ * Render a fluid container that scrolls on overflow.
+ *
+ * @param {CommonProps & ScrollProps & HTMLAttributes} props
+ */
+export default function Scroll({
+  children,
+  classes,
+  elementRef,
+
+  variant = 'raised',
+
+  ...htmlAttributes
+}) {
+  return (
+    <div
+      {...htmlAttributes}
+      ref={downcastRef(elementRef)}
+      className={classnames(
+        // Prevent vertical flex or grid blowout: keep this contained vertically
+        // to parent by setting a min width
+        'min-h-0',
+        'h-full w-full overflow-auto',
+        { 'scroll-shadows': variant === 'raised' },
+        classes
+      )}
+    >
+      {children}
+    </div>
+  );
+}

--- a/src/components/data/ScrollBox.js
+++ b/src/components/data/ScrollBox.js
@@ -1,0 +1,38 @@
+import Scroll from './Scroll';
+import ScrollContainer from './ScrollContainer';
+import ScrollContent from './ScrollContent';
+
+/**
+ * @typedef {import('../../types').CompositeProps} CompositeProps
+ * @typedef {import('preact').JSX.HTMLAttributes<HTMLElement>} HTMLAttributes
+ *
+ * @typedef ScrollBoxProps
+ * @prop {boolean} [borderless=false] - Turn off borders on outer container
+ */
+
+/**
+ * Render an opinionated composition of Scroll components, making `children`
+ * scrollable.
+ *
+ * @param {CompositeProps & ScrollBoxProps} props
+ */
+export default function ScrollBox({
+  children,
+  elementRef,
+
+  borderless = false,
+
+  ...htmlAttributes
+}) {
+  return (
+    <ScrollContainer
+      {...htmlAttributes}
+      borderless={borderless}
+      elementRef={elementRef}
+    >
+      <Scroll>
+        <ScrollContent>{children}</ScrollContent>
+      </Scroll>
+    </ScrollContainer>
+  );
+}

--- a/src/components/data/ScrollContainer.js
+++ b/src/components/data/ScrollContainer.js
@@ -1,0 +1,41 @@
+import classnames from 'classnames';
+
+import { downcastRef } from '../../util/typing';
+
+/**
+ * @typedef {import('../../types').PresentationalProps} CommonProps
+ * @typedef {import('preact').JSX.HTMLAttributes<HTMLDivElement>} HTMLDivAttributes
+ *
+ * @typedef ScrollContainerProps
+ * @prop {boolean} [borderless=false] - Remove border around container
+ */
+
+/**
+ * Constrain children (which may include both scrollable and non-scrolling
+ * content) to the dimensions of the immediate parent.
+ *
+ * @param {CommonProps & ScrollContainerProps & HTMLDivAttributes} props
+ */
+export default function ScrollContainer({
+  children,
+  classes,
+  elementRef,
+
+  borderless = false,
+
+  ...htmlAttributes
+}) {
+  return (
+    <div
+      {...htmlAttributes}
+      ref={downcastRef(elementRef)}
+      className={classnames(
+        'flex flex-col min-h-0 h-full w-full',
+        { border: !borderless },
+        classes
+      )}
+    >
+      {children}
+    </div>
+  );
+}

--- a/src/components/data/ScrollContainer.js
+++ b/src/components/data/ScrollContainer.js
@@ -30,7 +30,10 @@ export default function ScrollContainer({
       {...htmlAttributes}
       ref={downcastRef(elementRef)}
       className={classnames(
-        'flex flex-col min-h-0 h-full w-full',
+        'flex flex-colh-full w-full',
+        // Prevent overflow by overriding `min-height: auto`.
+        // See https://stackoverflow.com/a/66689926/434243.
+        'min-h-0',
         { border: !borderless },
         classes
       )}

--- a/src/components/data/ScrollContent.js
+++ b/src/components/data/ScrollContent.js
@@ -1,0 +1,30 @@
+import classnames from 'classnames';
+
+import { downcastRef } from '../../util/typing';
+
+/**
+ * @typedef {import('../../types').PresentationalProps} CommonProps
+ * @typedef {import('preact').JSX.HTMLAttributes<HTMLDivElement>} HTMLDivAttributes
+ */
+
+/**
+ * Apply consistent padding and spacing to content within a Scroll
+ *
+ * @param {CommonProps & HTMLDivAttributes} props
+ */
+export default function ScrollContent({
+  children,
+  classes,
+  elementRef,
+  ...htmlAttributes
+}) {
+  return (
+    <div
+      {...htmlAttributes}
+      ref={downcastRef(elementRef)}
+      className={classnames('px-3 py-2', classes)}
+    >
+      {children}
+    </div>
+  );
+}

--- a/src/components/data/index.js
+++ b/src/components/data/index.js
@@ -1,0 +1,3 @@
+export { default as Scroll } from './Scroll';
+export { default as ScrollContainer } from './ScrollContainer';
+export { default as ScrollContent } from './ScrollContent';

--- a/src/components/data/index.js
+++ b/src/components/data/index.js
@@ -1,3 +1,4 @@
 export { default as Scroll } from './Scroll';
 export { default as ScrollContainer } from './ScrollContainer';
 export { default as ScrollContent } from './ScrollContent';
+export { default as ScrollBox } from './ScrollBox';

--- a/src/components/data/test/Scroll-test.js
+++ b/src/components/data/test/Scroll-test.js
@@ -1,0 +1,7 @@
+import { testPresentationalComponent } from '../../test/common-tests';
+
+import Scroll from '../Scroll';
+
+describe('Scroll', () => {
+  testPresentationalComponent(Scroll);
+});

--- a/src/components/data/test/ScrollBox-test.js
+++ b/src/components/data/test/ScrollBox-test.js
@@ -1,0 +1,21 @@
+import { mount } from 'enzyme';
+
+import { testCompositeComponent } from '../../test/common-tests';
+
+import ScrollBox from '../ScrollBox';
+
+const createComponent = (Component, props = {}) => {
+  return mount(<Component {...props}>This is child content</Component>);
+};
+
+describe('ScrollBox', () => {
+  testCompositeComponent(ScrollBox);
+
+  it('disables container border when `borderless` is set', () => {
+    const withBorder = createComponent(ScrollBox);
+    const withoutBorder = createComponent(ScrollBox, { borderless: true });
+
+    assert.isFalse(withBorder.find('ScrollContainer').props().borderless);
+    assert.isTrue(withoutBorder.find('ScrollContainer').props().borderless);
+  });
+});

--- a/src/components/data/test/ScrollContainer-test.js
+++ b/src/components/data/test/ScrollContainer-test.js
@@ -1,0 +1,7 @@
+import { testPresentationalComponent } from '../../test/common-tests';
+
+import ScrollContainer from '../ScrollContainer';
+
+describe('ScrollContainer', () => {
+  testPresentationalComponent(ScrollContainer);
+});

--- a/src/components/data/test/ScrollContent-test.js
+++ b/src/components/data/test/ScrollContent-test.js
@@ -1,0 +1,7 @@
+import { testPresentationalComponent } from '../../test/common-tests';
+
+import ScrollContent from '../ScrollContent';
+
+describe('ScrollContent', () => {
+  testPresentationalComponent(ScrollContent);
+});

--- a/src/components/test/common-tests.js
+++ b/src/components/test/common-tests.js
@@ -14,6 +14,33 @@ const createComponent = (Component, props = {}) => {
  *
  * @param {FunctionComponent} Component
  */
+export function testCompositeComponent(Component) {
+  describe('Common composite functionality', () => {
+    it('applies `ref` via `elementRef`', () => {
+      const elementRef = createRef();
+      createComponent(Component, { elementRef });
+
+      assert.instanceOf(elementRef.current, Node);
+    });
+
+    it('applies HTML attributes to outer element', () => {
+      const wrapperOuterEl = createComponent(Component, {
+        'data-testid': 'foo-container',
+      })
+        .childAt(0)
+        .getDOMNode();
+
+      assert.isTrue(wrapperOuterEl.hasAttribute('data-testid'));
+      assert.equal(wrapperOuterEl.getAttribute('data-testid'), 'foo-container');
+    });
+  });
+}
+
+/**
+ * Set of tests common to all presentational components
+ *
+ * @param {import('preact').FunctionComponent} Component
+ */
 export function testPresentationalComponent(Component) {
   describe('Common presentational functionality', () => {
     it('applies extra classes', () => {

--- a/src/next.js
+++ b/src/next.js
@@ -1,6 +1,11 @@
 export * from './components/icons';
 
-export { Scroll, ScrollContent, ScrollContainer } from './components/data';
+export {
+  Scroll,
+  ScrollContent,
+  ScrollContainer,
+  ScrollBox,
+} from './components/data';
 export { Spinner } from './components/feedback';
 export { Button, ButtonUnstyled, IconButton } from './components/input';
 export { Link, LinkUnstyled } from './components/navigation/';

--- a/src/next.js
+++ b/src/next.js
@@ -1,4 +1,6 @@
 export * from './components/icons';
+
+export { Scroll, ScrollContent, ScrollContainer } from './components/data';
 export { Spinner } from './components/feedback';
 export { Button, ButtonUnstyled, IconButton } from './components/input';
 export { Link, LinkUnstyled } from './components/navigation/';

--- a/src/pattern-library/components/LibraryNext.js
+++ b/src/pattern-library/components/LibraryNext.js
@@ -99,10 +99,11 @@ function Code({ content, size, title }) {
  * Render import "usage" of a given `componentName`
  *
  * @param {object} props
- *   @prop {string} props.componentName
- *   @prop {'next'|'legacy'} [props.generation]
+ *   @param {string} props.componentName
+ *   @param {'next'|'legacy'} [props.generation]
+ *   @param {'sm'|'md'|'lg'} [props.size]
  */
-function Usage({ componentName, generation = 'next' }) {
+function Usage({ componentName, generation = 'next', size = 'md' }) {
   const importPath =
     generation === 'next'
       ? '@hypothesis/frontend-shared/lib/next'
@@ -111,6 +112,7 @@ function Usage({ componentName, generation = 'next' }) {
     <Code
       content={`import { ${componentName} } from '${importPath}';
 `}
+      size={size}
     />
   );
 }

--- a/src/pattern-library/components/patterns/ContainerComponents.js
+++ b/src/pattern-library/components/patterns/ContainerComponents.js
@@ -1,11 +1,26 @@
 import { Actions, Card, Frame, Scrollbox, LabeledButton } from '../../..';
+
 import Library from '../Library';
+import Next from '../LibraryNext';
 
 import { SampleListElements } from './samples';
 
 export default function ContainerComponents() {
   return (
     <Library.Page title="Containers">
+      <Library.Pattern title="Status">
+        <Next.Changelog>
+          <Next.ChangelogItem status="deprecated">
+            The legacy implementation of
+            <s>
+              <code>Scrollbox</code>
+            </s>{' '}
+            is deprecated and slated for removal in v6 of{' '}
+            <code>frontend-shared</code>. Use re-implemented
+            <code>ScrollBox</code> component in the data display group instead.
+          </Next.ChangelogItem>
+        </Next.Changelog>
+      </Library.Pattern>
       <Library.Pattern title="Frame">
         <Library.Example title="Laying out content in a Frame">
           <p>

--- a/src/pattern-library/components/patterns/ContainerPatterns.js
+++ b/src/pattern-library/components/patterns/ContainerPatterns.js
@@ -3,8 +3,6 @@ import { useState } from 'preact/hooks';
 import { IconButton, LabeledButton } from '../../../';
 import Library from '../Library';
 
-import { SampleListElements } from './samples';
-
 export default function ContainerPatterns() {
   const [showModalExample, setShowModalExample] = useState(false);
   return (
@@ -211,53 +209,6 @@ export default function ContainerPatterns() {
                     </div>
                   </div>
                 </div>
-              </div>
-            </div>
-          </Library.Demo>
-        </Library.Example>
-      </Library.Pattern>
-
-      <Library.Pattern title="Scrollbox">
-        <p>
-          <code>Scrollbox</code> is a CSS-only pattern that provides scroll-hint
-          affordances for overflowing content (shadows). It sets its own{' '}
-          <code>overflow: auto</code> scrolling context, but authors need to
-          define bounding dimensions.
-        </p>
-        <Library.Example title="List in a scrollbox">
-          <p>
-            This example shows an overflowing <code>ul</code> in a{' '}
-            <code>scrollbox</code>.
-          </p>
-          <Library.Demo withSource>
-            <div style="height:250px;width:250px">
-              <div className="hyp-scrollbox">
-                <ul className="p-3 space-y-4">
-                  <SampleListElements />
-                </ul>
-              </div>
-            </div>
-          </Library.Demo>
-        </Library.Example>
-
-        <Library.Example title="Scrollbox with header offset">
-          <p>
-            The <code>scrollbox--with-header</code> pattern offsets the top
-            scroll-hinting shadow to accommodate one header-like element with a
-            touch-target height (currently 44px).
-          </p>
-
-          <Library.Demo withSource>
-            <div style="height:250px;width:250px">
-              <div className="hyp-scrollbox--with-header">
-                <div className="hyp-sticky-header">
-                  <div className="hyp-sticky-header__heading">
-                    <strong>NATO Phonetic Alphabet</strong>
-                  </div>
-                </div>
-                <ul className="p-3 space-y-4">
-                  <SampleListElements />
-                </ul>
               </div>
             </div>
           </Library.Demo>

--- a/src/pattern-library/components/patterns/data/Scroll.js
+++ b/src/pattern-library/components/patterns/data/Scroll.js
@@ -1,0 +1,188 @@
+import { Scroll, ScrollContainer, ScrollContent } from '../../../../next';
+import Library from '../../Library';
+import Next from '../../LibraryNext';
+
+import { SampleListElements } from '../samples';
+
+export default function ScrollPage() {
+  return (
+    <Library.Page
+      title="Scroll"
+      intro={
+        <>
+          <p>
+            The <code>Scroll</code> family of presentational components provide
+            support for customized scrollable content in cases that{' '}
+            <code>ScrollBox</code> does not satisfy a use case.
+          </p>
+          <ul>
+            <li>
+              <code>ScrollContainer</code>: Contains its content — a mix of
+              scrollable and (optionally) non-scrollable content — to the
+              dimensions of a parent element
+            </li>
+            <li>
+              <code>Scroll</code>: A layout container that scrolls on overflow,
+              with shadows for scroll-hinting
+            </li>
+            <li>
+              <code>ScrollContent</code>: Applies consistent spacing and padding
+              to content in a <code>Scroll</code>
+            </li>
+          </ul>
+        </>
+      }
+    >
+      <Library.Pattern title="Status">
+        <p>
+          <code>Scroll</code>, <code>ScrollContainer</code>, and{' '}
+          <code>ScrollContent</code> are new components modeled after aspects of
+          the legacy <code>Scrollbox</code> component.
+        </p>
+      </Library.Pattern>
+
+      <Library.Pattern title="Usage">
+        <Next.Usage
+          componentName="Scroll, ScrollContainer, ScrollContent"
+          size="sm"
+        />
+        <Library.Example>
+          <p>
+            Sizing constraints are dictated by the immediate parent container of
+            the outermost <code>Scroll*</code> component. Here and in following
+            examples, the parent container sets width (<code>320px</code>) and
+            height (<code>200px</code>).
+          </p>
+          <Library.Demo title="Scrolling content" withSource>
+            <div className="w-[320px] h-[200px]">
+              <ScrollContainer>
+                <Scroll>
+                  <ScrollContent>
+                    <ul>
+                      <SampleListElements />
+                    </ul>
+                  </ScrollContent>
+                </Scroll>
+              </ScrollContainer>
+            </div>
+          </Library.Demo>
+        </Library.Example>
+      </Library.Pattern>
+
+      <Library.Pattern title="Scroll">
+        <p>
+          <code>Scroll</code> provides a fluid container that scrolls on
+          overflow.
+        </p>
+        <Library.Example>
+          <Library.Demo title="Using Scroll by itself" withSource>
+            <div className="w-[320px] h-[200px]">
+              <Scroll>
+                <ul>
+                  <SampleListElements />
+                </ul>
+              </Scroll>
+            </div>
+          </Library.Demo>
+        </Library.Example>
+
+        <Library.Example title="Variant">
+          <p>
+            <code>Scroll</code>
+            {"'s"} <code>raised</code> variant (default) renders CSS shadows to
+            hint that content is scrollable. These can be disabled by using the{' '}
+            <code>flat</code> variant.
+          </p>
+          <Library.Demo title="variant:'raised' (default)" withSource>
+            <div className="w-[320px] h-[200px]">
+              <Scroll variant="raised">
+                <ul>
+                  <SampleListElements />
+                </ul>
+              </Scroll>
+            </div>
+          </Library.Demo>
+
+          <Library.Demo title="variant:'flat'" withSource>
+            <div className="w-[320px] h-[200px]">
+              <Scroll variant="flat">
+                <ul>
+                  <SampleListElements />
+                </ul>
+              </Scroll>
+            </div>
+          </Library.Demo>
+        </Library.Example>
+      </Library.Pattern>
+
+      <Library.Pattern title="ScrollContent">
+        <p>
+          <code>ScrollContent</code> puts consistent padding and spacing around
+          content in a <code>Scroll</code> component.
+        </p>
+        <Library.Example>
+          <Library.Demo title="Scroll with ScrollContent" withSource>
+            <div className="w-[320px] h-[200px]">
+              <Scroll>
+                <ScrollContent>
+                  <ul>
+                    <SampleListElements />
+                  </ul>
+                </ScrollContent>
+              </Scroll>
+            </div>
+          </Library.Demo>
+        </Library.Example>
+      </Library.Pattern>
+
+      <Library.Pattern title="ScrollContainer">
+        <p>
+          <code>ScrollContainer</code> allows the combination of scrolling and
+          non-scrolling content to be constrained to the parent {"container's"}{' '}
+          dimensions. This is very handy when trying to constrain complex
+          content within, e.g., a modal.
+        </p>
+        <p>
+          Only the content within <code>Scroll</code> actually scrolls.
+        </p>
+        <Library.Example>
+          <Library.Demo title="Using ScrollContainer" withSource>
+            <div className="w-[320px] h-[200px]">
+              <ScrollContainer>
+                <div className="p-2 border-b">Non-scrolling content here</div>
+                <Scroll>
+                  <ScrollContent>
+                    <ul>
+                      <SampleListElements />
+                    </ul>
+                  </ScrollContent>
+                </Scroll>
+                <div className="p-2 border-t">More non-scrolling content</div>
+              </ScrollContainer>
+            </div>
+          </Library.Demo>
+        </Library.Example>
+        <Library.Example title="Disabling borders">
+          <p>
+            Turn off <code>ScrollContainer</code> borders with the{' '}
+            <code>borderless</code> boolean prop.
+          </p>
+          <Library.Demo withSource>
+            <div className="w-[320px] h-[200px]">
+              <ScrollContainer borderless>
+                <div className="p-2 border-b">Non-scrolling content here</div>
+                <Scroll>
+                  <ScrollContent>
+                    <ul>
+                      <SampleListElements />
+                    </ul>
+                  </ScrollContent>
+                </Scroll>
+              </ScrollContainer>
+            </div>
+          </Library.Demo>
+        </Library.Example>
+      </Library.Pattern>
+    </Library.Page>
+  );
+}

--- a/src/pattern-library/components/patterns/data/ScrollBox.js
+++ b/src/pattern-library/components/patterns/data/ScrollBox.js
@@ -1,0 +1,94 @@
+import { ScrollBox } from '../../../../next';
+import Library from '../../Library';
+import Next from '../../LibraryNext';
+
+import { SampleListElements } from '../samples';
+
+export default function ScrollBoxPage() {
+  return (
+    <Library.Page
+      title="ScrollBox"
+      intro={
+        <>
+          <p>
+            <code>ScrollBox</code> is an opinionated composite component that
+            provides a shorthand for styling scrollable content.
+          </p>
+          <p>
+            For more custom control over scrolling content, see{' '}
+            <code>Scroll</code> and its allies.
+          </p>
+        </>
+      }
+    >
+      <Library.Pattern title="Status">
+        <p>
+          <code>ScrollBox</code> is a re-implementation of the legacy component{' '}
+          <code>Scrollbox</code> (note casing change).
+        </p>
+        <Library.Example title="Migrating to this component">
+          <Next.Changelog>
+            <Next.ChangelogItem status="breaking">
+              <strong>Watch out!</strong> The casing of this {"component's"}{' '}
+              name has changed:
+              <s>
+                <code>Scrollbox</code>
+              </s>{' '}
+              ➜ <code>ScrollBox</code>
+            </Next.ChangelogItem>
+            <Next.ChangelogItem status="breaking">
+              Prop:
+              <s>
+                <code>withHeader</code>
+              </s>{' '}
+              ➜ No longer supported. Use <code>Scroll</code> components directly
+              to add header-like non-scrolling content.
+            </Next.ChangelogItem>
+            <Next.ChangelogItem status="breaking">
+              Prop:
+              <s>
+                <code>classes</code>
+              </s>{' '}
+              ➜ no longer supported. Use <code>Scroll</code>-family components
+              directly for more customization
+            </Next.ChangelogItem>
+          </Next.Changelog>
+        </Library.Example>
+      </Library.Pattern>
+
+      <Library.Pattern title="Usage">
+        <Next.Usage componentName="ScrollBox" />
+        <Library.Example title="Basic ScrollBox">
+          <Library.Demo withSource>
+            <div className="w-[280px] h-[200px]">
+              <ScrollBox>
+                <ul>
+                  <SampleListElements />
+                </ul>
+              </ScrollBox>
+            </div>
+          </Library.Demo>
+        </Library.Example>
+      </Library.Pattern>
+
+      <Library.Pattern title="Border">
+        <p>
+          <code>ScrollBox</code> applies a border to the outer{' '}
+          <code>ScrollContainer</code> by default. This can be disabled with the{' '}
+          <code>borderless</code> boolean prop.
+        </p>
+        <Library.Example>
+          <Library.Demo title="Turning off borders" withSource>
+            <div className="w-[280px] h-[200px]">
+              <ScrollBox borderless>
+                <ul>
+                  <SampleListElements />
+                </ul>
+              </ScrollBox>
+            </div>
+          </Library.Demo>
+        </Library.Example>
+      </Library.Pattern>
+    </Library.Page>
+  );
+}

--- a/src/pattern-library/router.js
+++ b/src/pattern-library/router.js
@@ -6,13 +6,22 @@ function routeFromCurrentURL(baseURL) {
 
 export function useRoute(baseURL, routes) {
   const [route, setRoute] = useState(() => routeFromCurrentURL(baseURL));
-  const routeData = useMemo(
-    () => routes.find(r => r.route && route.match(r.route)),
-    [route, routes]
-  );
+
+  // Data associated with the currently-applied route
+  const routeData = useMemo(() => {
+    return routes.find(r => {
+      if (!r.route) {
+        return false;
+      }
+      if (typeof r.route === 'string') {
+        return r.route === route;
+      }
+      return r.route && route.match(r.route);
+    });
+  }, [route, routes]);
   const title = `${
     routeData?.title ?? 'Page not found'
-  }: Hypothesis UI playground`;
+  }: Hypothesis Component Library`;
 
   useEffect(() => {
     document.title = title;

--- a/src/pattern-library/routes.js
+++ b/src/pattern-library/routes.js
@@ -26,6 +26,9 @@ import CustomizingComponentsPage from './components/patterns/CustomizingComponen
 
 import IconsPage from './components/patterns/data/Icons';
 
+import ScrollPage from './components/patterns/data/Scroll';
+import ScrollBoxPage from './components/patterns/data/ScrollBox';
+
 import SpinnerPage from './components/patterns/feedback/Spinner';
 
 import ButtonsPage from './components/patterns/input/Button';
@@ -186,7 +189,18 @@ const routes = [
     component: ThumbnailComponents,
     group: 'components',
   },
-  { title: 'Scrollbox', group: 'data' },
+  {
+    title: 'Scroll',
+    group: 'data',
+    component: ScrollPage,
+    route: '/data-scroll',
+  },
+  {
+    title: 'ScrollBox',
+    group: 'data',
+    component: ScrollBoxPage,
+    route: '/data-sbox',
+  },
   { title: 'Icons', group: 'data', component: IconsPage, route: '/data-icons' },
   { title: 'Table', group: 'data' },
   { title: 'Dialog', group: 'feedback' },

--- a/src/pattern-library/routes.js
+++ b/src/pattern-library/routes.js
@@ -190,16 +190,16 @@ const routes = [
     group: 'components',
   },
   {
+    title: 'ScrollBox',
+    group: 'data',
+    component: ScrollBoxPage,
+    route: '/data-scrollbox',
+  },
+  {
     title: 'Scroll',
     group: 'data',
     component: ScrollPage,
     route: '/data-scroll',
-  },
-  {
-    title: 'ScrollBox',
-    group: 'data',
-    component: ScrollBoxPage,
-    route: '/data-sbox',
   },
   { title: 'Icons', group: 'data', component: IconsPage, route: '/data-icons' },
   { title: 'Table', group: 'data' },

--- a/src/tailwind.preset.js
+++ b/src/tailwind.preset.js
@@ -3,6 +3,7 @@ import plugin from 'tailwindcss/plugin.js';
 import colors from 'tailwindcss/colors.js';
 
 import focusVisibleRing from './tailwind.focus-visible-ring.js';
+import scrollShadows from './tailwind.scroll-shadows.js';
 
 // Equivalent to spacing value 11; minimum touch-target size
 const minimumTouchDimension = '44px';
@@ -104,6 +105,8 @@ export default /** @type {Partial<import('tailwindcss').Config>} */ ({
   plugins: [
     // Make `.focus-visible-ring` an available utility class
     focusVisibleRing,
+    // Add `.scroll-shadows` for use by Scroll components
+    scrollShadows,
     plugin(({ addVariant }) => {
       // Add a custom variant such that the `theme-clean:` modifier is available
       // for all tailwind utility classes. e.g. `.theme-clean:bg-white` would

--- a/src/tailwind.scroll-shadows.js
+++ b/src/tailwind.scroll-shadows.js
@@ -1,0 +1,62 @@
+import plugin from 'tailwindcss/plugin.js';
+
+/**
+ * Utility class to show scroll-hint shadows at the top and bottom of a
+ * scrollable frame element if:
+ *  - The content height exceeds the frame height: i.e. can be scrolled, and
+ *  - The content is scrollable in the shadow's direction (up or down)
+ *
+ * Shadows are not visible once the frame has been scrolled all the way in the
+ * shadow's direction. Shadows are not visible if the height of the content
+ * does not overflow the frame (is not scrollable).
+ *
+ * The shadow hinting is handled by four positioned background gradients:
+ *   - One gradient each at top and bottom of frame that obscure the shadow hints
+ *     (shadow covers). These use `background-attachment: local`, which makes
+ *     their position fixed to the _content_ within the scrollbox.
+ *   - One gradient each at the top and the bottom of the frame that are the
+ *     shadow hints (shadows). These use `background-attachment: scroll` such
+ *     that they are always positioned at the top and the bottom of the
+ *     _scrollbox_ frame. When these positions align with the positions of the
+ *     shadow covers--at the top and the bottom of the overflowing content--
+ *     they will be obscured by those shadow covers.
+ *
+ * See https://lea.verou.me/2012/04/background-attachment-local/
+ *
+ * Safari's behavior can be different because of a bug with
+ * `background-attachment: local`.
+ * See https://bugs.webkit.org/show_bug.cgi?id=219324
+ * In Safari < 15.4:
+ *   - Scroll-hint shadows do not appear if content does not overflow (this is
+ *     consistent with other browsers)
+ *   - Only the bottom scroll-hint shadow appears if content overflows
+ *   - The bottom scroll-hint shadow is always present, even if content is
+ *     fully scrolled
+ */
+export default plugin(({ addUtilities }) => {
+  // These "shadow covers" scroll with the content. They align with and
+  // obscure the shadows when an element is scrolled all the way in one
+  // direction. If there is no overflow (nothing to scroll), these covers keep
+  // any shadows from showing.
+  const topShadowCover =
+    'linear-gradient(white 30%, rgba(255, 255, 255, 0)) 0 0';
+  const bottomShadowCover =
+    'linear-gradient(rgba(255, 255, 255, 0), white 70%) 0 100%';
+
+  // The shadows are in a fixed position (`background-attachment: scroll`)
+  // relative to the scrolling container.
+  const topShadow =
+    'linear-gradient(to bottom, rgba(0, 0, 0, 0.1), rgba(0, 0, 0, 0.05) 5px, rgba(255, 255, 255, 0) 70%) 0 0';
+  const bottomShadow =
+    'linear-gradient(to top, rgba(0, 0, 0, 0.1), rgba(0, 0, 0, 0.05) 5px, rgba(255, 255, 255, 0) 70%) 0 100%';
+
+  addUtilities({
+    '.scroll-shadows': {
+      background: `${topShadowCover}, ${bottomShadowCover}, ${topShadow}, ${bottomShadow}`,
+      backgroundRepeat: 'no-repeat',
+      backgroundColor: 'white',
+      backgroundSize: '100% 40px, 100% 40px, 100% 14px, 100% 14px',
+      backgroundAttachment: 'local, local, scroll, scroll',
+    },
+  });
+});

--- a/src/types.js
+++ b/src/types.js
@@ -12,6 +12,13 @@
  */
 
 /**
+ * Props common to components that are opinionated compositions of other
+ * components.
+ *
+ * @typedef {Omit<PresentationalProps, 'classes'>} CompositeProps
+ */
+
+/**
  * Props common to Base, abstract components. These are not part of the
  * package API.
  *


### PR DESCRIPTION
This PR adds new components: `Scroll`, `ScrollContainer`, `ScrollContent`, and `ScrollBox`. `Scroll`, `ScrollContainer` and `ScrollContent` are presentational components, which are composed by the composite component `ScrollBox`, which is meant to replace the legacy `Scrollbox` (note casing difference) component.

_Updated_: Pushed a couple additional commits to fix a bug with route matching and to put the `ScrollBox` link before `Scroll` in the nav for now. There's still some more thinking about how to arrange navigation best, but I'm kind of falling into a rathole with it so am going to put aside for now.

Depends on #505

### Testing

Check out this branch, run `make dev` and visit http://localhost:4001/data-scroll and http://localhost:4001/data-scrollbox

<img width="1599" alt="image" src="https://user-images.githubusercontent.com/439947/181060872-b19a1100-af73-444c-8657-7f9a5795cfcc.png">

<img width="1599" alt="image" src="https://user-images.githubusercontent.com/439947/181060909-221f0388-4a4d-4054-9f6f-745b6e89eaf3.png">


### Checklist

- [x] component(s) implementation
- [x] component tests
- [x] exports in package
- [x] test against `client` or `lms`
- [x] document in pattern library
- [x] deprecate associated legacy component(s)
- [x] remove any associated patterns
