### PR TITLE
Ensure `ButtonUnstyled` takes HTML attributes for button elements

### DIFF
--- a/src/components/input/ButtonUnstyled.js
+++ b/src/components/input/ButtonUnstyled.js
@@ -7,12 +7,13 @@ import ButtonBase from './ButtonBase';
 /**
  * @typedef {import('../../types').PresentationalProps} CommonProps
  * @typedef {import('./ButtonBase').ButtonCommonProps} ButtonCommonProps
+ * @typedef {import('./ButtonBase').HTMLButtonAttributes} HTMLButtonAttributes
  */
 
 /**
  * Render a button with common attributes but no styling
  *
- * @param {CommonProps & ButtonCommonProps} props
+ * @param {CommonProps & ButtonCommonProps & HTMLButtonAttributes} props
  */
 const ButtonUnstyledNext = function ButtonUnstyled({
   children,

--- a/src/pattern-library/components/patterns/input/ButtonPage.js
+++ b/src/pattern-library/components/patterns/input/ButtonPage.js
@@ -399,7 +399,10 @@ export default function ButtonPage() {
           </p>
           <Library.Example>
             <Library.Demo withSource>
-              <ButtonUnstyled classes="focus-visible-ring bg-slate-0 p-2">
+              <ButtonUnstyled
+                classes="focus-visible-ring bg-slate-0 p-2"
+                onClick={() => alert('You clicked it!')}
+              >
                 My custom button
               </ButtonUnstyled>
             </Library.Demo>


### PR DESCRIPTION
Um, derp. `ButtonUnstyled` needs to take HTML button attributes. It's not too useful to have a button that can't, e.g., take an `onClick`...

Plain ol' mistake!