### PR TITLE
Add additional outline level to pattern library pages via `Section`

### DIFF
--- a/src/pattern-library/components/Library.js
+++ b/src/pattern-library/components/Library.js
@@ -89,13 +89,16 @@ function PageIntro({ children }) {
  *
  * @param {object} props
  *   @param {Children} props.children
+ *   @param {string} [props.id]
  *   @param {Children} [props.intro]
  *   @param {string} props.title
  */
-function Section({ children, intro, title }) {
+function Section({ children, id, intro, title }) {
   return (
     <section className="pb-16 space-y-8">
-      <h2 className="text-3xl font-bold">{title}</h2>
+      <h2 className="text-3xl font-bold" id={id}>
+        {title}
+      </h2>
       {intro && <SectionIntro>{intro}</SectionIntro>}
       <div className="space-y-16 styled-text">{children}</div>
     </section>
@@ -121,13 +124,16 @@ function SectionIntro({ children }) {
  *
  * @param {object} props
  *   @param {Children} props.children
+ *   @param {string} [props.id]
  *   @param {Children} [props.intro]
- *   @param {string} [props.title]
+ *   @param {string} props.title
  */
-function Pattern({ children, title }) {
+function Pattern({ children, id, title }) {
   return (
     <section className="space-y-8">
-      <h3 className="text-2xl text-slate-7">{title}</h3>
+      <h3 className="text-2xl text-slate-7" id={id}>
+        {title}
+      </h3>
       <div className="space-y-8 px-4">{children}</div>
     </section>
   );
@@ -138,9 +144,10 @@ function Pattern({ children, title }) {
  *
  * @param {object} props
  *   @param {Children} props.children
+ *   @param {string} [props.id]
  *   @param {string} [props.title]
  */
-function Example({ children, title }) {
+function Example({ children, id, title }) {
   const kids = toChildArray(children);
 
   // Extract Demo components out of any children
@@ -152,7 +159,11 @@ function Example({ children, title }) {
 
   return (
     <div className="space-y-6">
-      {title && <h4 className="text-xl text-slate-9 font-light">{title}</h4>}
+      {title && (
+        <h4 className="text-xl text-slate-9 font-light" id={id}>
+          {title}
+        </h4>
+      )}
 
       <div className="space-y-6 px-4">{notDemos}</div>
       <div className="space-y-16 px-4">{demos}</div>

--- a/src/pattern-library/components/Library.js
+++ b/src/pattern-library/components/Library.js
@@ -5,12 +5,7 @@ import { useState } from 'preact/hooks';
 import { jsxToHTML } from '../util/jsx-to-string';
 
 /**
- * @typedef LibraryBaseProps
- * @prop {import("preact").ComponentChildren} [intro] - Optional
- *   introductory content
- * @prop {import("preact").ComponentChildren} [children]
- * @prop {string} [title]
- *
+ * @typedef {import('preact').ComponentChildren} Children
  */
 
 /**
@@ -46,7 +41,10 @@ import { jsxToHTML } from '../util/jsx-to-string';
 /**
  * Render content for a pattern-library page
  *
- * @param {LibraryBaseProps} props
+ * @param {object} props
+ *   @param {Children} props.children
+ *   @param {Children} [props.intro]
+ *   @param {string} props.title
  */
 function Page({ children, intro, title }) {
   return (
@@ -60,6 +58,9 @@ function Page({ children, intro, title }) {
 
 /**
  * Sticky pattern-library page header
+ *
+ * @param {object} props
+ *   @param {string} props.title
  */
 function PageTitle({ title }) {
   return (
@@ -71,6 +72,9 @@ function PageTitle({ title }) {
 
 /**
  * Page introductory text
+ *
+ * @param {object} props
+ *   @param {Children} props.children
  */
 function PageIntro({ children }) {
   return (
@@ -83,7 +87,10 @@ function PageIntro({ children }) {
 /**
  * Render info about a primary section of a page
  *
- * @param {LibraryBaseProps} props
+ * @param {object} props
+ *   @param {Children} props.children
+ *   @param {Children} [props.intro]
+ *   @param {string} props.title
  */
 function Section({ children, intro, title }) {
   return (
@@ -97,6 +104,9 @@ function Section({ children, intro, title }) {
 
 /**
  * Page introductory text
+ *
+ *  @param {object} props
+ *    @param {Children} props.children
  */
 function SectionIntro({ children }) {
   return (
@@ -109,7 +119,10 @@ function SectionIntro({ children }) {
 /**
  * Render info about a secondary section of a page
  *
- * @param {LibraryBaseProps} props
+ * @param {object} props
+ *   @param {Children} props.children
+ *   @param {Children} [props.intro]
+ *   @param {string} [props.title]
  */
 function Pattern({ children, title }) {
   return (
@@ -121,24 +134,13 @@ function Pattern({ children, title }) {
 }
 
 /**
- * @typedef LibraryExampleProps
- * @prop {import("preact").ComponentChildren} [children]
- * @prop {string} [title]
- * @prop {'split'|'wide'} [variant='split'] - Layout variant. Applies
- *   appropriate className.
- *   - Split (default) lays out in a row. Non-demo example content is rendered
- *     left, with demos right. Demos in this variant stack vertically.
- *   - Wide lays out in a full-width column. Non-example is rendered first,
- *     then a row to contain demos. Demos in this variant render next to each
- *     other in a single row.
- */
-
-/**
  * Render information about a tertiary section on a page.
  *
- * @param {LibraryExampleProps} props
+ * @param {object} props
+ *   @param {Children} props.children
+ *   @param {string} [props.title]
  */
-function Example({ children, title, variant = 'split' }) {
+function Example({ children, title }) {
   const kids = toChildArray(children);
 
   // Extract Demo components out of any children
@@ -153,28 +155,18 @@ function Example({ children, title, variant = 'split' }) {
       {title && <h4 className="text-xl text-slate-9 font-light">{title}</h4>}
 
       <div className="space-y-6 px-4">{notDemos}</div>
-      <div
-        className={classnames({
-          'space-y-16 px-4': variant === 'split',
-          'flex flex-row gap-16 flex-wrap': variant === 'wide',
-        })}
-      >
-        {demos}
-      </div>
+      <div className="space-y-16 px-4">{demos}</div>
     </div>
   );
 }
 
 /**
- * @typedef DemoButtonProps
- * @prop {import("preact").ComponentChildren} [children]
- * @prop {() => void} [onClick]
- * @prop {boolean} pressed
- */
-
-/**
+ * Render a button to swap between demo and source views in a Demo
  *
- * @param {DemoButtonProps} props
+ * @param {object} props
+ *   @param {import("preact").ComponentChildren} props.children
+ *   @param {() => void} props.onClick
+ *   @param {boolean} props.pressed
  */
 function DemoButton({ children, onClick, pressed }) {
   return (
@@ -195,24 +187,20 @@ function DemoButton({ children, onClick, pressed }) {
 }
 
 /**
- * @typedef DemoProps
- * @prop {import("preact").ComponentChildren} [children]
- * @prop {string} [classes] - Extra CSS classes for the demo content's immediate
- *   parent container
- * @prop {boolean} [withSource=false] - Should the demo also render the source?
- *   When true, a "Source" tab will be rendered, which will display the JSX
- *   source of the Demo's children
- * @prop {object} [style] - Inline styles to apply to the demo container
- * @prop {string} [title]
- */
-
-/**
  * Render a "Demo", with optional source. This will render the children as
  * provided in a tabbed container. If `withSource` is `true`, the JSX source
  * of the children will be provided in a separate "Source" tab from the
  * rendered Demo content.
  *
- * @param {DemoProps} props
+ * @param {object} props
+ *   @param {import("preact").ComponentChildren} [props.children]
+ *   @param {string} [props.classes] - Extra CSS classes for the demo content's
+ *     immediate parent container
+ *   @param {boolean} [props.withSource=false] - Should the demo also render the source?
+ *   When true, a "Source" tab will be rendered, which will display the JSX
+ *   source of the Demo's children
+ *   @param {object} [props.style] - Inline styles to apply to the demo container
+ *   @param {string} [props.title]
  */
 function Demo({ children, classes, withSource = false, style = {}, title }) {
   const [visibleTab, setVisibleTab] = useState('demo');

--- a/src/pattern-library/components/Library.js
+++ b/src/pattern-library/components/Library.js
@@ -2,8 +2,6 @@ import classnames from 'classnames';
 import { toChildArray } from 'preact';
 import { useState } from 'preact/hooks';
 
-import { Frame } from '../../components/containers';
-
 import { jsxToHTML } from '../util/jsx-to-string';
 
 /**
@@ -17,34 +15,36 @@ import { jsxToHTML } from '../util/jsx-to-string';
 
 /**
  * Components for rendering patterns, examples and demos in the pattern-library
- * page. A pattern-library Page contains Patterns, which in turn contain
- * Examples. An Example _may_ contain one or more Demos. Child content (markup)
- * may also be rendered in these components, as desired.
+ * page.
  *
  * Example of structure:
  *
- * <Library.Page intro={<p>Some introductory content</p>} title="Elephants">
+ * <Page intro={<p>Some introductory content</p>} title="Elephants">
  *   <p>Any content you want on the page.</p>
- *   More content: it can be any valid `ComponentChildren`
  *
- *   <Library.Pattern title="Elephant">
- *     <p>The `Elephant` component is used to render information about elephant
- *     personalities.</p>
- *     <Library.Example title="Colored elephants">
- *       <p>You can change the color of your elephant.</p>
- *       <Library.Demo withSource>
- *         <Elephant color="pink" />
- *       </Library.Demo>
- *     </Library.Example>
- *     // More Examples if desired
- *   </Library.Pattern>
- *
+ *   <Library.Section title="ComponentName">
+ *     <Library.Pattern title="Usage">
+ *       <p>The `Elephant` component is used to render information about elephant
+ *       personalities.</p>
+ *       <Library.Example title="Colored elephants">
+ *         <p>You can change the color of your elephant.</p>
+ *         <Library.Demo withSource>
+ *           <Elephant color="pink" />
+ *         </Library.Demo>
+ *         // More Demos if desired...
+ *       </Library.Example>
+ *       // More Examples if desired...
+ *     </Library.Pattern>
  *   // more Patterns if desired...
+ *   </Library.Section>
+ *
+ *   // More Sections...
+ *
  * </Library.Page>
  */
 
 /**
- * Render a pattern-library page.
+ * Render content for a pattern-library page
  *
  * @param {LibraryBaseProps} props
  */
@@ -81,14 +81,40 @@ function PageIntro({ children }) {
 }
 
 /**
- * Render info about a single pattern (or component) on a pattern-library page.
+ * Render info about a primary section of a page
+ *
+ * @param {LibraryBaseProps} props
+ */
+function Section({ children, intro, title }) {
+  return (
+    <section className="pb-16 space-y-8">
+      <h2 className="text-3xl font-bold">{title}</h2>
+      {intro && <SectionIntro>{intro}</SectionIntro>}
+      <div className="space-y-16 styled-text">{children}</div>
+    </section>
+  );
+}
+
+/**
+ * Page introductory text
+ */
+function SectionIntro({ children }) {
+  return (
+    <div className="styled-text text-lg space-y-3 leading-relaxed">
+      {children}
+    </div>
+  );
+}
+
+/**
+ * Render info about a secondary section of a page
  *
  * @param {LibraryBaseProps} props
  */
 function Pattern({ children, title }) {
   return (
     <section className="space-y-8">
-      <h2 className="text-2xl text-slate-7">{title}</h2>
+      <h3 className="text-2xl text-slate-7">{title}</h3>
       <div className="space-y-8 px-4">{children}</div>
     </section>
   );
@@ -108,7 +134,7 @@ function Pattern({ children, title }) {
  */
 
 /**
- * Render example content and optional Demo(s) for a pattern.
+ * Render information about a tertiary section on a page.
  *
  * @param {LibraryExampleProps} props
  */
@@ -124,7 +150,7 @@ function Example({ children, title, variant = 'split' }) {
 
   return (
     <div className="space-y-6">
-      {title && <h3 className="text-xl text-slate-9 font-light">{title}</h3>}
+      {title && <h4 className="text-xl text-slate-9 font-light">{title}</h4>}
 
       <div className="space-y-6 px-4">{notDemos}</div>
       <div
@@ -206,7 +232,7 @@ function Demo({ children, classes, withSource = false, style = {}, title }) {
     <div className="space-y-2 p-4">
       <div className="flex items-center">
         <div className="py-2 grow">
-          <h4 className="text-lg italic text-slate-7 font-light">{title}</h4>
+          <h5 className="text-lg italic text-slate-7 font-light">{title}</h5>
         </div>
         <div className="flex flex-row items-center justify-end gap-x-4">
           {withSource && (
@@ -241,9 +267,9 @@ function Demo({ children, classes, withSource = false, style = {}, title }) {
           </div>
         )}
         {visibleTab === 'source' && (
-          <Frame classes="w-full rounded-md bg-slate-7 text-color-text-inverted p-4">
+          <div className="border w-full rounded-md bg-slate-7 text-color-text-inverted p-4">
             <ul>{source}</ul>
-          </Frame>
+          </div>
         )}
       </div>
     </div>
@@ -252,6 +278,7 @@ function Demo({ children, classes, withSource = false, style = {}, title }) {
 
 export default {
   Page,
+  Section,
   Pattern,
   Example,
   Demo,

--- a/src/pattern-library/components/patterns/ButtonComponents.js
+++ b/src/pattern-library/components/patterns/ButtonComponents.js
@@ -84,7 +84,7 @@ export default function ButtonComponents() {
           </Library.Demo>
         </Library.Example>
 
-        <Library.Example title="Variants" variant="wide">
+        <Library.Example title="Variants">
           <h4>Dark variant</h4>
           <p>
             The <code>IconButton</code> dark variant is for use on darker (light
@@ -220,7 +220,7 @@ export default function ButtonComponents() {
           </Library.Demo>
         </Library.Example>
 
-        <Library.Example title="Variants" variant="wide">
+        <Library.Example title="Variants">
           <Library.Demo title="Default" withSource>
             <LabeledButton icon="edit">Edit</LabeledButton>
             <LabeledButton icon="edit" pressed>

--- a/src/pattern-library/components/patterns/ContainerComponents.js
+++ b/src/pattern-library/components/patterns/ContainerComponents.js
@@ -106,7 +106,7 @@ export default function ContainerComponents() {
           overflowing content. It provides a scroll context and is styled with
           the <code>scrollbox</code> pattern.
         </p>
-        <Library.Example variant="wide">
+        <Library.Example>
           <p>
             A <code>Scrollbox</code> will fill its available space. Constraints
             to that space need to be applied to a parent element. Here a parent

--- a/src/pattern-library/components/patterns/TableComponents.js
+++ b/src/pattern-library/components/patterns/TableComponents.js
@@ -29,7 +29,7 @@ function TableExample() {
   );
 
   return (
-    <Library.Example title="Basic Table" variant="wide">
+    <Library.Example title="Basic Table">
       <p>
         A <code>Table</code> will fill available space if none of its ancestors
         apply any constraints on height or width. It will fill 100% of its
@@ -64,7 +64,7 @@ function ScrollboxTableExample() {
   );
 
   return (
-    <Library.Example title="Constrained Table" variant="wide">
+    <Library.Example title="Constrained Table">
       <p>
         <code>Tables</code> render inside of a <code>Scrollbox</code> container
         component, which gives the table a scroll context and allows it to
@@ -119,7 +119,7 @@ function EmptyTableExample() {
   );
 
   return (
-    <Library.Example title="Constrained Table" variant="wide">
+    <Library.Example title="Constrained Table">
       <p>
         This Table has no items (it is empty). When not in loading state, the
         provided <code>emptyItemsMessage</code> will render centered in the

--- a/src/pattern-library/components/patterns/TablePatterns.js
+++ b/src/pattern-library/components/patterns/TablePatterns.js
@@ -13,7 +13,7 @@ export default function TablePatterns() {
         spaces.
       </p>
       <Library.Pattern title="Table">
-        <Library.Example title="Basic table" variant="wide">
+        <Library.Example title="Basic table">
           <p>
             By default, a <code>table</code> will fill available horizontal
             space, and will use whatever height is needed to render its rows.{' '}


### PR DESCRIPTION
This PR is part of a thread of work to better structure pattern-library documentation pages (i.e. HTML outline) and introduce some intra-page navigation. This adds a `Section` component at the `h2` level and demotes `Pattern` (to `h3`), `Example` (to `h4`) and `Demo` (`h5`). There is no visible change here, though there is a temporary heading gap between `h1` and `h3` until pages are updated to use the `Section` component.

This PR also introduces an optional `id` prop for several structural Library components. This is in advance of some upcoming intra-page navigation work. It's not expected that pattern-library authors will assign manual `id`s to component instances (though they _can_). 

The objective here is to better support pages that document multiple components and to prepare for improved navigation.  The proposed page structure will be something like:

* Page Title
    * Intro
    * ComponentOne (`Section`/`h2`)
        * Usage (`Pattern`/`h3`)
            * Migrating to this component (`Example`/`h4`)
        * Props (`Pattern`/`h3`)
            * active (`Example`/`h4`)
            * size (`Example`/`h4`)
    * ComponentTwo (`Section`/`h2`)
        * Usage (`Pattern`/`h3`)
            * Migrating to this component (`Example`/`h4`)
        * Props (`Pattern`/`h3`)
            * active (`Example`/`h4`)
            * size (`Example`/`h4`)

_Note_: The names of the pattern-library components have developed organically over time and are not particularly elegant. I'll be keeping this in mind.