### PR TITLE
Reduce right margin a little for close button in CardHeader

### DIFF
--- a/src/components/layout/CardHeader.tsx
+++ b/src/components/layout/CardHeader.tsx
@@ -57,7 +57,7 @@ const CardHeaderNext = function CardHeader({
           classes={classnames(
             // Pull button right such that its icon right-aligns with the
             // header's bottom border
-            '-mr-3'
+            '-mr-2.5'
           )}
         >
           <CancelIcon />


### PR DESCRIPTION
Follow on from #787

That nearly made the CardHeader's close button perfect, but not quite. In situ in the client it felt a little too far to the right. (Net change: 2px. Yep, we're getting fine-tuned here).

Before this change:

<img width="424" alt="image" src="https://user-images.githubusercontent.com/439947/212172236-006f78d0-9fa0-4dc4-9dbc-160ebcd70be8.png">


And after:

<img width="421" alt="image" src="https://user-images.githubusercontent.com/439947/212172866-b7119ba3-9403-4cb7-84ac-739bc5465c4d.png">

