### PR TITLE
Add `useSyncedRef` hook

### DIFF
--- a/src/hooks/test/use-synced-ref-test.js
+++ b/src/hooks/test/use-synced-ref-test.js
@@ -1,0 +1,114 @@
+import { mount } from 'enzyme';
+import { useEffect } from 'preact/hooks';
+
+import { useSyncedRef } from '../use-synced-ref';
+
+function Widget({ elementRef, visible, onRender }) {
+  const ref = useSyncedRef(elementRef);
+
+  assert.equal(ref.target, elementRef);
+
+  useEffect(() => {
+    onRender?.(ref.current);
+  });
+
+  if (!visible) {
+    return null;
+  }
+
+  return <div ref={ref}>Test</div>;
+}
+
+describe('useSyncedRef', () => {
+  it('updates target object ref with current ref value', () => {
+    const ref = { current: null };
+
+    const widget = mount(<Widget elementRef={ref} visible />);
+    assert.instanceOf(ref.current, HTMLElement);
+
+    widget.setProps({ elementRef: ref, visible: false });
+    assert.isNull(ref.current);
+  });
+
+  it('updates new target object ref with current ref value', () => {
+    const refA = { current: null };
+    const refB = { current: null };
+
+    const widget = mount(<Widget elementRef={refA} visible />);
+    assert.instanceOf(refA.current, HTMLElement);
+
+    widget.setProps({ elementRef: refB, visible: true });
+    assert.instanceOf(refB.current, HTMLElement);
+  });
+
+  it('updates target callback ref with current ref value', () => {
+    let refValue;
+    const ref = value => (refValue = value);
+
+    const widget = mount(<Widget elementRef={ref} visible />);
+    assert.instanceOf(refValue, HTMLElement);
+
+    widget.setProps({ elementRef: ref, visible: false });
+    assert.isNull(refValue);
+  });
+
+  it('updates new target callback ref with current ref value', () => {
+    let refValueA;
+    const refA = value => (refValueA = value);
+    let refValueB;
+    const refB = value => (refValueB = value);
+
+    const widget = mount(<Widget elementRef={refA} visible />);
+    assert.instanceOf(refValueA, HTMLElement);
+
+    widget.setProps({ elementRef: refB, visible: true });
+    assert.instanceOf(refValueB, HTMLElement);
+  });
+
+  it('does not update target ref on render if target and ref are unchanged', () => {
+    let updateCount = 0;
+    const ref = {
+      get current() {
+        return this._current;
+      },
+      set current(value) {
+        ++updateCount;
+        this._current = value;
+      },
+    };
+
+    const widget = mount(<Widget elementRef={ref} visible />);
+    assert.equal(updateCount, 1);
+
+    widget.setProps({ elementRef: ref, visible: true });
+    assert.equal(updateCount, 1);
+
+    widget.unmount();
+    assert.equal(updateCount, 2);
+  });
+
+  it('does not invoke target ref on render if target and ref are unchanged', () => {
+    let updateCount = 0;
+    const ref = () => ++updateCount;
+
+    const widget = mount(<Widget elementRef={ref} visible />);
+    assert.equal(updateCount, 1);
+
+    widget.setProps({ elementRef: ref, visible: true });
+    assert.equal(updateCount, 1);
+
+    widget.unmount();
+    assert.equal(updateCount, 2);
+  });
+
+  it('acts like a normal object ref if no target is provided', () => {
+    let refValue;
+    const onRender = element => (refValue = element);
+
+    const widget = mount(<Widget visible={true} onRender={onRender} />);
+    assert.instanceOf(refValue, HTMLElement);
+
+    widget.setProps({ onRender, visible: false });
+    assert.isNull(refValue);
+  });
+});

--- a/src/hooks/use-synced-ref.js
+++ b/src/hooks/use-synced-ref.js
@@ -1,0 +1,100 @@
+import { useRef } from 'preact/hooks';
+
+/**
+ * @template T
+ * @typedef {import('preact').RefObject<T>} RefObject
+ */
+
+/**
+ * @template T
+ * @typedef {import('preact').Ref<T>} Ref
+ */
+
+/**
+ * Object ref which synchronizes its value to another ref.
+ *
+ * @template T
+ * @implements {RefObject<T>}
+ */
+class SyncedRef {
+  /**
+   * @param {Ref<T>} [target] - Initial target for this ref to synchronize to.
+   *   This is not called/set until the {@link current} property of the
+   *   SyncedRef is set. This makes the target behave close to how it would
+   *   if used in place of the SyncedRef.
+   */
+  constructor(target) {
+    /** @type {Ref<T>|undefined} */
+    this._target = target;
+
+    /** @type {T|null} */
+    this._value = null;
+  }
+
+  get current() {
+    return this._value;
+  }
+
+  /** @param {T|null} value */
+  set current(value) {
+    this._value = value;
+    this._updateTarget();
+  }
+
+  get target() {
+    return this._target;
+  }
+
+  /** @param {Ref<T>|undefined} target */
+  set target(target) {
+    if (target === this._target) {
+      return;
+    }
+    this._target = target;
+
+    // If the target changes after the initial render, we currently synchronize
+    // the value immediately. This is different than what happens if the target
+    // were passed to an element directly, as it would be updated only after the
+    // render.
+    this._updateTarget();
+  }
+
+  _updateTarget() {
+    const value = this._value;
+    if (typeof this._target === 'function') {
+      this._target(value);
+    } else if (this._target) {
+      this._target.current = value;
+    }
+  }
+}
+
+/**
+ * Return an object ref which synchronizes its value to another "target" ref.
+ *
+ * This is useful when a component needs an object ref for an element for
+ * internal use, but also wants to allow the caller to get a ref for the same
+ * element.
+ *
+ * The target ref can be either a callback or an object.
+ *
+ * @example
+ *   function Widget({ elementRef }) {
+ *     const ref = useSyncedRef(elementRef);
+ *
+ *     useEffect(() => {
+ *       ref.current.focus();
+ *     }, []);
+ *
+ *     return <input ref={ref}>...</input>;
+ *   }
+ *
+ * @template T
+ * @param {import('preact').Ref<T>} [targetRef]
+ * @return {import('preact').RefObject<T>}
+ */
+export function useSyncedRef(targetRef) {
+  const container = useRef(new SyncedRef(targetRef));
+  container.current.target = targetRef;
+  return container.current;
+}


### PR DESCRIPTION
Add a hook that can be used to synchronize an external ref provided to a
component with an internal object ref used by the component itself.