### PR TITLE
Add BucketButton component and documentation

### DIFF
--- a/src/components/navigation/BucketButton.js
+++ b/src/components/navigation/BucketButton.js
@@ -1,0 +1,124 @@
+import classnames from 'classnames';
+
+import { downcastRef } from '../../util/typing';
+
+import ButtonBase from '../input/ButtonBase';
+
+/**
+ * @typedef {import('../../types').PresentationalProps} CommonProps
+ * @typedef {import('../input/ButtonBase').HTMLButtonAttributes} HTMLButtonAttributes
+ * @typedef {import('../input/ButtonBase').ButtonCommonProps} ButtonCommonProps
+ *
+ * @typedef BucketButtonProps
+ * @prop {'left'|'up'|'down'|'lozenge'} [variant='lozenge']
+ */
+
+/**
+ * A button for pointing toward a quantified set of items somewhere else in the
+ * UI or off-screen.
+ *
+ * Used by the bucket bar in the client application to point at
+ * highlights/annotations in the guest document. Expected button content is
+ * numeric text, e.g.:
+ *
+ *   <BucketButton variant="left">5</BucketButton>
+ *
+ * The arrow-points are created by the combination of borders and positioning.
+ * See https://css-tricks.com/snippets/css/css-triangle/
+ *
+ * @param {CommonProps & ButtonCommonProps & BucketButtonProps &
+ * HTMLButtonAttributes} props
+ */
+const BucketButtonNext = function BucketButton({
+  children,
+  classes,
+  elementRef,
+
+  expanded,
+  pressed,
+  title,
+
+  variant = 'lozenge',
+
+  ...htmlAttributes
+}) {
+  return (
+    <ButtonBase
+      {...htmlAttributes}
+      elementRef={downcastRef(elementRef)}
+      classes={classnames(
+        // Establish relative positioning to allow absolute positioning of
+        // ::before and ::after pseudo-elements (the arrow pointers)
+        'relative',
+        'w-[26px] h-[16px]',
+        'flex items-center justify-center',
+        'bg-white rounded-[4px] border',
+        // The borders of ::before and ::after will be used to style the arrow
+        // pointer border (grey) and fill (white) respectively
+        'before:absolute before:border-transparent',
+        'after:absolute after:border-transparent',
+        'text-[10px] text-color-text-light leading-none font-semibold',
+        {
+          // This adds a 1-pixel x-offset to the default `shadow` (see tailwind
+          // config)
+          'shadow-[1px_1px_1px_rgba(0,0,0,0.1)]': variant !== 'down',
+          // The down arrow has no y-offset on its shadow to avoid odd edges
+          // around its down-pointing wedge
+          'shadow-[1px_0px_1px_rgba(0,0,0,0.1)]': variant === 'down',
+        },
+        {
+          // Styling for left-pointing arrows
+          'rounded-r-[4px] rounded-l-[2px]': variant === 'left',
+          // Position the right edges of ::before and ::after to align with the
+          // left edge of the button's body, centered vertically
+          'before:right-full before:top-1/2 after:right-full after:top-1/2':
+            variant === 'left',
+          // ::before is the grey border of the left-pointing wedge, 1px wider
+          // than the fill
+          'before:mt-[-8px] before:border-8 before:border-r-[5px] before:border-r-grey-3':
+            variant === 'left',
+          // ::after is the white fill of the left-pointing wedge. NB: ordering
+          // of these rules after the ::before rules is important for
+          // compositing order
+          'after:mt-[-7px] after:border-[7px] after:border-r-[4px] after:border-r-white':
+            variant === 'left',
+        },
+        {
+          'z-1 rounded-t-px-sm rounded-b-px': variant === 'up',
+          // Position the bottom edges of ::before and ::after to align with the
+          // top edges of the button body. Center horizontally.
+          'before:top-auto before:left-1/2 before:bottom-full after:top-auto after:left-1/2 after:bottom-full':
+            variant === 'up',
+          // Grey border of up-pointing wedge
+          'before:ml-[-13px] before:border-[13px] before:border-b-[6px] before:border-b-grey-3':
+            variant === 'up',
+          // White fill of up-pointing wedge
+          'after:ml-[-12px] after:border-[12px] after:border-b-[5px] after:border-b-white':
+            variant === 'up',
+        },
+        {
+          'z-1 rounded-t-px rounded-b-px-sm': variant === 'down',
+          // Position the top edges of ::before and ::after at the bottom of
+          // the button body. Center horizontally.
+          'before:top-full before:left-1/2 after:top-full after:left-1/2':
+            variant === 'down',
+          // Grey border of down-pointing wedge
+          'before:ml-[-13px] before:border-[13px] before:border-t-[6px] before:border-t-grey-3':
+            variant === 'down',
+          // White fill of down-pointing wedge
+          'after:ml-[-12px] after:border-[12px] after:border-t-[5px] after:border-t-white':
+            variant === 'down',
+        },
+        classes
+      )}
+      data-component="BucketButton"
+      expanded={expanded}
+      pressed={pressed}
+      title={title}
+    >
+      {children}
+    </ButtonBase>
+  );
+};
+
+export default BucketButtonNext;

--- a/src/components/navigation/index.js
+++ b/src/components/navigation/index.js
@@ -1,3 +1,4 @@
+export { default as BucketButton } from './BucketButton';
 export { default as Link } from './Link';
 export { default as LinkBase } from './LinkBase';
 export { default as LinkButton } from './LinkButton';

--- a/src/components/navigation/test/BucketButton-test.js
+++ b/src/components/navigation/test/BucketButton-test.js
@@ -1,0 +1,7 @@
+import { testPresentationalComponent } from '../../test/common-tests';
+
+import BucketButton from '../BucketButton';
+
+describe('BucketButton', () => {
+  testPresentationalComponent(BucketButton);
+});

--- a/src/next.js
+++ b/src/next.js
@@ -36,4 +36,9 @@ export {
   Overlay,
   Panel,
 } from './components/layout';
-export { Link, LinkBase, LinkButton } from './components/navigation/';
+export {
+  BucketButton,
+  Link,
+  LinkBase,
+  LinkButton,
+} from './components/navigation/';

--- a/src/pattern-library/components/patterns/navigation/BucketsPage.js
+++ b/src/pattern-library/components/patterns/navigation/BucketsPage.js
@@ -1,0 +1,142 @@
+import { BucketButton } from '../../../../next';
+import Library from '../../Library';
+import Next from '../../LibraryNext';
+
+export default function BucketsPage() {
+  return (
+    <Library.Page
+      title="Buckets"
+      intro={
+        <>
+          <p>
+            <em>Buckets</em> are a concept are used in the Hypothesis client.
+            They represent a set of one or more annotation highlights that are
+            located near each other in the source text.
+          </p>
+          <p>
+            Bucket buttons point at and navigate to these groups of annotation
+            highlights, which are either in the visible content of the source
+            document (guest page) or off-screen (above or below).
+          </p>
+        </>
+      }
+    >
+      <Library.Section
+        title="BucketButton"
+        intro={
+          <p>
+            <code>BucketButton</code> is a presentational component for styling
+            a button that points towards a group of items elsewhere in the UI or
+            off-screen.
+          </p>
+        }
+      >
+        <Library.Pattern title="Status">
+          <p>
+            <code>BucketButton</code> is a new component.
+          </p>
+        </Library.Pattern>
+
+        <Library.Pattern title="Usage">
+          <Next.Usage componentName="BucketButton" />
+          <Library.Example>
+            <Library.Demo
+              title="BucketButton variants 'lozenge', 'up', 'down', 'left'"
+              withSource
+            >
+              <BucketButton>13</BucketButton>
+              <BucketButton variant="up">3</BucketButton>
+              <BucketButton variant="down">7</BucketButton>
+              <BucketButton variant="left">5</BucketButton>
+            </Library.Demo>
+
+            <p>
+              The following example shows <code>BucketButtons</code> as they
+              might appear in the client, positioned absolutely in a{' '}
+              {'"bucket bar"'}.
+            </p>
+
+            <Library.Demo title="BucketButtons in visual context" withSource>
+              <div className="w-[23px] h-[250px] bg-grey-2">
+                <ul className="relative h-full pointer-events-none">
+                  <li
+                    className="absolute right-0 pointer-events-auto mt-[-11px]"
+                    style={{ top: '15px' }}
+                  >
+                    <BucketButton variant="up">6</BucketButton>
+                  </li>
+
+                  <li
+                    className="absolute right-0 pointer-events-auto mt-[-8px]"
+                    style={{ top: '47px' }}
+                  >
+                    <BucketButton variant="left">10</BucketButton>
+                  </li>
+
+                  <li
+                    className="absolute right-0 pointer-events-auto mt-[-8px]"
+                    style={{ top: '112px' }}
+                  >
+                    <BucketButton variant="left">1</BucketButton>
+                  </li>
+
+                  <li
+                    className="absolute right-0 pointer-events-auto"
+                    style={{ top: '230px' }}
+                  >
+                    <BucketButton variant="down">4</BucketButton>
+                  </li>
+                </ul>
+              </div>
+            </Library.Demo>
+          </Library.Example>
+        </Library.Pattern>
+
+        <Library.Pattern title="Props">
+          <p>
+            <code>BucketButton</code> also takes common{' '}
+            <a href="./input-button">
+              <code>ButtonBase</code>
+            </a>{' '}
+            props.
+          </p>
+          <Library.Example title="variant">
+            <p>
+              While <code>lozenge</code> is the default variant, it is not
+              currently used anywhere. Translation: you need to tell your bucket
+              button which direction to point using the <code>variant</code>{' '}
+              prop.
+            </p>
+            <Library.Demo title="variant: lozenge (default)" withSource>
+              <BucketButton variant="lozenge">24</BucketButton>
+            </Library.Demo>
+
+            <p>
+              The <code>left</code> variant is intended to point to and navigate
+              to a bucket of annotations currently visible on-screen.
+            </p>
+            <Library.Demo title="variant: left" withSource>
+              <BucketButton variant="left">3</BucketButton>
+            </Library.Demo>
+
+            <p>
+              The <code>up</code> variant is intended to point to and navigate
+              to the next bucket offscreen (above).
+            </p>
+            <Library.Demo title="variant: up" withSource>
+              <BucketButton variant="up">4</BucketButton>
+            </Library.Demo>
+
+            <p>
+              The <code>down</code> variant is intended to point to and navigate
+              to the next bucket offscreen (below).
+            </p>
+            <Library.Demo title="variant: down" withSource>
+              <BucketButton variant="down">6</BucketButton>
+            </Library.Demo>
+          </Library.Example>
+        </Library.Pattern>
+      </Library.Section>
+    </Library.Page>
+  );
+}

--- a/src/pattern-library/routes.js
+++ b/src/pattern-library/routes.js
@@ -24,6 +24,7 @@ import CardPage from './components/patterns/layout/CardPage';
 import PanelPage from './components/patterns/layout/PanelPage';
 import OverlayPage from './components/patterns/layout/OverlayPage';
 
+import BucketsPage from './components/patterns/navigation/BucketsPage';
 import LinkPage from './components/patterns/navigation/LinkPage';
 import LinkButtonPage from './components/patterns/navigation/LinkButtonPage';
 
@@ -177,6 +178,12 @@ const routes = [
     group: 'layout',
     component: OverlayPage,
     route: '/layout-overlay',
+  },
+  {
+    title: 'Buckets',
+    group: 'navigation',
+    component: BucketsPage,
+    route: '/navigation-buckets',
   },
   {
     title: 'Link',

--- a/styles/library.scss
+++ b/styles/library.scss
@@ -5,6 +5,10 @@
 @layer components {
   // Support some basic text styling in Library components
   .styled-text {
+    :where(a):not(:where([class~='unstyled-text'] *)) {
+      @apply text-brand underline hover:text-brand-dark transition-colors;
+    }
+
     :where(code):not(:where([class~='unstyled-text'] *)) {
       @apply p-1 bg-slate-0 rounded-sm mx-0.5;
       font-size: 0.85em;


### PR DESCRIPTION
This PR adds a `BucketButton` component to the `navigation` component group.

## Why (on earth) this work?

There are several reasons I opted to chunk this bit of work out:

* `Buckets.scss` is the last remaining external UI-component SASS module in the `client` application: this converts over to preferred tailwind inline utility class usage
* Encapsulating this design within a component and removal of last layer of abstraction allows for cleaner separation of styling concerns. The previous CSS abstractions masked that the button styling was tackling some things — specifically positioning — that are more appropriately handled on the containing element/component
* Gives us an opportunity (as a sort of test case) to see what brief pattern-library documentation of patterns like this could look like. The associated pattern-library page attempts to explain in brief what a "bucket" is and what these buttons are intended for.
* Gives us an opportunity to place the design pattern in context with, e.g., other buttons and UI

On this branch, you can see the bucket buttons at http://localhost:4001/navigation-buckets