### PR TITLE
Enable `noImplicitAny` TS option

### DIFF
--- a/src/components/Thumbnail.js
+++ b/src/components/Thumbnail.js
@@ -10,7 +10,7 @@ import { Spinner } from './Spinner';
  * @prop {Children|null} [children] - Thumbnail content (typically an img)
  * @prop {string} [classes] - Additional CSS classes to apply
  * @prop {boolean} [isLoading=false] - Is the thumbnail loading?
- * @prop {object} [placeholder='...'] - Optional placeholder to replace default
+ * @prop {Children} [placeholder='...'] - Optional placeholder to replace default
  * @prop {'small'|'medium'|'large'} [size='medium'] - Relative size of spinner
  *   to surrounding content. Typically the `large` size is appropriate, but for
  *   small thumbnails, `medium` might feel more appropriate.

--- a/src/components/buttons.js
+++ b/src/components/buttons.js
@@ -65,6 +65,8 @@ function ButtonBase({
   ...restProps
 }) {
   const role = restProps?.role ?? 'button';
+
+  /** @type {Record<string, unknown>} */
   const ariaProps = {
     'aria-label': restProps.title,
   };

--- a/src/components/data/DataTable.js
+++ b/src/components/data/DataTable.js
@@ -38,7 +38,7 @@ import TableCell from './TableCell';
  *   double-click or pressing "Enter"
  * @prop {(r: Row) => void} [onSelectRow] - Callback when a row is "selected" by
  *   focus or click
- * @prop {(r: Row, field: string) => Children} [renderItem] - Callback to render an individual table cell
+ * @prop {(r: Row, field: keyof Row) => Children} [renderItem] - Callback to render an individual table cell
  * @prop {Children} [emptyMessage] - Content to render if rows is empty (and not
  *   in a loading state)
  */
@@ -58,7 +58,7 @@ const DataTableNext = function DataTable({
   title,
   selectedRow,
   loading = false,
-  renderItem = (row, field) => row[field],
+  renderItem = (row, field) => /** @type {Children} */ (row[field]),
   onSelectRow,
   onConfirmRow,
   emptyMessage,
@@ -160,7 +160,9 @@ const DataTableNext = function DataTable({
               onKeyDown={event => handleKeyDown(event, row)}
             >
               {fields.map(field => (
-                <TableCell key={field}>{renderItem(row, field)}</TableCell>
+                <TableCell key={field}>
+                  {renderItem(row, /** @type {keyof Row} */ (field))}
+                </TableCell>
               ))}
             </TableRow>
           ))}

--- a/src/components/input/ButtonBase.js
+++ b/src/components/input/ButtonBase.js
@@ -41,6 +41,7 @@ const ButtonBaseNext = function ButtonBase({
   role,
   ...htmlAttributes
 }) {
+  /** @type {Record<string, unknown>} */
   const ariaProps = {
     'aria-label': title,
   };

--- a/src/components/input/Input.js
+++ b/src/components/input/Input.js
@@ -28,6 +28,7 @@ const InputNext = function Input({
 
   ...htmlAttributes
 }) {
+  // @ts-expect-error - "aria-label" is missing from HTMLInputAttributes
   if (!htmlAttributes.id && !htmlAttributes['aria-label']) {
     console.warn(
       '`Input` component should have either an `id` or an `aria-label` attribute'

--- a/src/pattern-library/components/Library.js
+++ b/src/pattern-library/components/Library.js
@@ -200,7 +200,7 @@ function DemoButton({ children, onClick, pressed }) {
  *   @param {boolean} [props.withSource=false] - Should the demo also render the source?
  *    When true, a "Source" tab will be rendered, which will display the JSX
  *    source of the Demo's children.
- *   @param {object} [props.style] - Inline styles to apply to the demo container
+ *   @param {import('preact').JSX.CSSProperties} [props.style] - Inline styles to apply to the demo container
  *   @param {string} [props.title]
  */
 function Demo({ children, classes, withSource = false, style = {}, title }) {

--- a/src/pattern-library/components/PlaygroundApp.js
+++ b/src/pattern-library/components/PlaygroundApp.js
@@ -135,7 +135,14 @@ export default function PlaygroundApp({
             <NavHeader>Components</NavHeader>
             {Object.keys(componentGroups).map(group => {
               return (
-                <NavSection key={group} title={componentGroups[group]}>
+                <NavSection
+                  key={group}
+                  title={
+                    componentGroups[
+                      /** @type {keyof componentGroups} */ (group)
+                    ]
+                  }
+                >
                   <NavList
                     routes={getRoutes(
                       /** @type PlaygroundRouteGroup */ (group)

--- a/src/pattern-library/components/patterns/ColorsPage.js
+++ b/src/pattern-library/components/patterns/ColorsPage.js
@@ -1,6 +1,13 @@
 import classnames from 'classnames';
 import Library from '../Library';
 
+/**
+ * @typedef ColorSwatchProps
+ * @prop {string} colorClass
+ * @prop {string} colorName
+ */
+
+/** @param {ColorSwatchProps} props */
 function ColorSwatch({ colorClass, colorName }) {
   return (
     <div>

--- a/src/pattern-library/components/patterns/IconComponents.js
+++ b/src/pattern-library/components/patterns/IconComponents.js
@@ -4,12 +4,11 @@ import Next from '../LibraryNext';
 import { Card, Icon, registerIcon } from '../../../';
 import * as iconSrc from '../../../icons';
 
+/** @type {Record<string, symbol>} */
 const icons = {};
 
-for (const iconName in iconSrc) {
-  if (Object.prototype.hasOwnProperty.call(iconSrc, iconName)) {
-    icons[iconName] = registerIcon(iconName, iconSrc[iconName]);
-  }
+for (let [iconName, src] of Object.entries(iconSrc)) {
+  icons[iconName] = registerIcon(iconName, src);
 }
 
 export default function IconComponents() {

--- a/src/pattern-library/components/patterns/TableComponents.js
+++ b/src/pattern-library/components/patterns/TableComponents.js
@@ -7,6 +7,13 @@ import Next from '../LibraryNext';
 
 import { sampleTableContent } from './samples';
 
+/**
+ * @typedef File
+ * @prop {string} displayName
+ * @prop {string} updated
+ */
+
+/** @param {File} file */
 const renderCallback = file => (
   <>
     <td>{file.displayName}</td>
@@ -14,6 +21,7 @@ const renderCallback = file => (
   </>
 );
 
+/** @param {File} file */
 const customizedRenderCallback = file => (
   <>
     <td className="text-grey-6">{file.displayName}</td>
@@ -26,7 +34,7 @@ const { tableHeaders, items } = sampleTableContent();
 function TableExample() {
   const [isLoading, setIsLoading] = useState(false);
   const [selectedFile, setSelectedFile] = useState(
-    /** @type {null|object} */ (null)
+    /** @type {null|File} */ (null)
   );
 
   return (
@@ -61,7 +69,7 @@ function TableExample() {
 function ScrollboxTableExample() {
   const [isLoading, setIsLoading] = useState(false);
   const [selectedFile, setSelectedFile] = useState(
-    /** @type {null|object} */ (items[items.length - 1])
+    /** @type {null|File} */ (items[items.length - 1])
   );
 
   return (
@@ -107,9 +115,10 @@ function ScrollboxTableExample() {
 
 function EmptyTableExample() {
   const [isLoading, setIsLoading] = useState(false);
+  /** @type {File[]} */
   const items = [];
   const [selectedFile, setSelectedFile] = useState(
-    /** @type {null|object} */ (items[items.length - 1])
+    /** @type {null|File} */ (items[items.length - 1])
   );
 
   const emptyItemsMessage = (

--- a/src/pattern-library/components/patterns/data/IconsPage.js
+++ b/src/pattern-library/components/patterns/data/IconsPage.js
@@ -38,7 +38,8 @@ export default function IconsPage() {
         <Library.Pattern title="Available icon components">
           <div className="grid grid-cols-4 gap-6">
             {Object.keys(Icons).map(iconName => {
-              const IconComponent = Icons[iconName];
+              const IconComponent =
+                Icons[/** @type {keyof Icons} */ (iconName)];
               return (
                 <div
                   className="flex flex-col gap-y-4 border rounded-sm p-4 items-center justify-center"

--- a/src/pattern-library/components/patterns/input/CheckboxPage.js
+++ b/src/pattern-library/components/patterns/input/CheckboxPage.js
@@ -7,8 +7,9 @@ import Next from '../../LibraryNext';
 export default function CheckboxPage() {
   const [checked, setChecked] = useState(false);
 
+  /** @param {Event} e */
   const handleControlledChange = e => {
-    setChecked(e.target.checked);
+    setChecked(/** @type {HTMLInputElement} */ (e.target).checked);
   };
   return (
     <Library.Page

--- a/src/pattern-library/router.js
+++ b/src/pattern-library/router.js
@@ -134,8 +134,9 @@ export function useRoute(baseURL, routes) {
   // Intercept clicks on links and trigger navigation to a route within the
   // app if appropriate.
   useEffect(() => {
+    /** @param {Event} event */
     const clickListener = event => {
-      const link = event.target.closest('a');
+      const link = /** @type {HTMLElement} */ (event.target).closest('a');
       if (!link) {
         return;
       }

--- a/src/pattern-library/util/jsx-to-string.js
+++ b/src/pattern-library/util/jsx-to-string.js
@@ -12,6 +12,7 @@ function escapeQuotes(str) {
   return str.replace(/"/g, '\\"');
 }
 
+/** @param {any} type */
 function componentName(type) {
   const name = typeof type === 'string' ? type : type.displayName ?? type.name;
   // Handle (display)name conflicts if there are two components with the same

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -12,7 +12,6 @@
     "declarationDir": "../lib",
 
     "strict": true,
-    "noImplicitAny": false,
     "target": "ES2020"
   },
   "include": ["**/*.js"],


### PR DESCRIPTION
Fix the remaining errors when the `noImplicitAny` TS option is enabled, and then remove the override that turned it off. This matches the TS settings in our other repos and will catch missing/incorrect types.