### PR TITLE
Make `highlight.js` a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,6 @@
   "main": "./lib/index.js",
   "browserslist": "chrome 70, firefox 70, safari 11.1",
   "dependencies": {
-    "highlight.js": "^11.6.0",
-    "normalize.css": "^8.0.1"
+    "highlight.js": "^11.6.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "express": "^4.17.1",
     "fancy-log": "^2.0.0",
     "gulp": "^4.0.0",
-    "highlight.js": "^11.6.0",
     "karma": "^6.3.4",
     "karma-chai": "^0.1.0",
     "karma-chrome-launcher": "^3.1.0",
@@ -82,6 +81,7 @@
   "main": "./lib/index.js",
   "browserslist": "chrome 70, firefox 70, safari 11.1",
   "dependencies": {
+    "highlight.js": "^11.6.0",
     "normalize.css": "^8.0.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5055,11 +5055,6 @@ normalize-range@^0.1.2:
   resolved "https://registry.yarnpkg.com/normalize-range/-/normalize-range-0.1.2.tgz#2d10c06bdfd312ea9777695a4d28439456b75942"
   integrity sha1-LRDAa9/TEuqXd2laTShDlFa3WUI=
 
-normalize.css@^8.0.1:
-  version "8.0.1"
-  resolved "https://registry.yarnpkg.com/normalize.css/-/normalize.css-8.0.1.tgz#9b98a208738b9cc2634caacbc42d131c97487bf3"
-  integrity sha512-qizSNPO93t1YUuUhP22btGOo3chcvDFqFaj2TRybP0DMxkHOCTYwp3n34fel4a31ORXy4m1Xq0Gyqpb5m33qIg==
-
 now-and-later@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/now-and-later/-/now-and-later-2.0.1.tgz"


### PR DESCRIPTION
It's needed for other apps to be able to build the pattern library.

Also remove a wayward unused dependency on `normalize.css`