### PR TITLE
Fix alignment of CardHeader close button; convert to TS

### DIFF
--- a/src/components/layout/CardHeader.js
+++ b/src/components/layout/CardHeader.js
@@ -45,7 +45,15 @@ const CardHeaderNext = function CardHeader({
       {title && <CardTitle>{title}</CardTitle>}
       {children}
       {onClose && (
-        <IconButton onClick={onClose} title="Close">
+        <IconButton
+          onClick={onClose}
+          title="Close"
+          classes={classnames(
+            // Pull button right such that its icon right-aligns with the
+            // header's bottom border
+            '-mr-3'
+          )}
+        >
           <CancelIcon />
         </IconButton>
       )}

--- a/src/components/layout/CardHeader.tsx
+++ b/src/components/layout/CardHeader.tsx
@@ -1,5 +1,7 @@
 import classnames from 'classnames';
+import type { JSX } from 'preact';
 
+import type { PresentationalProps } from '../../types';
 import { downcastRef } from '../../util/typing';
 
 import { CancelIcon } from '../icons';
@@ -7,20 +9,24 @@ import { IconButton } from '../input';
 
 import CardTitle from './CardTitle';
 
-/**
- * @typedef {import('../../types').PresentationalProps} CommonProps
- * @typedef {import('preact').JSX.HTMLAttributes<HTMLElement>} HTMLAttributes
- *
- * @typedef CardHeaderProps
- * @prop {string} [title]
- * @prop {() => void} [onClose] - Optional callback to close the Card. When
- *   present, a close button will be rendered
- */
+type ComponentProps = {
+  title?: string;
+
+  /**
+   * Optional callback for close-button click. When present, a close button
+   * will be rendered.
+   */
+  onClose?: () => void;
+};
+
+type HTMLAttributes = JSX.HTMLAttributes<HTMLElement>;
+
+export type CardHeaderProps = PresentationalProps &
+  ComponentProps &
+  HTMLAttributes;
 
 /**
  * Render a header area in a Card with optional title and/or close button
- *
- * @param {CommonProps & CardHeaderProps & HTMLAttributes} props
  */
 const CardHeaderNext = function CardHeader({
   children,
@@ -31,7 +37,7 @@ const CardHeaderNext = function CardHeader({
   title,
 
   ...htmlAttributes
-}) {
+}: CardHeaderProps) {
   return (
     <div
       {...htmlAttributes}


### PR DESCRIPTION
Use a negative right margin make the close button (when present) in CardHeader appear right-aligned with the bottom border. Without this, the padding in the button causes it to look like the button has too much space on the right.

Landing this will allow us to move forward with updating `client` components that use the `Panel` shared component.

Opportunistically also converted `CardHeader` to TS.

Fixes #677

## Testing

Check out this branch, run `make dev` and visit http://localhost:4001/layout-card to see the `CardHeader` examples. Note the difference in alignment of the close button between this branch and `main`. You can also see the difference on the [`Panel` pattern library page](http://localhost:4001/layout-panel) page (`Panel` uses `CardHeader`).