### PR TITLE
Update release process and docs to work with GH rebase-and-merge method

### DIFF
--- a/docs/releases.md
+++ b/docs/releases.md
@@ -1,34 +1,37 @@
-# Release process
+# How to version and publish `frontend-shared`
 
-## 1. Version and tag locally
+## Summary
 
-We use [Semantic Versioning](https://semver.org/#semantic-versioning-200).
+1. **Update the package version** in `package.json` and merge that change into the `main` branch. We use [Semantic Versioning](https://semver.org/#semantic-versioning-200).
+2. **Create a tag** pointing at the version-change commit and generate a **new GitHub release**. Publishing a GitHub release will kick off a GitHub Action that will **publish the `@hypothesis/frontend-shared` package to `npm`.**
 
-1. Create a new working branch
-2. Run
+## 1. Update the package version
+
+1. Create a new git branch.
+2. On the new branch, run:
 
    ```shell
-   $ yarn version
+   $ yarn version --no-git-tag-version
    ```
 
-   This will update the `package.json` version, create a commit and add
-   an annotated version tag.
+   This will update the `package.json` version and create a commit on your new branch.
 
-3. Push your tag and branch: `git push origin <tag> <branch>`
+3. Push the branch, then open and merge a version-bump PR.[^1]
 
-## 2. Merge and release on GitHub
+## 2. Tag, release and publish
 
-1. Go through the PR/merge cycle for the version-update branch
-2. Create a [new GitHub release](https://github.com/hypothesis/frontend-shared/releases/new/)
+Create a [new GitHub release](https://github.com/hypothesis/frontend-shared/releases/new/) with these values:
 
-   - Title: use the tag name
-   - Click the `Auto-generate release notes` button to generate release notes.
-     Release notes are _required_. We use [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) formatting. Be sure to highlight any breaking changes.
-   - Binary: nope
+1.  _Tag_: Create a new tag for the release, targeting the `main` branch (your just-merged version bump should be at the tip)[^2]. The tag should match the version number, e.g. `v5.2.1`.
+2.  _Title_: Use the tag name.
+3.  Click the `Auto-generate release notes` button to generate release notes and edit as needed. We use [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) formatting.[^2]
+4.  Leave other fields alone/as defaults.
 
-Publishing this will kick off a GitHub Action that will publish the package.
-
-## 3. Check your work
+## 3. Verify the release
 
 - Check to see if the version has been updated on [npm](https://www.npmjs.com/package/@hypothesis/frontend-shared)
-- Check the contents of the package on UNPKG. The URL pattern is `https://unpkg.com/browse/@hypothesis/frontend-shared@<version>/`, e.g. https://unpkg.com/browse/@hypothesis/frontend-shared@1.11.0/
+- Check the contents of the package on UNPKG. The URL pattern is `https://unpkg.com/browse/@hypothesis/frontend-shared@<version>/`, e.g. https://unpkg.com/browse/@hypothesis/frontend-shared@5.2.0/
+
+[^1]: Unlike other PRs, a version-bump PR does not require review. But do wait for CI to complete first.
+[^2]: You can create a tag manually as a separate step if you want to tag a non-tip commit.
+[^3]: You can look at release notes for [other recent releases](https://github.com/hypothesis/frontend-shared/releases) as exemplars. You don't need to include every change (especially, e.g., dependency updates).


### PR DESCRIPTION
If we want to use `rebase-and-merge` as our GitHub merge method, we need to adjust our release process to ensure that the version tag points at the intended commit. Rebase-and-merge rewrites commit hashes, so tags should not be created until after the target commit is present on the `main` branch.