### PR TITLE
Improve rendering of JSX props whose values are JSX expressions

### DIFF
--- a/src/pattern-library/util/jsx-to-string.js
+++ b/src/pattern-library/util/jsx-to-string.js
@@ -1,6 +1,7 @@
 import hljs from 'highlight.js/lib/core';
 import hljsXMLLang from 'highlight.js/lib/languages/xml';
 import hljsJavascriptLang from 'highlight.js/lib/languages/javascript';
+import { Fragment } from 'preact';
 
 /**
  * Escape `str` for use in a "-quoted string.
@@ -64,8 +65,6 @@ export function jsxToString(vnode) {
   } else if (typeof vnode === 'boolean') {
     return '';
   } else if (vnode && 'type' in vnode) {
-    const name = componentName(vnode.type);
-
     // nb. The special `key` and `ref` props are not included in `vnode.props`.
     // `ref` is not serializable to a string and `key` is generally set dynamically
     // (eg. from an index or item ID) so it doesn't make sense to include it either.
@@ -102,6 +101,7 @@ export function jsxToString(vnode) {
       propStr = ' ' + propStr;
     }
 
+    const name = vnode.type === Fragment ? '' : componentName(vnode.type);
     const children = vnode.props.children;
     if (children) {
       let childrenStr = Array.isArray(children)

--- a/src/pattern-library/util/jsx-to-string.js
+++ b/src/pattern-library/util/jsx-to-string.js
@@ -32,6 +32,17 @@ function indentLines(str, indent) {
 }
 
 /**
+ * Test if an element looks like a JSX element.
+ *
+ * @param {any} value
+ * @return {value is import('preact').VNode<any>}
+ */
+function isJSXElement(value) {
+  const elementType = value?.type;
+  return typeof elementType === 'string' || typeof elementType === 'function';
+}
+
+/**
  * Render a JSX expression as a code string.
  *
  * Currently this only supports serializing props with simple types (strings,
@@ -77,6 +88,8 @@ export function jsxToString(vnode) {
         } else if (typeof value === 'function' && componentName(value)) {
           // Handle {import("preact").FunctionComponent<{}>} props
           valueStr = `{${componentName(value)}}`;
+        } else if (isJSXElement(value)) {
+          valueStr = `{${jsxToString(value)}}`;
         } else if (value) {
           // `toString` necessary for Symbols
           valueStr = `{${value.toString()}}`;


### PR DESCRIPTION
Call `jsxToString` recursively to render these prop values as readable JSX strings, rather than just stringifying them, which produces the string `[object Object]`. I also fixed rendering of fragments in this function. Previously they were rendered as `<p>...</p>` instead of `<>...</>` because the minified `Fragment` function happened to have a `name` property value of `p`.

**Before:**

<img width="752" alt="JSX attr before" src="https://user-images.githubusercontent.com/2458/181487842-1711280d-c620-4bbd-b6e3-427f5629c4ea.png">

**After:**

<img width="748" alt="JSX attr after v2" src="https://user-images.githubusercontent.com/2458/181490874-d4cc349b-361c-4464-81c7-92188a8a93f1.png">

Note that in the "after" screenshot the text inside the JSX element has some incorrect highlighting. From various discussions in the Highlight.js repository I believe this is due to its relatively crude regex-based processing and the way JSX support is implemented, although I'd need to look into that deeper to get a better understanding.

