### PR TITLE
Don't use styles from `ButtonBase` in other Button components

### DIFF
--- a/src/components/input/Button.js
+++ b/src/components/input/Button.js
@@ -42,7 +42,7 @@ const ButtonNext = function Button({
     <ButtonBase
       {...htmlAttributes}
       classes={classnames(
-        // NB: Base classes are applied by ButtonBase
+        'focus-visible-ring transition-colors whitespace-nowrap flex items-center',
         'font-semibold rounded-sm',
         {
           // Variants
@@ -64,6 +64,7 @@ const ButtonNext = function Button({
       pressed={pressed}
       title={title}
       data-component="Button"
+      unstyled
     >
       {Icon && <Icon className="w-em h-em" />}
       {children}

--- a/src/components/input/IconButton.js
+++ b/src/components/input/IconButton.js
@@ -48,7 +48,7 @@ const IconButtonNext = function IconButton({
     <ButtonBase
       {...htmlAttributes}
       classes={classnames(
-        // NB: Base classes are applied by ButtonBase
+        'focus-visible-ring transition-colors whitespace-nowrap flex items-center',
         'justify-center gap-x-2 rounded-sm',
         {
           // variant
@@ -77,6 +77,7 @@ const IconButtonNext = function IconButton({
       pressed={pressed}
       expanded={expanded}
       data-component="IconButton"
+      unstyled
     >
       {Icon && <Icon className="w-em h-em" />}
       {children}

--- a/src/components/navigation/LinkButton.js
+++ b/src/components/navigation/LinkButton.js
@@ -38,7 +38,7 @@ const LinkButtonNext = function LinkButton({
       {...htmlAttributes}
       elementRef={downcastRef(elementRef)}
       classes={classnames(
-        // NB: Base classes are applied by ButtonBase
+        'focus-visible-ring transition-colors whitespace-nowrap',
         'aria-pressed:font-semibold aria-expanded:font-semibold rounded-sm',
         {
           // inline
@@ -66,6 +66,7 @@ const LinkButtonNext = function LinkButton({
         classes
       )}
       data-component="LinkButton"
+      unstyled
     >
       {children}
     </ButtonBase>


### PR DESCRIPTION
The abstraction of "base button classes" to `ButtonBase` led to a bug, #650, where `LinkButton` attempts to apply both `inline` and `flex` layout to a `button` when the `inline` prop is set. Remove this abstraction so that devs can see the entire styling context and avoid similar bugs in future.

This is less DRY but more safe and clear.

Fixes #650

Before fix:

<img width="817" alt="image" src="https://user-images.githubusercontent.com/439947/195916968-86c73a89-321d-4c92-85e9-54191205c793.png">


After fix:

<img width="862" alt="Screen Shot 2022-10-14 at 2 30 13 PM" src="https://user-images.githubusercontent.com/439947/195916918-1739d49f-6f91-4612-9131-c9c3f44d99ec.png">

