### PR TITLE
Differentiate export names from function names in components

### DIFF
--- a/src/components/data/Scroll.js
+++ b/src/components/data/Scroll.js
@@ -16,7 +16,7 @@ import { downcastRef } from '../../util/typing';
  *
  * @param {CommonProps & ScrollProps & HTMLAttributes} props
  */
-export default function Scroll({
+const ScrollNext = function Scroll({
   children,
   classes,
   elementRef,
@@ -42,4 +42,6 @@ export default function Scroll({
       {children}
     </div>
   );
-}
+};
+
+export default ScrollNext;

--- a/src/components/data/ScrollBox.js
+++ b/src/components/data/ScrollBox.js
@@ -16,7 +16,7 @@ import ScrollContent from './ScrollContent';
  *
  * @param {CompositeProps & ScrollBoxProps} props
  */
-export default function ScrollBox({
+const ScrollBoxNext = function ScrollBox({
   children,
   elementRef,
 
@@ -36,4 +36,6 @@ export default function ScrollBox({
       </Scroll>
     </ScrollContainer>
   );
-}
+};
+
+export default ScrollBoxNext;

--- a/src/components/data/ScrollContainer.js
+++ b/src/components/data/ScrollContainer.js
@@ -16,7 +16,7 @@ import { downcastRef } from '../../util/typing';
  *
  * @param {CommonProps & ScrollContainerProps & HTMLDivAttributes} props
  */
-export default function ScrollContainer({
+const ScrollContainerNext = function ScrollContainer({
   children,
   classes,
   elementRef,
@@ -42,4 +42,6 @@ export default function ScrollContainer({
       {children}
     </div>
   );
-}
+};
+
+export default ScrollContainerNext;

--- a/src/components/data/ScrollContent.js
+++ b/src/components/data/ScrollContent.js
@@ -12,7 +12,7 @@ import { downcastRef } from '../../util/typing';
  *
  * @param {CommonProps & HTMLDivAttributes} props
  */
-export default function ScrollContent({
+const ScrollContentNext = function ScrollContent({
   children,
   classes,
   elementRef,
@@ -28,4 +28,6 @@ export default function ScrollContent({
       {children}
     </div>
   );
-}
+};
+
+export default ScrollContentNext;

--- a/src/components/feedback/Spinner.js
+++ b/src/components/feedback/Spinner.js
@@ -13,7 +13,7 @@ import { SpinnerSpokesIcon } from '../icons';
  *
  * @param {SpinnerProps} props
  */
-export default function Spinner({ size = 'sm', color = 'text-light' }) {
+const SpinnerNext = function Spinner({ size = 'sm', color = 'text-light' }) {
   return (
     <SpinnerSpokesIcon
       className={classnames(
@@ -30,4 +30,6 @@ export default function Spinner({ size = 'sm', color = 'text-light' }) {
       data-component="Spinner"
     />
   );
-}
+};
+
+export default SpinnerNext;

--- a/src/components/input/Button.js
+++ b/src/components/input/Button.js
@@ -23,7 +23,7 @@ import ButtonBase from './ButtonBase';
  *
  * @param {CommonProps & ButtonCommonProps & ButtonProps & HTMLButtonAttributes} props
  */
-export default function Button({
+const ButtonNext = function Button({
   children,
   classes,
   elementRef,
@@ -69,4 +69,6 @@ export default function Button({
       {children}
     </ButtonBase>
   );
-}
+};
+
+export default ButtonNext;

--- a/src/components/input/ButtonBase.js
+++ b/src/components/input/ButtonBase.js
@@ -27,7 +27,7 @@ import { downcastRef } from '../../util/typing';
  *
  * @param {BaseProps & ButtonCommonProps & HTMLButtonAttributes} props
  */
-export default function ButtonBase({
+const ButtonBaseNext = function ButtonBase({
   elementRef,
   children,
   className,
@@ -64,4 +64,6 @@ export default function ButtonBase({
       {children}
     </button>
   );
-}
+};
+
+export default ButtonBaseNext;

--- a/src/components/input/ButtonUnstyled.js
+++ b/src/components/input/ButtonUnstyled.js
@@ -14,7 +14,7 @@ import ButtonBase from './ButtonBase';
  *
  * @param {CommonProps & ButtonCommonProps} props
  */
-export default function ButtonUnstyled({
+const ButtonUnstyledNext = function ButtonUnstyled({
   children,
   classes,
   elementRef,
@@ -37,4 +37,6 @@ export default function ButtonUnstyled({
       {children}
     </ButtonBase>
   );
-}
+};
+
+export default ButtonUnstyledNext;

--- a/src/components/input/IconButton.js
+++ b/src/components/input/IconButton.js
@@ -26,7 +26,7 @@ import ButtonBase from './ButtonBase';
  *
  * @param {CommonProps & ButtonCommonProps & IconButtonProps & HTMLButtonAttributes} props
  */
-export default function IconButton({
+const IconButtonNext = function IconButton({
   children,
   classes,
   elementRef,
@@ -78,4 +78,6 @@ export default function IconButton({
       {children}
     </ButtonBase>
   );
-}
+};
+
+export default IconButtonNext;

--- a/src/components/layout/Card.js
+++ b/src/components/layout/Card.js
@@ -21,7 +21,7 @@ import { downcastRef } from '../../util/typing';
  *
  * @param {CommonProps & CardProps & Omit<HTMLAttributes, 'width'>} props
  */
-export default function Card({
+const CardNext = function Card({
   children,
   classes,
   elementRef,
@@ -54,4 +54,6 @@ export default function Card({
       {children}
     </div>
   );
-}
+};
+
+export default CardNext;

--- a/src/components/layout/CardActions.js
+++ b/src/components/layout/CardActions.js
@@ -12,7 +12,7 @@ import { downcastRef } from '../../util/typing';
  *
  * @param {CommonProps & HTMLAttributes} props
  */
-export default function CardActions({
+const CardActionsNext = function CardActions({
   children,
   classes,
   elementRef,
@@ -29,4 +29,6 @@ export default function CardActions({
       {children}
     </div>
   );
-}
+};
+
+export default CardActionsNext;

--- a/src/components/layout/CardContent.js
+++ b/src/components/layout/CardContent.js
@@ -15,7 +15,7 @@ import { downcastRef } from '../../util/typing';
  *
  * @param {CommonProps & CardContentProps & Omit<HTMLAttributes, 'size'>} props
  */
-export default function CardContent({
+const CardContentNext = function CardContent({
   children,
   classes,
   elementRef,
@@ -41,4 +41,6 @@ export default function CardContent({
       {children}
     </div>
   );
-}
+};
+
+export default CardContentNext;

--- a/src/components/layout/CardHeader.js
+++ b/src/components/layout/CardHeader.js
@@ -22,7 +22,7 @@ import CardTitle from './CardTitle';
  *
  * @param {CommonProps & CardHeaderProps & HTMLAttributes} props
  */
-export default function CardHeader({
+const CardHeaderNext = function CardHeader({
   children,
   classes,
   elementRef,
@@ -51,4 +51,6 @@ export default function CardHeader({
       )}
     </div>
   );
-}
+};
+
+export default CardHeaderNext;

--- a/src/components/layout/CardTitle.js
+++ b/src/components/layout/CardTitle.js
@@ -13,7 +13,7 @@ import { downcastRef } from '../../util/typing';
  *
  * @param {CommonProps & HTMLAttributes} props
  */
-export default function CardTitle({
+const CardTitleNext = function CardTitle({
   children,
   classes,
   elementRef,
@@ -30,4 +30,6 @@ export default function CardTitle({
       {children}
     </div>
   );
-}
+};
+
+export default CardTitleNext;

--- a/src/components/layout/Panel.js
+++ b/src/components/layout/Panel.js
@@ -26,7 +26,7 @@ import CardActions from './CardActions';
  *
  * @param {CompositeProps & PanelProps & Omit<HTMLAttributes, 'icon'|'size'|'width'>} props
  */
-export default function Panel({
+const PanelNext = function Panel({
   children,
   elementRef,
 
@@ -53,4 +53,6 @@ export default function Panel({
       </CardContent>
     </Card>
   );
-}
+};
+
+export default PanelNext;

--- a/src/components/navigation/Link.js
+++ b/src/components/navigation/Link.js
@@ -18,7 +18,7 @@ import LinkBase from './LinkBase';
  *
  * @param {CommonProps & LinkProps & HTMLAnchorAttributes} props
  */
-export default function Link({
+const LinkNext = function Link({
   children,
   classes,
   elementRef,
@@ -53,4 +53,6 @@ export default function Link({
       {children}
     </LinkBase>
   );
-}
+};
+
+export default LinkNext;

--- a/src/components/navigation/LinkBase.js
+++ b/src/components/navigation/LinkBase.js
@@ -10,7 +10,7 @@ import { downcastRef } from '../../util/typing';
  *
  * @param {BaseProps & HTMLAnchorAttributes} props
  */
-export default function LinkBase({
+const LinkBaseNext = function LinkBase({
   children,
   className,
   elementRef,
@@ -27,4 +27,6 @@ export default function LinkBase({
       {children}
     </a>
   );
-}
+};
+
+export default LinkBaseNext;

--- a/src/components/navigation/LinkUnstyled.js
+++ b/src/components/navigation/LinkUnstyled.js
@@ -12,7 +12,7 @@ import LinkBase from './LinkBase';
  *
  * @param {CommonProps & HTMLAnchorAttributes} props
  */
-export default function LinkUnstyled({
+const LinkUnstyledNext = function LinkUnstyled({
   children,
   classes,
   elementRef,
@@ -29,4 +29,6 @@ export default function LinkUnstyled({
       {children}
     </LinkBase>
   );
-}
+};
+
+export default LinkUnstyledNext;

--- a/src/components/test/common-tests.js
+++ b/src/components/test/common-tests.js
@@ -96,7 +96,7 @@ export function testPresentationalComponent(Component, componentName) {
       assert.isTrue(wrapperOuterEl.hasAttribute('data-component'));
       assert.equal(
         wrapperOuterEl.getAttribute('data-component'),
-        componentName ?? Component.name
+        componentName ?? Component.displayName ?? Component.name
       );
     });
   });


### PR DESCRIPTION
To alleviate collisions in the tests in projects using these shared
components — for now, at least — differentiate the reference naming of
default component exports to ensure unique default export names.