### PR TITLE
Adjust typing on some `Ref` and `RefObject` properties

### DIFF
--- a/src/hooks/use-arrow-key-navigation.js
+++ b/src/hooks/use-arrow-key-navigation.js
@@ -46,7 +46,7 @@ function isElementVisible(element) {
  * [1] https://www.w3.org/TR/wai-aria-practices/#kbd_roving_tabindex
  * [2] https://www.w3.org/TR/wai-aria-practices/#keyboard
  *
- * @param {import('preact').RefObject<HTMLElement>} containerRef
+ * @param {import('preact').RefObject<HTMLElement | undefined>} containerRef
  * @param {object} options
  *   @param {boolean} [options.autofocus] - Whether to focus the first element
  *     in the set of matching elements when the component is mounted

--- a/src/hooks/use-element-should-close.js
+++ b/src/hooks/use-element-should-close.js
@@ -37,7 +37,7 @@ function listen(element, events, listener, { useCapture = false } = {}) {
  * that should close it - such as clicks outside the element or Esc key presses.
  * When such an interaction happens, the `handleClose` callback is invoked.
  *
- * @param {Ref<HTMLElement>} closeableEl - Outer DOM element for the popup
+ * @param {Ref<HTMLElement | undefined>} closeableEl - Outer DOM element for the popup
  * @param {boolean} isOpen - Whether the popup is currently visible/open
  * @param {() => void} handleClose - Callback invoked to close the popup
  */

--- a/src/types.js
+++ b/src/types.js
@@ -7,7 +7,7 @@
  *   component's default classes
  * @prop {never} [className] - Use variants, props, base component (when
  *   available) or `classes` instead
- * @prop {import('preact').Ref<HTMLElement>} [elementRef] - Ref for component's
+ * @prop {import('preact').Ref<HTMLElement | undefined>} [elementRef] - Ref for component's
  *   outermost element.
  */
 


### PR DESCRIPTION
This allows better compatibility with refs generated by `useRef()` in applications.