### PR TITLE
Version 5.3 PR 1/n: Documentation updates from feedback

### DIFF
--- a/src/pattern-library/components/patterns/CustomizingComponentsPage.js
+++ b/src/pattern-library/components/patterns/CustomizingComponentsPage.js
@@ -14,51 +14,74 @@ export default function CustomizingComponentsPage() {
         </>
       }
     >
-      <Library.Pattern title="How to customize a component">
+      <Library.Pattern title="Step 1: Stop and reflect">
         <p>
-          These steps should be taken in order when design or layout
-          customization of a component is necessary.
+          Components in this library are designed to be flexible within the
+          bounds of established design patterns. Certain guard rails exist on
+          purpose. Reflect before you customize!
         </p>
-        <ol>
-          <li>
-            Use a <strong>different variant</strong> of the component. Check the{' '}
-            {"component's"} documentation in this library to see what variants
-            are available.
-          </li>
-          <li>
-            Use <strong>component styling props</strong>, e.g.{' '}
-            <code>color</code>, <code>underline</code> or <code>size</code>.
-            These differ per component and define styling aspects that are
-            intended to be adjusted.
-          </li>
-          <li>
-            Use an <strong>unstyled component</strong>, e.g.{' '}
-            <code>LinkUnstyled</code>. This is appropriate if you want to do
-            considerable customization of a component.
-          </li>
-          <li>
-            Use the{' '}
-            <strong>
-              <code>classes</code> prop
-            </strong>
-            . This allows authors to append arbitrary classes to the{' '}
-            {"component's"} outermost element but should be used with
-            consideration.
-          </li>
-          <li>
-            Use a <strong>different component</strong>, or create a new one.
-          </li>
-          <li>
-            Emergency escape hatch: Use{' '}
-            <strong>
-              <code>!important</code> CSS rules
-            </strong>{' '}
-            (these class names are prefixed with a <code>!</code> in
-            <code>tailwindcss</code>) . This should be a last-ditch tactic.
-          </li>
-        </ol>
+      </Library.Pattern>
 
-        <Library.Example title="Stop and reflect">
+      <Library.Pattern title="How to customize a component">
+        <Library.Example title="Intended customization">
+          <p>
+            The following options represent flexibility purposely baked into
+            components.
+          </p>
+          <ol>
+            <li>
+              Use a <strong>different variant</strong> of the component. Check
+              the {"component's"} documentation in this library to see what
+              variants are available.
+            </li>
+            <li>
+              Use <strong>component styling props</strong>, e.g.{' '}
+              <code>color</code>, <code>underline</code> or <code>size</code>.
+              These differ per component and define styling aspects that are
+              intended to be adjusted.
+            </li>
+            <li>
+              Use an <strong>unstyled component</strong>, e.g.{' '}
+              <code>LinkUnstyled</code>. This is appropriate if you want to do
+              considerable customization of a component.
+            </li>
+          </ol>
+        </Library.Example>
+
+        <Library.Example title="Stronger medicine">
+          <p>
+            For use if the above options do not satisfy the need. Tread with
+            care.
+          </p>
+          <ol>
+            <li>
+              <p>
+                Use the{' '}
+                <strong>
+                  <code>classes</code> prop
+                </strong>
+                . This allows authors to append arbitrary classes to the{' '}
+                {"component's"} outermost element but should be used with
+                consideration.
+              </p>
+              <p>
+                The intention is to allow for extension, not override. There is
+                no guarantee that provided <code>classes</code> {"won't"}{' '}
+                conflict with classes applied by the component.
+              </p>
+            </li>
+            <li>
+              Use a <strong>different component</strong>, or create a new one.
+            </li>
+            <li>
+              Emergency escape hatch: Use{' '}
+              <strong>
+                <code>!important</code> CSS rules
+              </strong>{' '}
+              (these class names are prefixed with a <code>!</code> in
+              <code>tailwindcss</code>) . This should be a last-ditch tactic.
+            </li>
+          </ol>
           <p>
             Any time you use <code>classes</code> and especially if you use{' '}
             <code>!important</code> hacks, raise the issue. It may be that the

--- a/src/pattern-library/components/patterns/CustomizingComponentsPage.js
+++ b/src/pattern-library/components/patterns/CustomizingComponentsPage.js
@@ -65,9 +65,10 @@ export default function CustomizingComponentsPage() {
                 consideration.
               </p>
               <p>
-                The intention is to allow for extension, not override. There is
-                no guarantee that provided <code>classes</code> {"won't"}{' '}
-                conflict with classes applied by the component.
+                The intention is to allow for extension, not override. in the
+                event of a conflict between the {"component's"} own styling and
+                the classes specified here, there is currently no guarantee of
+                which will take precedence.
               </p>
             </li>
             <li>

--- a/src/pattern-library/components/patterns/UsingComponentsPage.js
+++ b/src/pattern-library/components/patterns/UsingComponentsPage.js
@@ -1,16 +1,23 @@
+import {
+  Button,
+  Card,
+  CardContent,
+  EditIcon,
+  ReplyIcon,
+  CheckIcon,
+  ScrollBox,
+} from '../../../next';
 import Library from '../Library';
 
 import Next from '../LibraryNext';
+
+import { SampleListElements } from './samples';
 
 export default function UsingComponentsPage() {
   return (
     <Library.Page
       title="Using components"
-      intro={
-        <>
-          <p>This guide applies to updated ({'"next"'}) components only.</p>
-        </>
-      }
+      intro={<p>This guide applies to updated ({'"next"'}) components only.</p>}
     >
       <Library.Pattern title="Component categories">
         <ul>
@@ -48,20 +55,17 @@ export default function UsingComponentsPage() {
           component, and call out any deviation of the component from its{' '}
           {"category's"} common props.
         </p>
+      </Library.Pattern>
 
-        <Library.Example title="Simple components" />
-        <p>
-          <strong>Simple components</strong> are opinionated and take only
-          documented, component-specific props.
-        </p>
-        <Library.Example title="Presentational components" />
-        <p>
-          <strong>Presentational components</strong> have more customization
-          flexibility and take these common props:
-        </p>
-        <Next.Code
-          size="sm"
-          content={`/**
+      <Library.Pattern title="Common props API">
+        <Library.Example title="Presentational components">
+          <p>
+            <strong>Presentational components</strong> take these common props
+            unless documented otherwise:
+          </p>
+          <Next.Code
+            size="sm"
+            content={`/**
  * @typedef PresentationalProps
  * @prop {import('preact').ComponentChildren} [children]
  * @prop {string|string[]} [classes] - Optional extra CSS classes to append to the
@@ -72,16 +76,145 @@ export default function UsingComponentsPage() {
  *   outermost element.
  */
 `}
-        />
+            title="Common presentational-component props"
+          />
+
+          <p>
+            Presentational components also take <strong>HTML attributes</strong>{' '}
+            applicable to their outermost element.
+          </p>
+        </Library.Example>
         <Library.Example title="Composite components">
           <p>
-            Composite components accept the same common props as presentational
-            components with the exception of{' '}
-            <s>
-              <code>classes</code>
-            </s>
-            .
+            <strong>Composite components</strong> accept the same common props
+            as presentational components with the exception of{' '}
+            <code>classes</code>.
           </p>
+        </Library.Example>
+
+        <Library.Example title="Simple components">
+          <p>
+            <strong>Simple components</strong> take only documented,
+            component-specific props.
+          </p>
+        </Library.Example>
+      </Library.Pattern>
+
+      <Library.Pattern title="Other prop conventions">
+        <Library.Example title="variant">
+          <p>
+            Many components provide stylistic <strong>variants</strong>.
+            Variants are mutually exclusive and may affect several different
+            aspects of styling.
+          </p>
+          <p>
+            In contrast, other props like <code>underline</code> or{' '}
+            <code>size</code> impact a single aspect of styling and may be
+            combined in various ways.
+          </p>
+          <Library.Demo
+            title="Card variants, affecting shadows and hover effects"
+            withSource
+          >
+            <Card variant="raised">
+              <CardContent>
+                This is content inside of a <code>Card</code> with the default,{' '}
+                <code>raised</code> <code>variant</code>.
+              </CardContent>
+            </Card>
+
+            <Card variant="flat">
+              <CardContent>
+                This is content inside of a <code>Card</code> with the{' '}
+                <code>flat</code> <code>variant</code>.
+              </CardContent>
+            </Card>
+          </Library.Demo>
+        </Library.Example>
+
+        <Library.Example title="size">
+          <p>
+            <code>size</code> takes size abbreviations (strings) as values and
+            impacts spacing and padding. Typically, accepted values are{' '}
+            <code>{"'sm', 'md', 'lg'"}</code>. Components generally inherit font
+            sizing, unless documented otherwise.
+          </p>
+          <Library.Demo withSource>
+            <Button icon={EditIcon} size="sm">
+              Small (sm)
+            </Button>
+            <Button icon={ReplyIcon} size="md">
+              Medium (md, default)
+            </Button>
+            <Button icon={CheckIcon} size="lg">
+              Large (lg)
+            </Button>
+          </Library.Demo>
+        </Library.Example>
+
+        <Library.Example title="Boolean props">
+          <p>
+            Boolean props are named for their truthy state. For example,{' '}
+            <code>ScrollBox</code> has borders by default. Thus the associated
+            boolean prop to disable them is named <code>borderless</code> (not{' '}
+            <code>border={'{false}'}</code>).
+          </p>
+          <Library.Demo title="Turning off borders on a ScrollBox" withSource>
+            <div className="w-[280px] h-[200px]">
+              <ScrollBox borderless>
+                <ul>
+                  <SampleListElements />
+                </ul>
+              </ScrollBox>
+            </div>
+          </Library.Demo>
+        </Library.Example>
+      </Library.Pattern>
+
+      <Library.Pattern title="Inspecting and debugging components">
+        <p>
+          To aid with in-browser inspecting, all components add a{' '}
+          <code>data-component</code> and, sometimes, a{' '}
+          <code>data-composite-component</code> attribute to their outermost
+          elements.
+        </p>
+        <Library.Example title="data-component">
+          <p>
+            Presentational and simple components set <code>data-component</code>{' '}
+            only.
+          </p>
+          <Next.Code
+            content={
+              <div
+                /* eslint-disable-next-line react/no-unknown-property */
+                class="rounded-sm border bg-white shadow hover:shadow-md w-full"
+                data-component="Card"
+              />
+            }
+            size="sm"
+            title="Rendered outer div for Card"
+          />
+        </Library.Example>
+
+        <Library.Example title="data-composite-component">
+          <p>
+            Composite components set <code>data-composite-component</code>. For
+            example, the outermost element of <code>Panel</code> is both a{' '}
+            <code>Card</code> (<code>data-component</code>) and a{' '}
+            <code>Panel</code> (<code>data-composite-component</code>).
+          </p>
+          <Next.Code
+            content={
+              <div
+                /* eslint-disable-next-line react/no-unknown-property */
+                class="rounded-sm border bg-white shadow hover:shadow-md w-full"
+                data-component="Card"
+                data-composite-component="Panel"
+              />
+            }
+            size="sm"
+            title="Rendered outer div for Panel"
+          />
         </Library.Example>
       </Library.Pattern>
     </Library.Page>

--- a/src/pattern-library/components/patterns/data/ScrollBoxPage.js
+++ b/src/pattern-library/components/patterns/data/ScrollBoxPage.js
@@ -71,13 +71,13 @@ export default function ScrollBoxPage() {
         </Library.Example>
       </Library.Pattern>
 
-      <Library.Pattern title="Border">
-        <p>
-          <code>ScrollBox</code> applies a border to the outer{' '}
-          <code>ScrollContainer</code> by default. This can be disabled with the{' '}
-          <code>borderless</code> boolean prop.
-        </p>
-        <Library.Example>
+      <Library.Pattern title="Props">
+        <Library.Example title="borderless">
+          <p>
+            <code>ScrollBox</code> applies a border to the outer{' '}
+            <code>ScrollContainer</code> by default. This can be disabled with
+            the <code>borderless</code> boolean prop.
+          </p>
           <Library.Demo title="Turning off borders" withSource>
             <div className="w-[280px] h-[200px]">
               <ScrollBox borderless>

--- a/src/pattern-library/components/patterns/data/ScrollPage.js
+++ b/src/pattern-library/components/patterns/data/ScrollPage.js
@@ -86,7 +86,7 @@ export default function ScrollPage() {
           </Library.Demo>
         </Library.Example>
 
-        <Library.Example title="Variant">
+        <Library.Example title="variant">
           <p>
             <code>Scroll</code>
             {"'s"} <code>raised</code> variant (default) renders CSS shadows to
@@ -162,7 +162,7 @@ export default function ScrollPage() {
             </div>
           </Library.Demo>
         </Library.Example>
-        <Library.Example title="Disabling borders">
+        <Library.Example title="borderless">
           <p>
             Turn off <code>ScrollContainer</code> borders with the{' '}
             <code>borderless</code> boolean prop.

--- a/src/pattern-library/components/patterns/feedback/SpinnerPage.js
+++ b/src/pattern-library/components/patterns/feedback/SpinnerPage.js
@@ -58,29 +58,27 @@ export default function SpinnerPage() {
         </Library.Example>
       </Library.Pattern>
 
-      <Library.Pattern title="Color">
-        <Library.Example title="color: 'text-light' (default)">
-          <Library.Demo withSource>
+      <Library.Pattern title="Props">
+        <Library.Example title="color">
+          <Library.Demo title="color: 'text-light' (default)" withSource>
             <Spinner color="text-light" size="md" />
           </Library.Demo>
-        </Library.Example>
-        <Library.Example title="color: 'text'">
-          <Library.Demo withSource>
+          <Library.Demo title="color: 'text'" withSource>
             <Spinner color="text" size="md" />
           </Library.Demo>
         </Library.Example>
-      </Library.Pattern>
 
-      <Library.Pattern title="Size">
-        <Library.Demo title="size: 'sm' (1em) (default)" withSource>
-          <Spinner size="sm" />
-        </Library.Demo>
-        <Library.Demo title="size: 'md' (2em)" withSource>
-          <Spinner size="md" />
-        </Library.Demo>
-        <Library.Demo title="size: 'lg' (4em)" withSource>
-          <Spinner size="lg" />
-        </Library.Demo>
+        <Library.Example title="size">
+          <Library.Demo title="size: 'sm' (1em) (default)" withSource>
+            <Spinner size="sm" />
+          </Library.Demo>
+          <Library.Demo title="size: 'md' (2em)" withSource>
+            <Spinner size="md" />
+          </Library.Demo>
+          <Library.Demo title="size: 'lg' (4em)" withSource>
+            <Spinner size="lg" />
+          </Library.Demo>
+        </Library.Example>
       </Library.Pattern>
     </Library.Page>
   );

--- a/src/pattern-library/components/patterns/input/ButtonPage.js
+++ b/src/pattern-library/components/patterns/input/ButtonPage.js
@@ -74,8 +74,8 @@ export default function ButtonPage() {
         </Library.Example>
       </Library.Pattern>
 
-      <Library.Pattern title="Icons">
-        <Library.Example>
+      <Library.Pattern title="Props">
+        <Library.Example title="icon">
           <p>
             The <code>Button</code>
             {"'s"} <code>icon</code> prop accepts an icon component and will
@@ -95,17 +95,15 @@ export default function ButtonPage() {
             </span>
           </Library.Demo>
         </Library.Example>
-      </Library.Pattern>
 
-      <Library.Pattern title="Variant">
-        <p>
-          These examples show each variant in each of the supported states, as
-          well as an example with an icon. These states are associated with the{' '}
-          <code>pressed</code>, <code>expanded</code> and <code>disabled</code>{' '}
-          boolean props.
-        </p>
-        <Library.Example title="variant: 'secondary' (default)">
-          <Library.Demo withSource>
+        <Library.Example title="variant">
+          <p>
+            These examples show each variant in each of the supported states, as
+            well as an example with an icon. These states are associated with
+            the <code>pressed</code>, <code>expanded</code> and{' '}
+            <code>disabled</code> boolean props.
+          </p>
+          <Library.Demo title="variant: 'secondary' (default)" withSource>
             <Button variant="secondary">Default</Button>
             <Button variant="secondary">
               <CancelIcon />
@@ -121,10 +119,8 @@ export default function ButtonPage() {
               Disabled
             </Button>
           </Library.Demo>
-        </Library.Example>
 
-        <Library.Example title="variant: 'primary'">
-          <Library.Demo withSource>
+          <Library.Demo title="variant: 'primary'" withSource>
             <Button variant="primary">Default</Button>
             <Button variant="primary">
               <EditIcon />
@@ -141,14 +137,11 @@ export default function ButtonPage() {
             </Button>
           </Library.Demo>
         </Library.Example>
-      </Library.Pattern>
-
-      <Library.Pattern title="Size">
-        <p>
-          The <code>size</code> prop affects padding and spacing within the{' '}
-          <code>Button</code>, but other sizing (e.g. font size) is inherited.
-        </p>
-        <Library.Example>
+        <Library.Example title="size">
+          <p>
+            The <code>size</code> prop affects padding and spacing within the{' '}
+            <code>Button</code>, but other sizing (e.g. font size) is inherited.
+          </p>
           <Library.Demo withSource>
             <Button icon={EditIcon} size="sm">
               Small (sm)

--- a/src/pattern-library/components/patterns/input/IconButtonPage.js
+++ b/src/pattern-library/components/patterns/input/IconButtonPage.js
@@ -67,8 +67,8 @@ export default function IconButtonPage() {
         </Library.Example>
       </Library.Pattern>
 
-      <Library.Pattern title="Icons">
-        <Library.Example>
+      <Library.Pattern title="Props">
+        <Library.Example title="icon">
           <p>
             The <code>IconButton</code>
             {"'s"} <code>icon</code> prop accepts an icon component and will
@@ -84,7 +84,7 @@ export default function IconButtonPage() {
             </span>
           </Library.Demo>
         </Library.Example>
-        <Library.Example title="Custom icon styling">
+        <Library.Example title="icon: customizing styles">
           <p>
             If you need more control over icon styles, use an icon component
             directly in the content instead.
@@ -98,20 +98,17 @@ export default function IconButtonPage() {
             </IconButton>
           </Library.Demo>
         </Library.Example>
-      </Library.Pattern>
+        <Library.Example title="variant">
+          <p>
+            These examples show each variant in each of the supported states.
+            These states are associated with the <code>pressed</code>,{' '}
+            <code>expanded</code> and <code>disabled</code> boolean props.
+          </p>
 
-      <Library.Pattern title="Variant">
-        <p>
-          These examples show each variant in each of the supported states.
-          These states are associated with the <code>pressed</code>,{' '}
-          <code>expanded</code> and <code>disabled</code> boolean props.
-        </p>
-
-        <p>
-          For customization, use <code>ButtonUnstyled</code>.
-        </p>
-        <Library.Example title="variant: 'secondary' (default)">
-          <Library.Demo title="default, pressed, expanded, disabled" withSource>
+          <p>
+            For customization, use <code>ButtonUnstyled</code>.
+          </p>
+          <Library.Demo title="variant: 'secondary' (default)" withSource>
             <IconButton
               variant="secondary"
               title="Watch out!"
@@ -136,10 +133,8 @@ export default function IconButtonPage() {
               disabled
             />
           </Library.Demo>
-        </Library.Example>
 
-        <Library.Example title="variant: 'primary'">
-          <Library.Demo title="default, pressed, expanded, disabled" withSource>
+          <Library.Demo title="variant: 'primary'" withSource>
             <IconButton
               variant="primary"
               title="Watch out!"
@@ -164,12 +159,9 @@ export default function IconButtonPage() {
               disabled
             />
           </Library.Demo>
-        </Library.Example>
-
-        <Library.Example title="variant: 'dark'">
           <Library.Demo
             classes="bg-slate-0 p-4"
-            title="default, pressed, expanded, disabled"
+            title="variant: 'dark'"
             withSource
           >
             <IconButton variant="dark" title="Watch out!" icon={CautionIcon} />
@@ -193,22 +185,19 @@ export default function IconButtonPage() {
             />
           </Library.Demo>
         </Library.Example>
-      </Library.Pattern>
-
-      <Library.Pattern title="Size">
-        <p>
-          The <code>size</code> prop affects padding and spacing within the{' '}
-          <code>IconButton</code>.
-        </p>
-        <Library.Example>
-          <Library.Demo withSource>
+        <Library.Example title="size">
+          <p>
+            The <code>size</code> prop affects padding and spacing within the{' '}
+            <code>IconButton</code>.
+          </p>
+          <Library.Demo title="size: 'sm', 'md' and 'lg'" withSource>
             <IconButton icon={EditIcon} size="sm" title="Edit" />
             <IconButton icon={EditIcon} size="md" title="Edit" />
             <IconButton icon={EditIcon} size="lg" title="Edit" />
           </Library.Demo>
         </Library.Example>
 
-        <Library.Example title="Disabling touch-target sizing">
+        <Library.Example title="disableTouchSizing">
           <p>
             By default, <code>IconButton</code> will apply styles for touch
             devices (<code>pointer: coarse</code>) to ensure the minimum
@@ -217,7 +206,7 @@ export default function IconButtonPage() {
             <code>disableTouchSizing</code> boolean prop.
           </p>
 
-          <Library.Demo withSource>
+          <Library.Demo title="Disabling touch-target sizing" withSource>
             <IconButton icon={EditIcon} title="Edit" disableTouchSizing />
           </Library.Demo>
         </Library.Example>

--- a/src/pattern-library/components/patterns/input/InputPage.js
+++ b/src/pattern-library/components/patterns/input/InputPage.js
@@ -47,39 +47,41 @@ export default function InputPage() {
         </Library.Example>
       </Library.Pattern>
 
-      <Library.Pattern title="type">
-        <p>
-          <code>Input</code> currently supports the following <code>type</code>{' '}
-          values:
-        </p>
-        <ul>
-          <li>
-            <code>text</code> (default)
-          </li>
-          <li>
-            <code>url</code>
-          </li>
-          <li>
-            <code>email</code>
-          </li>
-          <li>
-            <code>text</code>
-          </li>
-        </ul>
-      </Library.Pattern>
+      <Library.Pattern title="Props">
+        <Library.Example title="type">
+          <p>
+            <code>Input</code> currently supports the following{' '}
+            <code>type</code> values:
+          </p>
+          <ul>
+            <li>
+              <code>text</code> (default)
+            </li>
+            <li>
+              <code>url</code>
+            </li>
+            <li>
+              <code>email</code>
+            </li>
+            <li>
+              <code>text</code>
+            </li>
+          </ul>
+        </Library.Example>
 
-      <Library.Pattern title="hasError">
-        <Library.Example>
-          <Library.Demo title="Input with an associated error" withSource>
+        <Library.Example title="hasError">
+          <p>
+            Set <code>hasError</code> to indicate that there is an associated
+            error for the <code>Input</code>.
+          </p>
+          <Library.Demo withSource>
             <div className="w-[350px]">
               <Input hasError value="something invalid" />
             </div>
           </Library.Demo>
         </Library.Example>
-      </Library.Pattern>
 
-      <Library.Pattern title="disabled">
-        <Library.Example>
+        <Library.Example title="disabled">
           <Library.Demo withSource>
             <div className="w-[350px]">
               <Input placeholder="Disabled..." disabled />

--- a/src/pattern-library/components/patterns/layout/CardPage.js
+++ b/src/pattern-library/components/patterns/layout/CardPage.js
@@ -114,7 +114,7 @@ export default function CardPage() {
           intensify on hover. These can be disabled by using the{' '}
           <code>flat</code> variant.
         </p>
-        <Library.Example title="Variant">
+        <Library.Example title="variant">
           <Library.Demo title="variant: 'raised' (default)" withSource>
             <Card variant="raised">
               <CardContent>
@@ -200,7 +200,7 @@ export default function CardPage() {
           </Library.Demo>
         </Library.Example>
 
-        <Library.Example title="Size">
+        <Library.Example title="size">
           <p>
             The <code>size</code> prop (<em>default</em> <code>md</code>)
             adjusts relative padding and spacing in <code>CardContent</code>.
@@ -313,28 +313,27 @@ export default function CardPage() {
             </Card>
           </Library.Demo>
         </Library.Example>
+      </Library.Pattern>
 
-        <Library.Example title="CardTitle">
-          <p>
-            Using <code>CardTitle</code> allows for more layout flexibility in{' '}
-            <code>CardHeader</code>.
-          </p>
-          <Library.Demo title="Setting title with CardTitle" withSource>
-            <Card>
-              <CardHeader>
-                <EditIcon />
-                <CardTitle>Card title</CardTitle>
-              </CardHeader>
-              <CardContent>
-                <div>
-                  Using <code>CardTitle</code> in a <code>CardHeader</code>.
-                  This allows for other custom content in the{' '}
-                  <code>CardHeader</code>.
-                </div>
-              </CardContent>
-            </Card>
-          </Library.Demo>
-        </Library.Example>
+      <Library.Pattern title="CardTitle">
+        <p>
+          Using <code>CardTitle</code> allows for more layout flexibility in{' '}
+          <code>CardHeader</code>.
+        </p>
+        <Library.Demo title="Setting title with CardTitle" withSource>
+          <Card>
+            <CardHeader>
+              <EditIcon />
+              <CardTitle>Card title</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div>
+                Using <code>CardTitle</code> in a <code>CardHeader</code>. This
+                allows for other custom content in the <code>CardHeader</code>.
+              </div>
+            </CardContent>
+          </Card>
+        </Library.Demo>
       </Library.Pattern>
 
       <Library.Pattern title="CardActions">

--- a/src/pattern-library/components/patterns/layout/PanelPage.js
+++ b/src/pattern-library/components/patterns/layout/PanelPage.js
@@ -55,11 +55,11 @@ export default function PanelPage() {
         </Library.Example>
       </Library.Pattern>
 
-      <Library.Pattern title="onClose">
-        <p>
-          Provide a function to <code>onClose</code> to render a close button.
-        </p>
-        <Library.Example>
+      <Library.Pattern title="Props">
+        <Library.Example title="onClose">
+          <p>
+            Provide a function to <code>onClose</code> to render a close button.
+          </p>
           <Library.Demo title="Panel with close button" withSource>
             <Panel title="Panel title" onClose={() => alert('you clicked it')}>
               Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
@@ -67,14 +67,12 @@ export default function PanelPage() {
             </Panel>
           </Library.Demo>
         </Library.Example>
-      </Library.Pattern>
 
-      <Library.Pattern title="icon">
-        <p>
-          An <code>IconComponent</code> provided to the <code>icon</code> prop
-          will be rendered to the left of the title.
-        </p>
-        <Library.Example>
+        <Library.Example title="icon">
+          <p>
+            An <code>IconComponent</code> provided to the <code>icon</code> prop
+            will be rendered to the left of the title.
+          </p>
           <Library.Demo withSource>
             <Panel title="Panel title" icon={EditIcon}>
               Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
@@ -82,14 +80,12 @@ export default function PanelPage() {
             </Panel>
           </Library.Demo>
         </Library.Example>
-      </Library.Pattern>
 
-      <Library.Pattern title="buttons">
-        <p>
-          <code>ComponentChildren</code> passed to the <code>buttons</code> prop
-          will be rendered as actions in the panel.
-        </p>
-        <Library.Example>
+        <Library.Example title="buttons">
+          <p>
+            <code>ComponentChildren</code> passed to the <code>buttons</code>{' '}
+            prop will be rendered as actions in the panel.
+          </p>
           <Library.Demo withSource>
             <Panel
               title="Panel title"

--- a/src/pattern-library/components/patterns/navigation/LinkPage.js
+++ b/src/pattern-library/components/patterns/navigation/LinkPage.js
@@ -55,39 +55,24 @@ export default function LinkPage() {
         </Library.Example>
       </Library.Pattern>
 
-      <Library.Pattern title="Color">
-        <p>
-          <code>color</code> applies to link text and hovered link text.
-        </p>
-        <Library.Example title="color: 'brand' (default)">
-          <Library.Demo
-            title="Using default color='brand' for sign up link"
-            withSource
-          >
+      <Library.Pattern title="Props">
+        <Library.Example title="color">
+          <p>
+            <code>color</code> applies to link text and hovered link text.
+          </p>
+          <Library.Demo title="color: 'brand' (default)" withSource>
             <Link href="https://www.example.com" color="brand">
               Sign up
             </Link>
           </Library.Demo>
-        </Library.Example>
-
-        <Library.Example title="color: 'text-light'">
-          <Library.Demo
-            title="Using color='text-light' for an annotation tag"
-            withSource
-          >
+          <Library.Demo title="color: 'text-light'" withSource>
             <Link href="https://www.example.com" color="text-light">
               <div className="flex items-center border rounded-sm bg-grey-0 px-1.5 py-1">
                 annotation tag
               </div>
             </Link>
           </Library.Demo>
-        </Library.Example>
-
-        <Library.Example title="color: 'text'">
-          <Library.Demo
-            title="Using color='text' for sidebar tab labels"
-            withSource
-          >
+          <Library.Demo title="color: 'text'" withSource>
             <p className="text-color-text">
               <Link href="https://www.example.com" color="text">
                 Page notes
@@ -95,30 +80,21 @@ export default function LinkPage() {
             </p>
           </Library.Demo>
         </Library.Example>
-      </Library.Pattern>
 
-      <Library.Pattern title="Underline">
-        <p>
-          By default, <code>Link</code>s are not underlined. This is acceptable
-          when the <code>Link</code> is a standalone, interactive element.
-          Underline on hover is encouraged, however, and <code>Link</code>s
-          inline with text content should always be underlined.
-        </p>
-        <Library.Example title="underline:'none' (default)">
-          <Library.Demo
-            title="Using underline='none' for standalone log in link"
-            withSource
-          >
+        <Library.Example title="underline">
+          <p>
+            By default, <code>Link</code>s are not underlined. This is
+            acceptable when the <code>Link</code> is a standalone, interactive
+            element. Underline on hover is encouraged, however, and{' '}
+            <code>Link</code>s inline with text content should always be
+            underlined.
+          </p>
+          <Library.Demo title="underline:'none' (default)" withSource>
             <Link href="https://www.example.com" underline="none">
               Log in
             </Link>
           </Library.Demo>
-        </Library.Example>
-        <Library.Example title="underline:'hover'">
-          <Library.Demo
-            title="Using underline='hover' for reply-expansion link"
-            withSource
-          >
+          <Library.Demo title="underline:'hover'" withSource>
             <Link
               href="https://www.example.com"
               color="text-light"
@@ -127,12 +103,7 @@ export default function LinkPage() {
               Show replies (7)
             </Link>
           </Library.Demo>
-        </Library.Example>
-        <Library.Example title="underline:'always'">
-          <Library.Demo
-            title="Using underline='always' in text content"
-            withSource
-          >
+          <Library.Demo title="underline:'always'" withSource>
             <p>
               Links should be{' '}
               <Link href="https://www.example.com" underline="always">


### PR DESCRIPTION
This is the first of a series of PRs representing changes merged to the `version-5.3` branch.

* The [first commit](49cf9c589de1e95cc63c8baa1381c1f9deeb0283) satisfies https://github.com/hypothesis/frontend-shared/issues/532, which is a laundry list of feedback items related to documentation in the pattern library. These are _content_ updates.
* The [second commit](2b5ab3f5e1828bcdfd83cafe528ef46b4c1962f1) does some markup and structural cleanup of pattern-library pages to ensure consistency of casing and sections. I don't anticipate this needs granular review.

Fixes #532