### PR TITLE
Do not set border-radius in component base styles

### DIFF
--- a/src/components/input/Button.js
+++ b/src/components/input/Button.js
@@ -43,7 +43,7 @@ const ButtonNext = function Button({
       {...htmlAttributes}
       classes={classnames(
         // NB: Base classes are applied by ButtonBase
-        'font-semibold',
+        'font-semibold rounded-sm',
         {
           // Variants
           'text-grey-7 bg-grey-1 enabled:hover:text-grey-9 enabled:hover:bg-grey-2 aria-pressed:text-grey-9 aria-expanded:text-grey-9':

--- a/src/components/input/ButtonBase.js
+++ b/src/components/input/ButtonBase.js
@@ -65,7 +65,7 @@ const ButtonBaseNext = function ButtonBase({
       {...htmlAttributes}
       className={classNames(
         {
-          'focus-visible-ring rounded-sm': !unstyled,
+          'focus-visible-ring': !unstyled,
           'transition-colors': !unstyled,
           // Set layout for button content
           'whitespace-nowrap flex items-center': !unstyled,

--- a/src/components/input/IconButton.js
+++ b/src/components/input/IconButton.js
@@ -49,7 +49,7 @@ const IconButtonNext = function IconButton({
       {...htmlAttributes}
       classes={classnames(
         // NB: Base classes are applied by ButtonBase
-        'justify-center gap-x-2',
+        'justify-center gap-x-2 rounded-sm',
         {
           // variant
           'text-grey-7 bg-transparent enabled:hover:text-grey-9 aria-pressed:text-brand aria-expanded:text-brand':

--- a/src/components/navigation/Link.js
+++ b/src/components/navigation/Link.js
@@ -32,6 +32,7 @@ const LinkNext = function Link({
     <LinkBase
       {...htmlAttributes}
       classes={classnames(
+        'rounded-sm',
         // NB: Base classes are applied by LinkBase
         {
           // color

--- a/src/components/navigation/LinkBase.js
+++ b/src/components/navigation/LinkBase.js
@@ -26,10 +26,7 @@ const LinkBaseNext = function LinkBase({
       /* data-component will be overwritten unless this component is used directly */
       data-component="LinkBase"
       {...htmlAttributes}
-      className={classnames(
-        { 'focus-visible-ring rounded-sm': !unstyled },
-        classes
-      )}
+      className={classnames({ 'focus-visible-ring': !unstyled }, classes)}
       rel="noopener noreferrer"
       ref={downcastRef(elementRef)}
     >

--- a/src/components/navigation/LinkButton.js
+++ b/src/components/navigation/LinkButton.js
@@ -39,7 +39,7 @@ const LinkButtonNext = function LinkButton({
       elementRef={downcastRef(elementRef)}
       classes={classnames(
         // NB: Base classes are applied by ButtonBase
-        'aria-pressed:font-semibold aria-expanded:font-semibold',
+        'aria-pressed:font-semibold aria-expanded:font-semibold rounded-sm',
         {
           // inline
           inline: inline,


### PR DESCRIPTION
In doing some quick assessment and overview of how we might plan the conversion of our apps over to the new component set, I spotted a couple of use cases in which setting `border-radius` rules (`rounded-*` rules in tailwind parlance) in base styles was undesirable. When reviewing the conventions for base styling — setting core layout, transition configuration, focus ring styling, but not metrics, colors, etc.), it seemed that these rules should not be present on base components.

These changes move `rounded-*` classes from base components to presentational components.