### PR TITLE
Add `Input` and `InputGroup` components

### DIFF
--- a/src/components/TextInput.js
+++ b/src/components/TextInput.js
@@ -26,6 +26,7 @@ import classnames from 'classnames';
 /**
  * Wrap a textual `<input>` element with some styles and provide error UI
  *
+ * @deprecated - Use Input component in the input group
  * @param {TextInputProps} props
  */
 export function TextInput({
@@ -60,6 +61,7 @@ export function TextInput({
  *
  * Current implementation assumes the input is on the left and button on right.
  *
+ * @deprecated - Use InputGroup component in the input group
  * @param {TextInputWithButtonProps} props
  */
 export function TextInputWithButton({ children, classes = '' }) {

--- a/src/components/input/IconButton.js
+++ b/src/components/input/IconButton.js
@@ -2,6 +2,8 @@ import classnames from 'classnames';
 
 import { downcastRef } from '../../util/typing';
 
+import { inputGroupStyles } from './InputGroup';
+
 import ButtonBase from './ButtonBase';
 
 /**
@@ -66,6 +68,8 @@ const IconButtonNext = function IconButton({
           'touch:min-w-touch-minimum touch:min-h-touch-minimum':
             !disableTouchSizing,
         },
+        // Adapt styling when this component is inside an InputGroup
+        inputGroupStyles,
         classes
       )}
       elementRef={downcastRef(elementRef)}

--- a/src/components/input/IconButton.js
+++ b/src/components/input/IconButton.js
@@ -61,7 +61,7 @@ const IconButtonNext = function IconButton({
 
           // size
           'p-2': size === 'md', // Default
-          'p-1': size === 'sm',
+          'p-1.5': size === 'sm',
           'p-3': size === 'lg',
 
           // Responsive

--- a/src/components/input/Input.js
+++ b/src/components/input/Input.js
@@ -1,0 +1,52 @@
+import classnames from 'classnames';
+
+import { downcastRef } from '../../util/typing';
+
+import { inputGroupStyles } from './InputGroup';
+
+/**
+ * @typedef {import('../../types').PresentationalProps} CommonProps
+ * @typedef {import('preact').JSX.HTMLAttributes<HTMLInputElement>} HTMLInputAttributes
+ *
+ * @typedef InputProps
+ * @prop {boolean} [hasError=false]
+ * @prop {'email'|'search'|'text'|'url'} [type="text"]
+ */
+
+/**
+ * Render a text field input
+ *
+ * @param {CommonProps & InputProps & Omit<HTMLInputAttributes, 'type'>} props
+ */
+const InputNext = function Input({
+  children,
+  classes,
+  elementRef,
+
+  hasError,
+  type = 'text',
+
+  ...htmlAttributes
+}) {
+  return (
+    <input
+      {...htmlAttributes}
+      type={type}
+      ref={downcastRef(elementRef)}
+      className={classnames(
+        'focus-visible-ring ring-inset border rounded-sm w-full p-2',
+        'bg-grey-0 focus:bg-white disabled:bg-grey-1',
+        'placeholder:text-color-grey-5 disabled:placeholder:color-grey-6',
+        { 'ring-inset ring-2 ring-red-error': hasError },
+        // Adapt styles when this component is inside an InputGroup
+        inputGroupStyles,
+        classes
+      )}
+      data-component="Input"
+    >
+      {children}
+    </input>
+  );
+};
+
+export default InputNext;

--- a/src/components/input/InputGroup.js
+++ b/src/components/input/InputGroup.js
@@ -1,0 +1,51 @@
+import classnames from 'classnames';
+
+import { downcastRef } from '../../util/typing';
+
+/**
+ * @typedef {import('../../types').PresentationalProps} CommonProps
+ * @typedef {import('preact').JSX.HTMLAttributes<HTMLElement>} HTMLAttributes
+ */
+
+// These styles may be applied to input components to adapt them when in
+// an InputGroup
+export const inputGroupStyles = classnames(
+  // All inputs within an InputGroup should have a border. Turn off border-radius
+  'input-group:border input-group:rounded-none',
+  // Restore border-radius on the leftmost and rightmost components in the group
+  'input-group:first:rounded-l-sm input-group:last:rounded-r-sm',
+  // "Collapse" borders between input components
+  'input-group:border-l-0 input-group:first:border-l'
+);
+
+/**
+ * Render a container that lays out a group of input components
+ *
+ * @param {CommonProps & HTMLAttributes} props
+ */
+const InputGroupNext = function InputGroup({
+  children,
+  classes,
+  elementRef,
+
+  ...htmlAttributes
+}) {
+  return (
+    <div
+      {...htmlAttributes}
+      ref={downcastRef(elementRef)}
+      className={classnames(
+        // Set the `.input-group` class so that children may
+        // use the `input-group:` variant in their styles
+        'input-group',
+        'flex items-stretch w-full justify-center',
+        classes
+      )}
+      data-component="InputGroup"
+    >
+      {children}
+    </div>
+  );
+};
+
+export default InputGroupNext;

--- a/src/components/input/index.js
+++ b/src/components/input/index.js
@@ -1,3 +1,5 @@
 export { default as Button } from './Button';
 export { default as ButtonUnstyled } from './ButtonUnstyled';
 export { default as IconButton } from './IconButton';
+export { default as Input } from './Input';
+export { default as InputGroup } from './InputGroup';

--- a/src/components/input/test/Input-test.js
+++ b/src/components/input/test/Input-test.js
@@ -1,0 +1,7 @@
+import { testPresentationalComponent } from '../../test/common-tests';
+
+import Input from '../Input';
+
+describe('Input', () => {
+  testPresentationalComponent(Input);
+});

--- a/src/components/input/test/InputGroup-test.js
+++ b/src/components/input/test/InputGroup-test.js
@@ -1,0 +1,7 @@
+import { testPresentationalComponent } from '../../test/common-tests';
+
+import InputGroup from '../InputGroup';
+
+describe('InputGroup', () => {
+  testPresentationalComponent(InputGroup);
+});

--- a/src/next.js
+++ b/src/next.js
@@ -1,5 +1,4 @@
 export * from './components/icons';
-
 export {
   Scroll,
   ScrollContent,
@@ -7,7 +6,13 @@ export {
   ScrollBox,
 } from './components/data';
 export { Spinner } from './components/feedback';
-export { Button, ButtonUnstyled, IconButton } from './components/input';
+export {
+  Button,
+  ButtonUnstyled,
+  IconButton,
+  Input,
+  InputGroup,
+} from './components/input';
 export {
   Card,
   CardContent,

--- a/src/pattern-library/components/LibraryNext.js
+++ b/src/pattern-library/components/LibraryNext.js
@@ -63,7 +63,7 @@ function ChangelogItem({ status, children }) {
  * Render provided `content` as a "code block" example.
  *
  * @param {object} props
- *   @param {string} props.content - Code content
+ *   @param {import('preact').ComponentChildren} props.content - Code content
  *   @param {'sm'|'md'|'lg'} [props.size]
  *   @param {string} [props.title] - Caption (e.g. filename, description) of
  *     code block

--- a/src/pattern-library/components/patterns/FormComponents.js
+++ b/src/pattern-library/components/patterns/FormComponents.js
@@ -7,6 +7,7 @@ import {
   TextInputWithButton,
 } from '../../..';
 import Library from '../Library';
+import Next from '../LibraryNext';
 
 export default function FormComponents() {
   const [wantSandwich, setWantSandwich] = useState(true);
@@ -14,6 +15,27 @@ export default function FormComponents() {
   const [textInputHasError, setTextInputHasError] = useState(true);
   return (
     <Library.Page title="Forms">
+      <Library.Pattern title="Status">
+        <Next.Changelog>
+          <Next.ChangelogItem status="deprecated">
+            <s>
+              <code>TextInput</code>
+            </s>{' '}
+            is deprecated and slated for removal in v6 of{' '}
+            <code>frontend-shared</code>. Use
+            <code>Input</code> component in the input group instead.
+          </Next.ChangelogItem>
+          <Next.ChangelogItem status="deprecated">
+            <s>
+              <code>TextInputWithButton</code>
+            </s>{' '}
+            is deprecated and slated for removal in v6 of{' '}
+            <code>frontend-shared</code>. Use
+            <code>InputGroup</code> component in the input group instead.
+          </Next.ChangelogItem>
+        </Next.Changelog>
+      </Library.Pattern>
+
       <Library.Pattern title="LabeledCheckbox">
         <Library.Example title="Unchecked (default)">
           <div style="font-size: 2em">

--- a/src/pattern-library/components/patterns/FormPatterns.js
+++ b/src/pattern-library/components/patterns/FormPatterns.js
@@ -1,4 +1,4 @@
-import { IconButton, SvgIcon } from '../../../';
+import { SvgIcon } from '../../../';
 import Library from '../Library';
 
 export default function FormPatterns() {
@@ -37,63 +37,6 @@ export default function FormPatterns() {
               <SvgIcon name="checkbox" />
               <span>Click me, please</span>
             </label>
-          </Library.Demo>
-        </Library.Example>
-      </Library.Pattern>
-
-      <Library.Pattern title="Text inputs">
-        <p>
-          A pattern for <code>input type=&quot;text&quot;</code>
-        </p>
-        <Library.Example title="Basic text input">
-          <Library.Demo withSource>
-            <input
-              className="hyp-text-input"
-              type="text"
-              placeholder="http://www.example.com"
-            />
-          </Library.Demo>
-        </Library.Example>
-
-        <Library.Example title="Text input in an error state">
-          <Library.Demo withSource>
-            <input
-              className="hyp-text-input has-error"
-              type="text"
-              placeholder="http://www.example.com"
-            />
-          </Library.Demo>
-        </Library.Example>
-      </Library.Pattern>
-
-      <Library.Pattern title="Text input with button">
-        <p>
-          A pattern that pairs a text input field with an icon-only button. Use
-          a dark-variant button to match the standard pattern here.
-        </p>
-        <Library.Example title="Text input with a dark-variant IconButton">
-          <Library.Demo withSource>
-            <div style={{ width: '300px' }}>
-              <div className="hyp-text-input-with-button">
-                <input type="text" placeholder="http://www.example.com" />
-                <IconButton icon="arrow-right" title="go" variant="dark" />
-              </div>
-            </div>
-          </Library.Demo>
-        </Library.Example>
-
-        <Library.Example title="Text input and button in an error state">
-          <Library.Demo withSource>
-            <div style={{ width: '300px' }}>
-              <div className="hyp-text-input-with-button">
-                <input
-                  type="text"
-                  placeholder="http://www.example.com"
-                  className="has-error"
-                />
-                <IconButton icon="arrow-right" title="go" variant="dark" />
-              </div>
-            </div>
           </Library.Demo>
         </Library.Example>
       </Library.Pattern>

--- a/src/pattern-library/components/patterns/UtilitiesPage.js
+++ b/src/pattern-library/components/patterns/UtilitiesPage.js
@@ -1,4 +1,7 @@
+import { Link } from '../../../next';
+
 import Library from '../Library';
+import Next from '../LibraryNext';
 
 export default function UtilitiesPage() {
   return (
@@ -68,6 +71,71 @@ export default function UtilitiesPage() {
             >
               Button
             </button>
+          </Library.Demo>
+        </Library.Example>
+        <Library.Example title="Styling groups of inputs">
+          <p>
+            The <code>input-group</code> modifier allows adaptation of styling
+            on inputs when they are part of a group of inputs. This is identical
+            in functionality to the{' '}
+            <Link
+              href="https://tailwindcss.com/docs/hover-focus-and-other-states#styling-based-on-parent-state"
+              underline="always"
+            >
+              tailwind <code>group</code> modifier
+            </Link>{' '}
+            but is {'"namespaced"'} to associate it with its more targeted
+            usage.
+          </p>
+
+          <p>
+            Each of the <code>button</code>s used in the following grouping
+            examples has the markup shown below. The <code>rounded-lg</code>{' '}
+            class sets border-radius on the buttons, but{' '}
+            <code>input-group:rounded-none</code> removes it when the buttons
+            are inside of an <code>input-group</code>.
+          </p>
+
+          <Next.Code
+            content={
+              <button className="border p-2 rounded-lg input-group:rounded-none">
+                Label
+              </button>
+            }
+            title="Button element styling"
+          />
+
+          <Library.Demo title="buttons in an .input-group" withSource>
+            <div className="input-group">
+              <div className="flex gap-x-2 input-group:gap-x-0">
+                <button className="border p-2 rounded-lg input-group:rounded-none">
+                  One
+                </button>
+                <button className="border p-2 rounded-lg input-group:rounded-none">
+                  Two
+                </button>
+                <button className="border p-2 rounded-lg input-group:rounded-none">
+                  Three
+                </button>
+              </div>
+            </div>
+          </Library.Demo>
+
+          <Library.Demo
+            title="The same buttons not in an .input-group"
+            withSource
+          >
+            <div className="flex gap-x-2 input-group:gap-x-0">
+              <button className="border p-2 rounded-lg input-group:rounded-none">
+                One
+              </button>
+              <button className="border p-2 rounded-lg input-group:rounded-none">
+                Two
+              </button>
+              <button className="border p-2 rounded-lg input-group:rounded-none">
+                Three
+              </button>
+            </div>
           </Library.Demo>
         </Library.Example>
       </Library.Pattern>

--- a/src/pattern-library/components/patterns/input/InputGroupPage.js
+++ b/src/pattern-library/components/patterns/input/InputGroupPage.js
@@ -1,0 +1,76 @@
+import { InputGroup, Input, IconButton, CopyIcon } from '../../../../next';
+import Library from '../../Library';
+import Next from '../../LibraryNext';
+
+export default function InputGroupPage() {
+  return (
+    <Library.Page
+      title="InputGroup"
+      intro={
+        <p>
+          <code>InputGroup</code> is a presentational component that provides
+          layout for groups of input components.
+        </p>
+      }
+    >
+      <Library.Pattern title="Status">
+        <p>
+          <code>InputGroup</code> is a new component based loosely on the legacy{' '}
+          <code>TextInputWithButton</code> component.
+        </p>
+      </Library.Pattern>
+      <Library.Pattern title="Usage">
+        <Next.Usage componentName="InputGroup" />
+        <Library.Example>
+          <Library.Demo
+            title="Basic InputGroup with an Input and an IconButton"
+            withSource
+          >
+            <div className="w-[350px]">
+              <InputGroup>
+                <Input name="test" />
+                <IconButton icon={CopyIcon} title="copy" variant="dark" />
+              </InputGroup>
+            </div>
+          </Library.Demo>
+        </Library.Example>
+
+        <Library.Example title="Scaling InputGroup size">
+          <p>
+            This example demonstrates <code>InputGroup</code> inputs scaling to
+            the local font size.
+          </p>
+          <Library.Demo withSource>
+            <div className="w-[350px]">
+              <div className="text-xs">
+                <InputGroup>
+                  <Input name="test" />
+                  <IconButton
+                    icon={CopyIcon}
+                    title="copy"
+                    size="sm"
+                    variant="dark"
+                  />
+                </InputGroup>
+              </div>
+            </div>
+          </Library.Demo>
+        </Library.Example>
+        <Library.Example title="Group-able Inputs">
+          <p>
+            The following input components are supported by{' '}
+            <code>InputGroup</code>:
+          </p>
+          <ul>
+            <li>
+              <code>Input</code>
+            </li>
+            <li>
+              <code>IconButton</code>
+            </li>
+          </ul>
+        </Library.Example>
+      </Library.Pattern>
+    </Library.Page>
+  );
+}

--- a/src/pattern-library/components/patterns/input/InputPage.js
+++ b/src/pattern-library/components/patterns/input/InputPage.js
@@ -1,0 +1,92 @@
+import { Input } from '../../../../next';
+import Library from '../../Library';
+import Next from '../../LibraryNext';
+
+export default function InputPage() {
+  return (
+    <Library.Page
+      title="Input"
+      intro={
+        <p>
+          <code>Input</code> is a presentational component for styling textual{' '}
+          <code>input</code> elements.
+        </p>
+      }
+    >
+      <Library.Pattern title="Status">
+        <p>
+          <code>Input</code> is new component modeled after the{' '}
+          <code>TextInput</code> legacy component.
+        </p>
+
+        <Library.Example title="Migrating to this component (from TextInput)">
+          <Next.Changelog>
+            <Next.ChangelogItem status="breaking">
+              Prop name:{' '}
+              <s>
+                <code>inputRef</code>
+              </s>{' '}
+              ➜ <code>elementRef</code>
+            </Next.ChangelogItem>
+            <Next.ChangelogItem status="changed">
+              The <code>input</code> element now stretches to fill all available
+              horizontal space
+            </Next.ChangelogItem>
+          </Next.Changelog>
+        </Library.Example>
+      </Library.Pattern>
+      <Library.Pattern title="Usage">
+        <Next.Usage componentName="Input" />
+
+        <Library.Example>
+          <Library.Demo title="Basic Input" withSource>
+            <div className="w-[350px]">
+              <Input placeholder="Placeholder..." />
+            </div>
+          </Library.Demo>
+        </Library.Example>
+      </Library.Pattern>
+
+      <Library.Pattern title="type">
+        <p>
+          <code>Input</code> currently supports the following <code>type</code>{' '}
+          values:
+        </p>
+        <ul>
+          <li>
+            <code>text</code> (default)
+          </li>
+          <li>
+            <code>url</code>
+          </li>
+          <li>
+            <code>email</code>
+          </li>
+          <li>
+            <code>text</code>
+          </li>
+        </ul>
+      </Library.Pattern>
+
+      <Library.Pattern title="hasError">
+        <Library.Example>
+          <Library.Demo title="Input with an associated error" withSource>
+            <div className="w-[350px]">
+              <Input hasError value="something invalid" />
+            </div>
+          </Library.Demo>
+        </Library.Example>
+      </Library.Pattern>
+
+      <Library.Pattern title="disabled">
+        <Library.Example>
+          <Library.Demo withSource>
+            <div className="w-[350px]">
+              <Input placeholder="Disabled..." disabled />
+            </div>
+          </Library.Demo>
+        </Library.Example>
+      </Library.Pattern>
+    </Library.Page>
+  );
+}

--- a/src/pattern-library/routes.js
+++ b/src/pattern-library/routes.js
@@ -14,6 +14,8 @@ import SpinnerPage from './components/patterns/feedback/SpinnerPage';
 
 import ButtonsPage from './components/patterns/input/ButtonPage';
 import IconButtonPage from './components/patterns/input/IconButtonPage';
+import InputPage from './components/patterns/input/InputPage';
+import InputGroupPage from './components/patterns/input/InputGroupPage';
 
 import CardPage from './components/patterns/layout/CardPage';
 import PanelPage from './components/patterns/layout/PanelPage';
@@ -215,7 +217,6 @@ const routes = [
     component: ButtonsPage,
     route: '/input-button',
   },
-  { title: 'Checkbox', group: 'input' },
   {
     title: 'IconButton',
     group: 'input',
@@ -223,7 +224,6 @@ const routes = [
     route: '/input-iconbutton',
   },
   { title: 'LinkButton', group: 'input' },
-  { title: 'TextField', group: 'input' },
   {
     title: 'Panel',
     group: 'layout',
@@ -236,6 +236,19 @@ const routes = [
     component: CardPage,
     route: '/layout-card',
   },
+  {
+    title: 'Input',
+    group: 'input',
+    component: InputPage,
+    route: '/input-input',
+  },
+  {
+    title: 'InputGroup',
+    group: 'input',
+    component: InputGroupPage,
+    route: '/input-input-group',
+  },
+  { title: 'Checkbox', group: 'input' },
   {
     title: 'Link',
     group: 'navigation',

--- a/src/tailwind.preset.js
+++ b/src/tailwind.preset.js
@@ -108,6 +108,12 @@ export default /** @type {Partial<import('tailwindcss').Config>} */ ({
     // Add `.scroll-shadows` for use by Scroll components
     scrollShadows,
     plugin(({ addVariant }) => {
+      // Add a custom variant to mark an element to serve as a container for
+      // a set of grouped input components. This is the same functionality
+      // as Tailwind's built-in "group" variant, but with a different name for
+      // clarity of purpose.
+      // See https://tailwindcss.com/docs/hover-focus-and-other-states#styling-based-on-parent-state
+      addVariant('input-group', '.input-group &');
       // Add a custom variant such that the `theme-clean:` modifier is available
       // for all tailwind utility classes. e.g. `.theme-clean:bg-white` would
       // only apply (set the element's background color to white) if a parent

--- a/styles/patterns/_forms.scss
+++ b/styles/patterns/_forms.scss
@@ -1,13 +1,5 @@
 @use '../mixins/patterns/forms';
 
-.hyp-text-input {
-  @include forms.text-input;
-}
-
-.hyp-text-input-with-button {
-  @include forms.text-input-with-button;
-}
-
 .hyp-label {
   @include forms.label;
 }


### PR DESCRIPTION
This PR adds `Input` and `InputGroup` components, which are intended to replace `TextInput` and `TextInputWithButton` respectively.

`Input` is fairly self-explanatory. `InputGroup` is a simpler and more flexible implementation of what `TextInputWithButton` did: allows for styling adaptations of inputs when they are in a "group." 

See http://localhost:4001/input-input and http://localhost:4001/input-input-group

Note: It would be breathtakingly simple to make the `Button` component group-able, a la `IconButton`; I held back because we don't have a current use case for it. It would allow for combinations like:

<img width="400" alt="Screen Shot 2022-07-28 at 3 25 13 PM" src="https://user-images.githubusercontent.com/439947/181811585-74b64259-64f7-4bf1-a194-6e7a30b30626.png">

<img width="195" alt="Screen Shot 2022-07-28 at 3 25 18 PM" src="https://user-images.githubusercontent.com/439947/181811607-f118397b-761c-4266-b80e-e19679243d82.png">

Depends on #533 
Fixes #524 
Fixes #525