### PR TITLE
Version 5.3 PR 2/n: Adjust common test functions to take options object

### DIFF
--- a/src/components/input/test/IconButton-test.js
+++ b/src/components/input/test/IconButton-test.js
@@ -10,7 +10,7 @@ describe('IconButton', () => {
     return mount(<IconButton {...props} />);
   };
 
-  testPresentationalComponent(IconButton, 'IconButton');
+  testPresentationalComponent(IconButton, { componentName: 'IconButton' });
 
   it('renders proportionally-sized icon', () => {
     const wrapper = createComponent({ icon: CancelIcon });

--- a/src/components/layout/test/Card-test.js
+++ b/src/components/layout/test/Card-test.js
@@ -3,5 +3,5 @@ import { testPresentationalComponent } from '../../test/common-tests';
 import Card from '../Card';
 
 describe('Card', () => {
-  testPresentationalComponent(Card, 'Card');
+  testPresentationalComponent(Card, { componentName: 'Card' });
 });

--- a/src/components/layout/test/Panel-test.js
+++ b/src/components/layout/test/Panel-test.js
@@ -10,7 +10,7 @@ const createComponent = (Component, props = {}) => {
 };
 
 describe('Panel', () => {
-  testCompositeComponent(Panel, 'Panel');
+  testCompositeComponent(Panel);
 
   it('renders an icon if one provided to `icon`', () => {
     const wrapper = createComponent(Panel, { icon: EditIcon });

--- a/src/components/navigation/test/Link-test.js
+++ b/src/components/navigation/test/Link-test.js
@@ -3,5 +3,5 @@ import { testPresentationalComponent } from '../../test/common-tests';
 import Link from '../Link';
 
 describe('Link', () => {
-  testPresentationalComponent(Link, 'Link');
+  testPresentationalComponent(Link, { componentName: 'Link' });
 });


### PR DESCRIPTION
This small PR adds some common test functionality.

Update common test functions to take options. Add `elementSelector` prop for components whose "primary" element is not the outermost. This will be the case for the `Checkbox` component, whose outermost element is a `label` but "primary" element is an `input` — that's where any passed HTML attributes get applied.

Depends on #569 