### PR TITLE
Adjust `size` styling and docs for `Button`, `IconButton`

### DIFF
--- a/src/components/input/Button.js
+++ b/src/components/input/Button.js
@@ -12,7 +12,7 @@ import ButtonBase from './ButtonBase';
  * @typedef {import('./ButtonBase').HTMLButtonAttributes} HTMLButtonAttributes
  *
  * @typedef ButtonProps
- * @prop {'sm'|'md'|'lg'} [size='md'] - Adjusts padding on button
+ * @prop {'xs'|'sm'|'md'|'lg'} [size='md'] - Adjusts padding on button
  * @prop {'primary'|'secondary'} [variant='secondary']
  * @prop {IconComponent} [icon] - Optional icon to display at left
  *   of button label text. Will be sized proportional to local font size.
@@ -54,8 +54,9 @@ const ButtonNext = function Button({
         {
           // Sizes
           'p-2 gap-x-2': size === 'md', // default
-          'px-1.5 py-1 gap-x-1.5': size === 'sm',
-          'px-3 py-2.5 gap-x-2.5': size === 'lg',
+          'p-1 gap-x-1': size === 'xs',
+          'p-1.5 gap-x-1.5': size === 'sm',
+          'p-2.5 gap-x-1.5': size === 'lg',
         },
         classes
       )}

--- a/src/components/input/IconButton.js
+++ b/src/components/input/IconButton.js
@@ -15,7 +15,7 @@ import ButtonBase from './ButtonBase';
  * @typedef IconButtonProps
  * @prop {IconComponent} [icon] - reference to an icon function component
  *   to render in this button, e.g. CautionIcon
- * @prop {'sm'|'md'|'lg'} [size='md']
+ * @prop {'xs'|'sm'|'md'|'lg'} [size='md']
  * @prop {boolean} [disableTouchSizing=false] - Disable minimum tap target
  *   sizing for touch devices. This may be necessary in legacy patterns where
  *   there isn't enough room in the interface for these larger dimensions.
@@ -61,8 +61,9 @@ const IconButtonNext = function IconButton({
 
           // size
           'p-2': size === 'md', // Default
+          'p-1': size === 'xs',
           'p-1.5': size === 'sm',
-          'p-3': size === 'lg',
+          'p-2.5': size === 'lg',
 
           // Responsive
           'touch:min-w-touch-minimum touch:min-h-touch-minimum':

--- a/src/pattern-library/components/patterns/input/ButtonPage.js
+++ b/src/pattern-library/components/patterns/input/ButtonPage.js
@@ -251,6 +251,17 @@ export default function ButtonPage() {
                 ➜ <code>{"'xs'"}</code>, <code>{"'sm'"}</code>,{' '}
                 <code>{"'md'"}</code>, <code>{"'lg'"}</code>
               </Next.ChangelogItem>
+              <Next.ChangelogItem status="breaking">
+                Prop: <code>size</code> value{' '}
+                <s>
+                  <code>{"'small'"}</code>
+                </s>{' '}
+                ➜ use <code>{"'xs'"}</code> instead: the padding/spacing values
+                have been adjusted such that all Button components are
+                harmonized. <code>{"IconButton's"}</code>{' '}
+                <code>{"'small'"}</code> size was inconsistent with the{' '}
+                <code>{"'sm'"}</code> size for other Buttons.
+              </Next.ChangelogItem>
             </Next.Changelog>
           </Library.Example>
         </Library.Pattern>

--- a/src/pattern-library/components/patterns/input/ButtonPage.js
+++ b/src/pattern-library/components/patterns/input/ButtonPage.js
@@ -73,6 +73,22 @@ export default function ButtonPage() {
                 </s>{' '}
                 ➜ <code>{"'secondary'"}</code>
               </Next.ChangelogItem>
+              <Next.ChangelogItem status="breaking">
+                Prop: <code>size</code> values{' '}
+                <s>
+                  <code>{"'small'"}</code>
+                </s>
+                ,{' '}
+                <s>
+                  <code>{"'medium'"}</code>
+                </s>{' '}
+                ,
+                <s>
+                  <code>{"'large'"}</code>
+                </s>{' '}
+                ➜ <code>{"'xs'"}</code>, <code>{"'sm'"}</code>,{' '}
+                <code>{"'md'"}</code>, <code>{"'lg'"}</code>
+              </Next.ChangelogItem>
             </Next.Changelog>
           </Library.Example>
         </Library.Pattern>
@@ -150,13 +166,16 @@ export default function ButtonPage() {
               </Button>
             </Library.Demo>
           </Library.Example>
-          <Library.Example title="size">
+          <Library.Example title="size: 'xs', 'sm', 'md' (default), 'lg'">
             <p>
               The <code>size</code> prop affects padding and spacing within the{' '}
               <code>Button</code>, but other sizing (e.g. font size) is
               inherited.
             </p>
             <Library.Demo withSource>
+              <Button icon={EditIcon} size="xs">
+                X-Small (xs)
+              </Button>
               <Button icon={EditIcon} size="sm">
                 Small (sm)
               </Button>
@@ -215,6 +234,22 @@ export default function ButtonPage() {
                   <code>{"'normal'"}</code>
                 </s>{' '}
                 ➜ <code>{"'secondary'"}</code>
+              </Next.ChangelogItem>
+              <Next.ChangelogItem status="breaking">
+                Prop: <code>size</code> values{' '}
+                <s>
+                  <code>{"'small'"}</code>
+                </s>
+                ,{' '}
+                <s>
+                  <code>{"'medium'"}</code>
+                </s>{' '}
+                ,
+                <s>
+                  <code>{"'large'"}</code>
+                </s>{' '}
+                ➜ <code>{"'xs'"}</code>, <code>{"'sm'"}</code>,{' '}
+                <code>{"'md'"}</code>, <code>{"'lg'"}</code>
               </Next.ChangelogItem>
             </Next.Changelog>
           </Library.Example>
@@ -359,7 +394,8 @@ export default function ButtonPage() {
               The <code>size</code> prop affects padding and spacing within the{' '}
               <code>IconButton</code>.
             </p>
-            <Library.Demo title="size: 'sm', 'md' and 'lg'" withSource>
+            <Library.Demo title="size: 'xs', 'sm', 'md' and 'lg'" withSource>
+              <IconButton icon={EditIcon} size="xs" title="Edit" />
               <IconButton icon={EditIcon} size="sm" title="Edit" />
               <IconButton icon={EditIcon} size="md" title="Edit" />
               <IconButton icon={EditIcon} size="lg" title="Edit" />


### PR DESCRIPTION
* Adjust utility classes applied for different `size`s of `Button` and `IconButton` to match existing use cases, and to be internally consistent. These changes reflect reality that I encountered when updating all shared components in the `client` application.
* Expand documentation about sizes in pattern library

Fixes #674
Fixes #649