### PR TITLE
Add JSX syntax highlighting

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "express": "^4.17.1",
     "fancy-log": "^2.0.0",
     "gulp": "^4.0.0",
+    "highlight.js": "^11.6.0",
     "karma": "^6.3.4",
     "karma-chai": "^0.1.0",
     "karma-chrome-launcher": "^3.1.0",

--- a/src/pattern-library/components/Library.js
+++ b/src/pattern-library/components/Library.js
@@ -4,7 +4,7 @@ import { useState } from 'preact/hooks';
 
 import { Frame } from '../../components/containers';
 
-import { jsxToString } from '../util/jsx-to-string';
+import { jsxToHTML } from '../util/jsx-to-string';
 
 /**
  * @typedef LibraryBaseProps
@@ -192,9 +192,10 @@ function Demo({ children, withSource = false, style = {}, title }) {
     return (
       <li key={idx}>
         <code>
-          <pre className="font-pre whitespace-pre-wrap break-words text-sm">
-            {jsxToString(child)}
-          </pre>
+          <pre
+            className="font-pre whitespace-pre-wrap break-words text-sm"
+            dangerouslySetInnerHTML={{ __html: jsxToHTML(child) }}
+          />
         </code>
       </li>
     );

--- a/src/pattern-library/components/LibraryNext.js
+++ b/src/pattern-library/components/LibraryNext.js
@@ -4,8 +4,9 @@
  */
 
 import classnames from 'classnames';
+import { useMemo } from 'preact/hooks';
 
-import { jsxToString } from '../util/jsx-to-string';
+import { jsxToHTML } from '../util/jsx-to-string';
 
 /**
  * Render a little label or pill next to changelog items
@@ -68,6 +69,8 @@ function ChangelogItem({ status, children }) {
  *     code block
  */
 function Code({ content, size, title }) {
+  const codeMarkup = useMemo(() => jsxToHTML(content), [content]);
+
   return (
     <figure className="space-y-2">
       <div
@@ -77,7 +80,10 @@ function Code({ content, size, title }) {
         )}
       >
         <code className="text-color-text-inverted">
-          <pre className="whitespace-pre-wrap">{jsxToString(content)}</pre>
+          <pre
+            className="whitespace-pre-wrap"
+            dangerouslySetInnerHTML={{ __html: codeMarkup }}
+          />
         </code>
       </div>
       {title && (

--- a/src/pattern-library/util/jsx-to-string.js
+++ b/src/pattern-library/util/jsx-to-string.js
@@ -1,3 +1,7 @@
+import hljs from 'highlight.js/lib/core';
+import hljsXMLLang from 'highlight.js/lib/languages/xml';
+import hljsJavascriptLang from 'highlight.js/lib/languages/javascript';
+
 /**
  * Escape `str` for use in a "-quoted string.
  *
@@ -98,4 +102,27 @@ export function jsxToString(vnode) {
   } else {
     return '';
   }
+}
+
+/**
+ * Render a JSX expression as syntax-highlighted HTML markup.
+ *
+ * For the syntax highlighting to be visible, a Highlight.js CSS stylesheet must be
+ * loaded on the page.
+ *
+ * @param {import('preact').ComponentChildren} vnode - JSX expression to render.
+ *   See {@link jsxToString}
+ * @return {string}
+ */
+export function jsxToHTML(vnode) {
+  // JSX support in Highlight.js involves a combination of the JS and XML
+  // languages, so we need to load both.
+  if (!hljs.getLanguage('javascript')) {
+    hljs.registerLanguage('javascript', hljsJavascriptLang);
+  }
+  if (!hljs.getLanguage('xml')) {
+    hljs.registerLanguage('xml', hljsXMLLang);
+  }
+  const code = jsxToString(vnode);
+  return hljs.highlightAuto(code).value;
 }

--- a/styles/pattern-library.scss
+++ b/styles/pattern-library.scss
@@ -9,3 +9,6 @@
 @use 'tailwindcss/utilities';
 @use 'tailwindcss/components';
 @use 'library';
+
+// Syntax highlighting style for Highlight.js.
+@use 'highlight.js/styles/github-dark.css';

--- a/yarn.lock
+++ b/yarn.lock
@@ -3765,6 +3765,11 @@ he@1.2.0:
   resolved "https://registry.npmjs.org/he/-/he-1.2.0.tgz"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
 
+highlight.js@^11.6.0:
+  version "11.6.0"
+  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-11.6.0.tgz#a50e9da05763f1bb0c1322c8f4f755242cff3f5a"
+  integrity sha512-ig1eqDzJaB0pqEvlPVIpSSyMaO92bH1N2rJpLMN/nX396wTpDA4Eq0uK+7I/2XG17pFaaKE0kjV/XPeGt7Evjw==
+
 homedir-polyfill@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz"


### PR DESCRIPTION
Add syntax highlighting to JSX code snippets. I looked at [Prism](https://prismjs.com) and [highlight.js](https://highlightjs.org). Highlight.js won as it has built-in types and better support for being imported as an ES module (ie. plays nicer with Rollup).

**Before:**

<img width="831" alt="No syntax highlighting" src="https://user-images.githubusercontent.com/2458/181046822-fee345d3-329d-490f-82b3-ca8ede26d83e.png">

**After:**

<img width="838" alt="JSX syntax highlighting" src="https://user-images.githubusercontent.com/2458/181046181-aa858446-d2df-4e55-8e83-0e562a1af0e8.png">
