### PR TITLE
Make small enhancements to Code, Example components and format object values nicely

### DIFF
--- a/src/pattern-library/components/Library.js
+++ b/src/pattern-library/components/Library.js
@@ -149,15 +149,6 @@ function Pattern({ children, id, title }) {
  *   @param {string} [props.title]
  */
 function Example({ children, id, title }) {
-  const kids = toChildArray(children);
-
-  // Extract Demo components out of any children
-  const demos = kids.filter(
-    kid => typeof kid === 'object' && kid?.type === Demo
-  );
-  // And everything else that is not a demo...
-  const notDemos = kids.filter(kid => !demos.includes(kid));
-
   return (
     <div className="space-y-6">
       {title && (
@@ -165,9 +156,7 @@ function Example({ children, id, title }) {
           {title}
         </h4>
       )}
-
-      <div className="space-y-6 px-4">{notDemos}</div>
-      <div className="space-y-16 px-4">{demos}</div>
+      {children}
     </div>
   );
 }

--- a/src/pattern-library/components/LibraryNext.js
+++ b/src/pattern-library/components/LibraryNext.js
@@ -8,6 +8,8 @@ import { useMemo } from 'preact/hooks';
 
 import { jsxToHTML } from '../util/jsx-to-string';
 
+import { Scroll, ScrollContainer } from '../../next';
+
 /**
  * Render a little label or pill next to changelog items
  *
@@ -62,6 +64,9 @@ function ChangelogItem({ status, children }) {
 /**
  * Render provided `content` as a "code block" example.
  *
+ * Long code content will scroll if <Code /> is rendered inside a parent
+ * element with constrained dimensions.
+ *
  * @param {object} props
  *   @param {import('preact').ComponentChildren} props.content - Code content
  *   @param {'sm'|'md'|'lg'} [props.size]
@@ -72,25 +77,29 @@ function Code({ content, size, title }) {
   const codeMarkup = useMemo(() => jsxToHTML(content), [content]);
 
   return (
-    <figure className="space-y-2">
-      <div
-        className={classnames(
-          'unstyled-text bg-slate-7 text-color-text-inverted p-4 rounded-md',
-          { 'text-sm': size === 'sm' }
+    <figure className="space-y-2 min-h-0 h-full">
+      <ScrollContainer borderless>
+        <div
+          className={classnames(
+            'unstyled-text bg-slate-7 text-color-text-inverted p-4 rounded-md min-h-0 h-full',
+            { 'text-sm': size === 'sm' }
+          )}
+        >
+          <Scroll variant="flat">
+            <code className="text-color-text-inverted">
+              <pre
+                className="whitespace-pre-wrap"
+                dangerouslySetInnerHTML={{ __html: codeMarkup }}
+              />
+            </code>
+          </Scroll>
+        </div>
+        {title && (
+          <figcaption className="flex justify-end">
+            <span className="italic">{title}</span>
+          </figcaption>
         )}
-      >
-        <code className="text-color-text-inverted">
-          <pre
-            className="whitespace-pre-wrap"
-            dangerouslySetInnerHTML={{ __html: codeMarkup }}
-          />
-        </code>
-      </div>
-      {title && (
-        <figcaption className="flex justify-end">
-          <span className="italic">{title}</span>
-        </figcaption>
-      )}
+      </ScrollContainer>
     </figure>
   );
 }

--- a/src/pattern-library/util/jsx-to-string.js
+++ b/src/pattern-library/util/jsx-to-string.js
@@ -89,6 +89,9 @@ export function jsxToString(vnode) {
           valueStr = `{${componentName(value)}}`;
         } else if (isJSXElement(value)) {
           valueStr = `{${jsxToString(value)}}`;
+        } else if (value && typeof value === 'object') {
+          // Use the prop name instead of [Object object]; it's more helpful
+          valueStr = `{${name}}`;
         } else if (value) {
           // `toString` necessary for Symbols
           valueStr = `{${value.toString()}}`;


### PR DESCRIPTION
This PR pops off three small commits from other component branches so that those branches may contain purely component- and component-documentation-related changes.

* Add scrolling to `Code` — long code content will now scroll if the parent container has dimension constraints (used for showing the `rows` used in `Table` examples)
* Remove unneeded complexity from the rendering of `Example` children. `Demo`s may now be interleaved with other content in `Examples` (Used to interleave content and demos in `AspectRatio` and `Thumbnail` examples).
* Make prop values that are objects render a little more nicely than their stringified `[object Object]`. This is hamfisted and quick but it helps.  (Make props passed to `DataTable` more readable in demo Source tabs)