### PR TITLE
Add data- attributes to components for better debugging

### DIFF
--- a/src/components/data/Scroll.js
+++ b/src/components/data/Scroll.js
@@ -37,6 +37,7 @@ export default function Scroll({
         { 'scroll-shadows': variant === 'raised' },
         classes
       )}
+      data-component="Scroll"
     >
       {children}
     </div>

--- a/src/components/data/ScrollBox.js
+++ b/src/components/data/ScrollBox.js
@@ -29,6 +29,7 @@ export default function ScrollBox({
       {...htmlAttributes}
       borderless={borderless}
       elementRef={elementRef}
+      data-composite-component="ScrollBox"
     >
       <Scroll>
         <ScrollContent>{children}</ScrollContent>

--- a/src/components/data/ScrollContainer.js
+++ b/src/components/data/ScrollContainer.js
@@ -34,6 +34,7 @@ export default function ScrollContainer({
         { border: !borderless },
         classes
       )}
+      data-component="ScrollContainer"
     >
       {children}
     </div>

--- a/src/components/data/ScrollContent.js
+++ b/src/components/data/ScrollContent.js
@@ -23,6 +23,7 @@ export default function ScrollContent({
       {...htmlAttributes}
       ref={downcastRef(elementRef)}
       className={classnames('px-3 py-2', classes)}
+      data-component="ScrollContent"
     >
       {children}
     </div>

--- a/src/components/feedback/Spinner.js
+++ b/src/components/feedback/Spinner.js
@@ -27,6 +27,7 @@ export default function Spinner({ size = 'sm', color = 'text-light' }) {
           'w-4em h-4em': size === 'lg',
         }
       )}
+      data-component="Spinner"
     />
   );
 }

--- a/src/components/input/Button.js
+++ b/src/components/input/Button.js
@@ -63,6 +63,7 @@ export default function Button({
       expanded={expanded}
       pressed={pressed}
       title={title}
+      data-component="Button"
     >
       {Icon && <Icon className="w-em h-em" />}
       {children}

--- a/src/components/input/ButtonUnstyled.js
+++ b/src/components/input/ButtonUnstyled.js
@@ -32,6 +32,7 @@ export default function ButtonUnstyled({
       expanded={expanded}
       pressed={pressed}
       title={title}
+      data-component="ButtonUnstyled"
     >
       {children}
     </ButtonBase>

--- a/src/components/input/IconButton.js
+++ b/src/components/input/IconButton.js
@@ -72,6 +72,7 @@ export default function IconButton({
       title={title}
       pressed={pressed}
       expanded={expanded}
+      data-component="IconButton"
     >
       {Icon && <Icon className="w-em h-em" />}
       {children}

--- a/src/components/input/test/IconButton-test.js
+++ b/src/components/input/test/IconButton-test.js
@@ -10,7 +10,7 @@ describe('IconButton', () => {
     return mount(<IconButton {...props} />);
   };
 
-  testPresentationalComponent(IconButton);
+  testPresentationalComponent(IconButton, 'IconButton');
 
   it('renders proportionally-sized icon', () => {
     const wrapper = createComponent({ icon: CancelIcon });

--- a/src/components/navigation/Link.js
+++ b/src/components/navigation/Link.js
@@ -48,6 +48,7 @@ export default function Link({
         classes
       )}
       elementRef={downcastRef(elementRef)}
+      data-component="Link"
     >
       {children}
     </LinkBase>

--- a/src/components/navigation/LinkUnstyled.js
+++ b/src/components/navigation/LinkUnstyled.js
@@ -24,6 +24,7 @@ export default function LinkUnstyled({
       {...htmlAttributes}
       className={classnames(classes)}
       elementRef={downcastRef(elementRef)}
+      data-component="LinkUnstyled"
     >
       {children}
     </LinkBase>

--- a/src/components/navigation/test/Link-test.js
+++ b/src/components/navigation/test/Link-test.js
@@ -3,5 +3,5 @@ import { testPresentationalComponent } from '../../test/common-tests';
 import Link from '../Link';
 
 describe('Link', () => {
-  testPresentationalComponent(Link);
+  testPresentationalComponent(Link, 'Link');
 });

--- a/src/components/test/common-tests.js
+++ b/src/components/test/common-tests.js
@@ -13,8 +13,11 @@ const createComponent = (Component, props = {}) => {
  * Set of tests common to all presentational components
  *
  * @param {FunctionComponent} Component
+ * @param {string} [componentName] - Temporary affordance to prevent name
+ *   collisions between updated components and legacy components with the same
+ *   component function name.
  */
-export function testCompositeComponent(Component) {
+export function testCompositeComponent(Component, componentName) {
   describe('Common composite functionality', () => {
     it('applies `ref` via `elementRef`', () => {
       const elementRef = createRef();
@@ -33,6 +36,16 @@ export function testCompositeComponent(Component) {
       assert.isTrue(wrapperOuterEl.hasAttribute('data-testid'));
       assert.equal(wrapperOuterEl.getAttribute('data-testid'), 'foo-container');
     });
+
+    it('applies a `data-composite-component` attribute for debugging', () => {
+      const wrapperOuterEl = createComponent(Component).childAt(0).getDOMNode();
+
+      assert.isTrue(wrapperOuterEl.hasAttribute('data-composite-component'));
+      assert.equal(
+        wrapperOuterEl.getAttribute('data-composite-component'),
+        componentName ?? Component.name
+      );
+    });
   });
 }
 
@@ -40,8 +53,11 @@ export function testCompositeComponent(Component) {
  * Set of tests common to all presentational components
  *
  * @param {import('preact').FunctionComponent} Component
+ * @param {string} [componentName] - Temporary affordance to prevent name
+ *   collisions between updated components and legacy components with the same
+ *   component function name.
  */
-export function testPresentationalComponent(Component) {
+export function testPresentationalComponent(Component, componentName) {
   describe('Common presentational functionality', () => {
     it('applies extra classes', () => {
       const wrapper = createComponent(Component, { classes: 'foo bar' });
@@ -72,6 +88,16 @@ export function testPresentationalComponent(Component) {
 
       assert.isTrue(wrapperOuterEl.hasAttribute('data-testid'));
       assert.equal(wrapperOuterEl.getAttribute('data-testid'), 'foo-container');
+    });
+
+    it('applies a `data-component` attribute for debugging', () => {
+      const wrapperOuterEl = createComponent(Component).childAt(0).getDOMNode();
+
+      assert.isTrue(wrapperOuterEl.hasAttribute('data-component'));
+      assert.equal(
+        wrapperOuterEl.getAttribute('data-component'),
+        componentName ?? Component.name
+      );
     });
   });
 }


### PR DESCRIPTION
This PR adds `data-component` and `data-composite-component` attributes to all components' outer elements and adds tests to ensure we keep these up-to-date and consistent.

The `data-composite-component` attribute is necessary for composite components, whose outermost container is another component. Thus for `ScrollBox` the outer `div` is both a `ScrollBox` and a `ScrollContainer`:

`<div data-composite-component="ScrollBox" class="..." data-component="ScrollContainer">`

I added an optional `componentName` parameter to common tests to account for component-name collisions during this time of re-implementation.