### PR TITLE
Add documentation for Using Components

### DIFF
--- a/src/pattern-library/components/patterns/UsingComponents.js
+++ b/src/pattern-library/components/patterns/UsingComponents.js
@@ -1,0 +1,89 @@
+import Library from '../Library';
+
+import Next from '../LibraryNext';
+
+export default function UsingComponentsPage() {
+  return (
+    <Library.Page
+      title="Using components"
+      intro={
+        <>
+          <p>This guide applies to updated ({'"next"'}) components only.</p>
+        </>
+      }
+    >
+      <Library.Pattern title="Component categories">
+        <ul>
+          <li>
+            <strong>Simple components</strong>: Opinionated, simple components
+            that apply design patterns. Example: <code>Spinner</code>.
+          </li>
+          <li>
+            <strong>Presentational components</strong>: Composable components
+            with customization flexibility. Example: <code>Button</code>,{' '}
+            <code>Link</code>.
+          </li>
+          <li>
+            <strong>Composite components</strong>: These components are
+            combinations of presentational components arranged and styled in a
+            particular way to satisfy a use case. Example:{' '}
+            <code>ScrollBox</code>.
+          </li>
+        </ul>
+      </Library.Pattern>
+      <Library.Pattern title="Component API">
+        <p>The props accepted by a component combine:</p>
+        <ul>
+          <li>
+            <strong>Common props</strong> available to all components in its
+            category
+          </li>
+          <li>
+            <strong>Specific props</strong> for the component
+          </li>
+        </ul>
+
+        <p>
+          Documentation pages for components cover the props specific to the
+          component, and call out any deviation of the component from its{' '}
+          {"category's"} common props.
+        </p>
+
+        <Library.Example title="Simple components" />
+        <p>
+          <strong>Simple components</strong> are opinionated and take only
+          documented, component-specific props.
+        </p>
+        <Library.Example title="Presentational components" />
+        <p>
+          <strong>Presentational components</strong> have more customization
+          flexibility and take these common props:
+        </p>
+        <Next.Code
+          size="sm"
+          content={`/**
+ * @typedef PresentationalProps
+ * @prop {import('preact').ComponentChildren} [children]
+ * @prop {string|string[]} [classes] - Optional extra CSS classes to append to the
+ *   component's default classes
+ * @prop {never} [className] - Use variants, props, unstyled component (when
+ *   available) or classes instead
+ * @prop {import('preact').Ref<HTMLElement>} [elementRef] - Ref for component's
+ *   outermost element.
+ */
+`}
+        />
+        <Library.Example title="Composite components">
+          <p>
+            Composite components accept the same common props as presentational
+            components with the exception of{' '}
+            <s>
+              <code>classes</code>
+            </s>
+            .
+          </p>
+        </Library.Example>
+      </Library.Pattern>
+    </Library.Page>
+  );
+}

--- a/src/pattern-library/components/patterns/data/Icons.js
+++ b/src/pattern-library/components/patterns/data/Icons.js
@@ -9,7 +9,7 @@ export default function IconPage() {
   return (
     <Library.Page
       title="Icons"
-      intro={<p>Icons are available as standalone components.</p>}
+      intro={<p>Icons are simple, standalone components.</p>}
     >
       <Library.Pattern title="Status">
         <p>

--- a/src/pattern-library/routes.js
+++ b/src/pattern-library/routes.js
@@ -24,6 +24,7 @@ import ThumbnailComponents from './components/patterns/ThumbnailComponents';
 
 import GettingStartedPage from './components/patterns/GettingStarted';
 import CustomizingComponentsPage from './components/patterns/CustomizingComponents';
+import UsingComponentsPage from './components/patterns/UsingComponents';
 
 import IconsPage from './components/patterns/data/Icons';
 
@@ -69,6 +70,8 @@ const routes = [
   {
     title: 'Using components',
     group: 'foundations',
+    component: UsingComponentsPage,
+    route: '/using-components',
   },
   {
     route: '/foundations-colors',


### PR DESCRIPTION
This PR adds some basic documentation for how to use the different categories of components provided by the package and their APIs.

Run `make dev` and visit http://localhost:4001/using-components

<img width="1636" alt="image" src="https://user-images.githubusercontent.com/439947/180608674-da5d0fe0-0a18-4d9f-934b-5662cf4dc5b6.png">


Depends on #505 