### PR TITLE
Remove detailed instructions for updating version in release docs

### DIFF
--- a/docs/releases.md
+++ b/docs/releases.md
@@ -2,32 +2,19 @@
 
 ## Summary
 
-1. **Update the package version** in `package.json` and merge that change into the `main` branch. We use [Semantic Versioning](https://semver.org/#semantic-versioning-200).
-2. **Create a tag** pointing at the version-change commit and generate a **new GitHub release**. Publishing a GitHub release will kick off a GitHub Action that will **publish the `@hypothesis/frontend-shared` package to `npm`.**
+1. **Update the package version** in `package.json` and merge that change into the `main` branch[^1]. We use [Semantic Versioning](https://semver.org/#semantic-versioning-200).
+2. **Create a tag** pointing at the version-change commit and generate a **new GitHub release** (details follow). Publishing a GitHub release will kick off a GitHub Action that will **publish the `@hypothesis/frontend-shared` package to `npm`.**
 
-## 1. Update the package version
-
-1. Create a new git branch.
-2. On the new branch, run:
-
-   ```shell
-   $ yarn version --no-git-tag-version
-   ```
-
-   This will update the `package.json` version and create a commit on your new branch.
-
-3. Push the branch, then open and merge a version-bump PR.[^1]
-
-## 2. Tag, release and publish
+## Creating a GitHub release
 
 Create a [new GitHub release](https://github.com/hypothesis/frontend-shared/releases/new/) with these values:
 
 1.  _Tag_: Create a new tag for the release, targeting the `main` branch (your just-merged version bump should be at the tip)[^2]. The tag should match the version number, e.g. `v5.2.1`.
 2.  _Title_: Use the tag name.
-3.  Click the `Auto-generate release notes` button to generate release notes and edit as needed. We use [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) formatting.[^2]
+3.  Click the `Auto-generate release notes` button to generate release notes and edit as needed. We use [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) formatting.[^3]
 4.  Leave other fields alone/as defaults.
 
-## 3. Verify the release
+## Verify the release
 
 - Check to see if the version has been updated on [npm](https://www.npmjs.com/package/@hypothesis/frontend-shared)
 - Check the contents of the package on UNPKG. The URL pattern is `https://unpkg.com/browse/@hypothesis/frontend-shared@<version>/`, e.g. https://unpkg.com/browse/@hypothesis/frontend-shared@5.2.0/


### PR DESCRIPTION
Simplify release documentation even further by removing references to `yarn version` as all it did was edit the `package.json` version field, which is easily done by hand.