### PR TITLE
Intercept in-app anchor links and trigger client-side navigation

### DIFF
--- a/src/pattern-library/components/PlaygroundApp.js
+++ b/src/pattern-library/components/PlaygroundApp.js
@@ -32,14 +32,15 @@ export default function PlaygroundApp({
 }) {
   const routes = getRoutes();
   const allRoutes = routes.concat(extraRoutes);
-  const [activeRoute, navigate] = useRoute(baseURL, allRoutes);
-  const content = activeRoute ? (
-    <activeRoute.component />
-  ) : (
-    <Library.Page title=":( Sorry">
-      <h1 className="text-2xl">Page not found</h1>
-    </Library.Page>
-  );
+  const [activeRoute] = useRoute(baseURL, allRoutes);
+  const content =
+    activeRoute && activeRoute.component ? (
+      <activeRoute.component />
+    ) : (
+      <Library.Page title=":( Sorry">
+        <h1 className="text-2xl">Page not found</h1>
+      </Library.Page>
+    );
 
   /**
    * Header for a primary section of nav
@@ -70,7 +71,6 @@ export default function PlaygroundApp({
               'border-transparent': activeRoute?.route !== route.route,
             })}
             href={route.route.toString()}
-            onClick={e => navigate(e, route.route)}
           >
             {route.title}
           </Link>
@@ -122,11 +122,7 @@ export default function PlaygroundApp({
         <div className="md:h-screen md:sticky md:top-0 overflow-scroll">
           <div className="md:sticky md:top-0 h-16 px-6 flex items-center bg-slate-0 border-b">
             <h1>
-              <Link
-                href={baseURL}
-                classes="grow flex gap-x-2 text-lg"
-                onClick={e => navigate(e, '/')}
-              >
+              <Link href={baseURL + '/'} classes="grow flex gap-x-2 text-lg">
                 <SvgIcon name="logo" />
                 Component Library
               </Link>


### PR DESCRIPTION
Previously clicking on a link from within the content of a page to another page
would trigger a full page reload. Only the links in the navigation bar used
client-side navigation. Update the router to intercept all clicks on "in-app"
URLs and handle them client-side.

In the process add missing types in `router.js`, and remove the custom `onClick`
handlers for links in the navbar, which are no longer required.

We discussed that we might want to replace the custom router with a 3rd-party
solution at some point, but we will need to evaluate options.

**Testing:**

1. Click around the links in the navigation bar, including the Hypothesis logo. They should work as before.
2. Go to the Spinner page (http://localhost:4001/feedback-spinner) and click on the "SpinnerSpokesIcon" link near the top. It should do a client-side navigation and scroll to the appropriate location.