### PR TITLE
Add PointerButton component and documentation

### DIFF
--- a/src/components/navigation/PointerButton.tsx
+++ b/src/components/navigation/PointerButton.tsx
@@ -1,0 +1,135 @@
+import classnames from 'classnames';
+
+import type { PresentationalProps } from '../../types';
+import { downcastRef } from '../../util/typing';
+
+import ButtonBase from '../input/ButtonBase';
+import type {
+  ButtonCommonProps,
+  HTMLButtonAttributes,
+} from '../input/ButtonBase';
+
+type ComponentProps = {
+  /**
+   * Direction the button should point. If not provided, the button will be
+   * lozenge-shaped.
+   */
+  direction?: 'left' | 'up' | 'down';
+};
+
+export type PointerButtonProps = PresentationalProps &
+  ButtonCommonProps &
+  ComponentProps &
+  HTMLButtonAttributes;
+
+/**
+ * A button for pointing toward a quantified set of items somewhere else in the
+ * UI or off-screen. When clicked, the application should navigate to the
+ * indicated or implied position.
+ *
+ * Used by the bucket bar in the client application to point at
+ * highlights/annotations in the guest document. Expected button content is
+ * numeric text, e.g.:
+ *
+ *   <PointerButton direction="left">5</PointerButton>
+ *
+ * The arrow-points are created by the combination of borders and positioning.
+ * See https://css-tricks.com/snippets/css/css-triangle/
+ */
+const PointerButtonNext = function PointerButton({
+  children,
+  classes,
+  elementRef,
+
+  expanded,
+  pressed,
+  title,
+
+  direction,
+
+  ...htmlAttributes
+}: PointerButtonProps) {
+  return (
+    <ButtonBase
+      {...htmlAttributes}
+      elementRef={downcastRef(elementRef)}
+      classes={classnames(
+        // Establish relative positioning to allow absolute positioning of
+        // ::before and ::after pseudo-elements (the arrow pointers)
+        'relative w-[26px] h-[16px]',
+        'flex items-center justify-center',
+        'bg-white rounded-[4px] border',
+        // The borders of ::before and ::after will be used to style the arrow
+        // pointer border (grey) and fill (white) respectively
+        'before:absolute before:border-transparent',
+        'after:absolute after:border-transparent',
+        'text-[10px] text-color-text-light leading-none font-semibold',
+        {
+          // This adds a 1-pixel x-offset to the default `shadow` (see tailwind
+          // config)
+          'shadow-[1px_1px_1px_rgba(0,0,0,0.1)]': direction !== 'down',
+          // The down arrow has no y-offset on its shadow to avoid odd edges
+          // around its down-pointing wedge
+          'shadow-[1px_0px_1px_rgba(0,0,0,0.1)]': direction === 'down',
+        },
+
+        // Styling for left-pointing arrows
+        {
+          'rounded-r-[4px] rounded-l-[2px]': direction === 'left',
+          // Position the right edges of ::before and ::after to align with the
+          // left edge of the button's body, centered vertically
+          'before:right-full before:top-1/2 after:right-full after:top-1/2':
+            direction === 'left',
+          // ::before is the grey border of the left-pointing wedge, 1px wider
+          // than the fill
+          'before:mt-[-8px] before:border-8 before:border-r-[5px] before:border-r-grey-3':
+            direction === 'left',
+          // ::after is the white fill of the left-pointing wedge. NB: ordering
+          // of these rules after the ::before rules is important for
+          // compositing order
+          'after:mt-[-7px] after:border-[7px] after:border-r-[4px] after:border-r-white':
+            direction === 'left',
+        },
+
+        // Styling for up-pointing arrows
+        {
+          'z-1 rounded-t-px-sm rounded-b-px': direction === 'up',
+          // Position the bottom edges of ::before and ::after to align with the
+          // top edges of the button body. Center horizontally.
+          'before:top-auto before:left-1/2 before:bottom-full after:top-auto after:left-1/2 after:bottom-full':
+            direction === 'up',
+          // Grey border of up-pointing wedge
+          'before:ml-[-13px] before:border-[13px] before:border-b-[6px] before:border-b-grey-3':
+            direction === 'up',
+          // White fill of up-pointing wedge
+          'after:ml-[-12px] after:border-[12px] after:border-b-[5px] after:border-b-white':
+            direction === 'up',
+        },
+
+        // Styling for down-pointing arrows
+        {
+          'z-1 rounded-t-px rounded-b-px-sm': direction === 'down',
+          // Position the top edges of ::before and ::after at the bottom of
+          // the button body. Center horizontally.
+          'before:top-full before:left-1/2 after:top-full after:left-1/2':
+            direction === 'down',
+          // Grey border of down-pointing wedge
+          'before:ml-[-13px] before:border-[13px] before:border-t-[6px] before:border-t-grey-3':
+            direction === 'down',
+          // White fill of down-pointing wedge
+          'after:ml-[-12px] after:border-[12px] after:border-t-[5px] after:border-t-white':
+            direction === 'down',
+        },
+        classes
+      )}
+      data-component="PointerButton"
+      expanded={expanded}
+      pressed={pressed}
+      title={title}
+    >
+      {children}
+    </ButtonBase>
+  );
+};
+
+export default PointerButtonNext;

--- a/src/components/navigation/index.js
+++ b/src/components/navigation/index.js
@@ -1,3 +1,4 @@
+export { default as PointerButton } from './PointerButton';
 export { default as Link } from './Link';
 export { default as LinkBase } from './LinkBase';
 export { default as LinkButton } from './LinkButton';

--- a/src/components/navigation/test/PointerButton-test.js
+++ b/src/components/navigation/test/PointerButton-test.js
@@ -1,0 +1,7 @@
+import { testPresentationalComponent } from '../../test/common-tests';
+
+import PointerButton from '../PointerButton';
+
+describe('PointerButton', () => {
+  testPresentationalComponent(PointerButton);
+});

--- a/src/next.js
+++ b/src/next.js
@@ -36,4 +36,9 @@ export {
   Overlay,
   Panel,
 } from './components/layout';
-export { Link, LinkBase, LinkButton } from './components/navigation/';
+export {
+  PointerButton,
+  Link,
+  LinkBase,
+  LinkButton,
+} from './components/navigation/';

--- a/src/pattern-library/components/patterns/navigation/PointerButtonPage.js
+++ b/src/pattern-library/components/patterns/navigation/PointerButtonPage.js
@@ -1,0 +1,141 @@
+import { PointerButton } from '../../../../next';
+import Library from '../../Library';
+import Next from '../../LibraryNext';
+
+export default function PointerButtonPage() {
+  return (
+    <Library.Page
+      title="PointerButton"
+      intro={
+        <>
+          <p>
+            <code>PointerButton</code> is a component for styling a button that
+            points towards a group of items elsewhere in the UI or off-screen.
+            They are specifically used to indicate and navigate to
+            &quot;buckets&quot; (groups of annotations that are near each other
+            in document content) in the Hypothesis client.
+          </p>
+          <p>
+            PointerButtons point at and navigate to these groups of annotation
+            highlights, which are either in the visible content of the source
+            document (guest page) or off-screen (above or below).
+          </p>
+        </>
+      }
+    >
+      <Library.Section
+        title="PointerButton"
+        intro={
+          <p>
+            <code>PointerButton</code> is a presentational component.
+          </p>
+        }
+      >
+        <Library.Pattern title="Status">
+          <p>
+            <code>PointerButton</code> is a new component.
+          </p>
+        </Library.Pattern>
+
+        <Library.Pattern title="Usage">
+          <Next.Usage componentName="PointerButton" />
+          <Library.Example>
+            <Library.Demo
+              title="PointerButton directions 'up', 'down', 'left'"
+              withSource
+            >
+              <PointerButton direction="up">3</PointerButton>
+              <PointerButton direction="down">7</PointerButton>
+              <PointerButton direction="left">5</PointerButton>
+            </Library.Demo>
+
+            <p>
+              The following example shows <code>PointerButtons</code> as they
+              might appear in the client, positioned absolutely in a{' '}
+              {'"bucket bar"'}.
+            </p>
+
+            <Library.Demo title="PointerButtons in visual context" withSource>
+              <div className="w-[23px] h-[250px] bg-grey-2">
+                <ul className="relative h-full pointer-events-none">
+                  <li
+                    className="absolute right-0 pointer-events-auto mt-[-11px]"
+                    style={{ top: '15px' }}
+                  >
+                    <PointerButton direction="up">6</PointerButton>
+                  </li>
+
+                  <li
+                    className="absolute right-0 pointer-events-auto mt-[-8px]"
+                    style={{ top: '47px' }}
+                  >
+                    <PointerButton direction="left">10</PointerButton>
+                  </li>
+
+                  <li
+                    className="absolute right-0 pointer-events-auto mt-[-8px]"
+                    style={{ top: '112px' }}
+                  >
+                    <PointerButton direction="left">1</PointerButton>
+                  </li>
+
+                  <li
+                    className="absolute right-0 pointer-events-auto"
+                    style={{ top: '230px' }}
+                  >
+                    <PointerButton direction="down">4</PointerButton>
+                  </li>
+                </ul>
+              </div>
+            </Library.Demo>
+          </Library.Example>
+        </Library.Pattern>
+
+        <Library.Pattern title="Props">
+          <p>
+            <code>PointerButton</code> also takes common{' '}
+            <a href="./input-button">
+              <code>ButtonBase</code>
+            </a>{' '}
+            props.
+          </p>
+          <Library.Example title="direction">
+            <p>
+              The <code>direction</code> prop is not required. When not
+              provided, the button will not point in any direction but instead
+              will be lozenge-shaped. This pattern is not used anywhere
+              currently.
+            </p>
+            <Library.Demo title="direction not set" withSource>
+              <PointerButton>24</PointerButton>
+            </Library.Demo>
+
+            <p>
+              The <code>left</code> direction is intended to point to and
+              navigate to a bucket of annotations currently visible on-screen.
+            </p>
+            <Library.Demo title="direction: left" withSource>
+              <PointerButton direction="left">3</PointerButton>
+            </Library.Demo>
+
+            <p>
+              The <code>up</code> direction is intended to point to and navigate
+              to the next bucket offscreen (above).
+            </p>
+            <Library.Demo title="direction: up" withSource>
+              <PointerButton direction="up">4</PointerButton>
+            </Library.Demo>
+
+            <p>
+              The <code>down</code> direction is intended to point to and
+              navigate to the next bucket offscreen (below).
+            </p>
+            <Library.Demo title="direction: down" withSource>
+              <PointerButton direction="down">6</PointerButton>
+            </Library.Demo>
+          </Library.Example>
+        </Library.Pattern>
+      </Library.Section>
+    </Library.Page>
+  );
+}

--- a/src/pattern-library/routes.js
+++ b/src/pattern-library/routes.js
@@ -24,6 +24,7 @@ import CardPage from './components/patterns/layout/CardPage';
 import PanelPage from './components/patterns/layout/PanelPage';
 import OverlayPage from './components/patterns/layout/OverlayPage';
 
+import PointerButtonPage from './components/patterns/navigation/PointerButtonPage';
 import LinkPage from './components/patterns/navigation/LinkPage';
 import LinkButtonPage from './components/patterns/navigation/LinkButtonPage';
 
@@ -189,6 +190,12 @@ const routes = [
     group: 'navigation',
     component: LinkButtonPage,
     route: '/navigation-linkbutton',
+  },
+  {
+    title: 'PointerButton',
+    group: 'navigation',
+    component: PointerButtonPage,
+    route: '/navigation-pointerbutton',
   },
   {
     route: '/components-buttons',

--- a/styles/library.scss
+++ b/styles/library.scss
@@ -5,6 +5,10 @@
 @layer components {
   // Support some basic text styling in Library components
   .styled-text {
+    :where(a):not(:where([class~='unstyled-text'] *)) {
+      @apply text-brand underline hover:text-brand-dark transition-colors;
+    }
+
     :where(code):not(:where([class~='unstyled-text'] *)) {
       @apply p-1 bg-slate-0 rounded-sm mx-0.5;
       font-size: 0.85em;


### PR DESCRIPTION
This PR adds a new component to the "navigation" group: `PointerButton`. This component is intended to "point at" and navigate to groups of items elsewhere or off-screen in the UI. For more context, run `make dev` on this branch and visit http://localhost:4001/navigation-pointerbutton

The bulk of this work was completed a couple of months ago but I'd like to rehydrate it to help us complete out the transition of `client` components to updated shared components.

<img width="1219" alt="image" src="https://user-images.githubusercontent.com/439947/213774606-3971632d-5445-4ee3-98ff-5221829c116c.png">

This component encapsulates part of the current [Buckets](https://github.com/hypothesis/client/blob/33ca18cb831ab854a64fe20b0f85097780a1c3cd/src/annotator/components/Buckets.js) component in the `client`. Whereas the `Buckets` component currently conflates button styling and positioning, and applies this via a convoluted use of the deprecated `LabeledButton` component, this new component encapsulates just the button pattern — leaving positioning up to the consumer — and fits the pattern in with the context of other application design patterns.

There's no evading that the CSS for this component is complex. It predates my tenure (I'm merely carrying it forward and trying to clean it up as best I can), and I haven't yet seen a simpler drop-in approach.

In a nutshell, this CSS pattern styles borders on absolutely-positioned `::before` and `::after` pseudo-elements to form the "points" on the button's arrows. https://css-tricks.com/snippets/css/css-triangle/ is cited in the component's commenting. Our particular use case is complicated because we have a "fill" color that is different than the button's border, and the button has more content and shape than just a triangle. I don't expect the reviewer to granularly understand every CSS rule here, but instead to verify that the linked example and comments in the component provide enough guideposts for a future dev.


