### PR TITLE
Fix CSS typo that breaks `ScrollContainer`

### DIFF
--- a/src/components/data/ScrollContainer.js
+++ b/src/components/data/ScrollContainer.js
@@ -30,7 +30,7 @@ export default function ScrollContainer({
       {...htmlAttributes}
       ref={downcastRef(elementRef)}
       className={classnames(
-        'flex flex-colh-full w-full',
+        'flex flex-col h-full w-full',
         // Prevent overflow by overriding `min-height: auto`.
         // See https://stackoverflow.com/a/66689926/434243.
         'min-h-0',


### PR DESCRIPTION
Accidentally deleted a space when adding commenting for `min-height`