### PR TITLE
Update to v3 of codecov/codecov-action

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Test
       run: yarn test
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v3
       with:
-        directory: ./coverage/
+        files: ./coverage/coverage-final.json
 


### PR DESCRIPTION
This goes in pair with https://github.com/hypothesis/client/pull/5191, so I'm just updating to the latest version of `codecov/codecov-action` and making the config consistent with what we have there.