### PR TITLE
Update test CSS bundling and add a11y tests to common tests

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -42,7 +42,7 @@ gulp.task(
  * nb. This is only used for unit tests that need CSS to verify accessibility requirements.
  */
 gulp.task('build-test-css', () =>
-  buildCSS(['styles/index.scss'], { tailwindConfig })
+  buildCSS(['styles/test.scss'], { tailwindConfig })
 );
 
 // Some (eg. a11y) tests rely on CSS bundles. We assume that JS will always take

--- a/src/components/input/Input.js
+++ b/src/components/input/Input.js
@@ -28,6 +28,11 @@ const InputNext = function Input({
 
   ...htmlAttributes
 }) {
+  if (!htmlAttributes.id && !htmlAttributes['aria-label']) {
+    console.warn(
+      '`Input` component should have either an `id` or an `aria-label` attribute'
+    );
+  }
   return (
     <input
       {...htmlAttributes}

--- a/src/components/input/test/Input-test.js
+++ b/src/components/input/test/Input-test.js
@@ -1,7 +1,13 @@
+import { mount } from 'enzyme';
+
 import { testPresentationalComponent } from '../../test/common-tests';
 
 import Input from '../Input';
 
+const contentFn = (Component, props = {}) => {
+  return mount(<Component aria-label="Test input" {...props} />);
+};
+
 describe('Input', () => {
-  testPresentationalComponent(Input);
+  testPresentationalComponent(Input, { createContent: contentFn });
 });

--- a/src/components/input/test/Input-test.js
+++ b/src/components/input/test/Input-test.js
@@ -10,4 +10,17 @@ const contentFn = (Component, props = {}) => {
 
 describe('Input', () => {
   testPresentationalComponent(Input, { createContent: contentFn });
+
+  it('should warn in console if accessibility attributes are missing', () => {
+    sinon.stub(console, 'warn');
+
+    mount(<Input placeholder="..." />);
+
+    assert.calledWith(
+      console.warn,
+      '`Input` component should have either an `id` or an `aria-label` attribute'
+    );
+
+    console.warn.restore();
+  });
 });

--- a/src/components/test/common-tests.js
+++ b/src/components/test/common-tests.js
@@ -1,6 +1,8 @@
 import { mount } from 'enzyme';
 import { createRef } from 'preact';
 
+import { checkAccessibility } from '../../../test/util/accessibility';
+
 /**
  * @typedef {import('preact').FunctionComponent} FunctionComponent
  */
@@ -73,6 +75,13 @@ export function testCompositeComponent(
         displayName
       );
     });
+
+    it(
+      'should pass a11y checks',
+      checkAccessibility({
+        content: () => createContent(Component),
+      })
+    );
   });
 }
 
@@ -129,6 +138,13 @@ export function testPresentationalComponent(
       assert.isTrue(primaryEl.hasAttribute('data-component'));
       assert.equal(primaryEl.getAttribute('data-component'), displayName);
     });
+
+    it(
+      'should pass a11y checks',
+      checkAccessibility({
+        content: () => createContent(Component),
+      })
+    );
   });
 }
 
@@ -164,6 +180,13 @@ export function testBaseComponent(Component) {
       assert.isTrue(wrapperOuterEl.hasAttribute('data-testid'));
       assert.equal(wrapperOuterEl.getAttribute('data-testid'), 'foo-container');
     });
+
+    it(
+      'should pass a11y checks',
+      checkAccessibility({
+        content: () => createComponent(Component),
+      })
+    );
   });
 }
 

--- a/src/karma.config.cjs
+++ b/src/karma.config.cjs
@@ -24,7 +24,7 @@ module.exports = function (config) {
       // CSS bundle relied upon by accessibility tests (eg. for color-contrast
       // checks).
       {
-        pattern: '../build/styles/index.css',
+        pattern: '../build/styles/test.css',
         watched: false,
       },
     ],

--- a/src/pattern-library/components/patterns/input/InputPage.js
+++ b/src/pattern-library/components/patterns/input/InputPage.js
@@ -49,7 +49,28 @@ export default function InputPage() {
           <Library.Example>
             <Library.Demo title="Basic Input" withSource>
               <div className="w-[350px]">
-                <Input placeholder="Placeholder..." />
+                <Input
+                  aria-label="Input example"
+                  placeholder="Placeholder..."
+                />
+              </div>
+            </Library.Demo>
+          </Library.Example>
+
+          <Library.Example title="Accessibility">
+            <p>
+              Hypothesis does not currently have a design pattern for labeling
+              text inputs. However, for accessibility, it is critical that an{' '}
+              <code>Input</code> have either an associated <code>label</code>{' '}
+              element or an <code>aria-label</code> attribute.
+            </p>
+
+            <Library.Demo title="Input with label" withSource>
+              <div className="w-[350px]">
+                <label htmlFor="input-with-label" className="font-semibold">
+                  Label
+                </label>
+                <Input id="input-with-label" placeholder="Placeholder..." />
               </div>
             </Library.Demo>
           </Library.Example>
@@ -84,7 +105,11 @@ export default function InputPage() {
             </p>
             <Library.Demo withSource>
               <div className="w-[350px]">
-                <Input hasError value="something invalid" />
+                <Input
+                  aria-label="Example input"
+                  hasError
+                  value="something invalid"
+                />
               </div>
             </Library.Demo>
           </Library.Example>
@@ -92,7 +117,11 @@ export default function InputPage() {
           <Library.Example title="disabled">
             <Library.Demo withSource>
               <div className="w-[350px]">
-                <Input placeholder="Disabled..." disabled />
+                <Input
+                  aria-label="Example input"
+                  placeholder="Disabled..."
+                  disabled
+                />
               </div>
             </Library.Demo>
           </Library.Example>

--- a/styles/test.scss
+++ b/styles/test.scss
@@ -1,0 +1,10 @@
+/**
+ * Stylesheet for tests
+ */
+
+// Styles for legacy components
+@use 'index';
+
+// Styles for new components
+@use 'tailwindcss/utilities';
+@use 'tailwindcss/components';


### PR DESCRIPTION
When writing the somewhat-more-involved tests for `DataTable` this afternoon, I realized there were two test things that needed doing:

1. The test CSS bundle didn't include CSS for updated components (i.e. Tailwind). This became a problem when I was trying to test `Table` behavior within constrained `Scroll` components.
2. I had neglected to add automated a11y tests to the common tests

This PR rectifies both of these.

The addition of accessibility tests kicked up one issue in the `Input` component that I have remedied for now and updated the associated pattern-library documentation. There's a broader thing to look at here as we disseminate this new component: making sure we are correctly labeling our text inputs.