### PR TITLE
Deprecate FullScreenSpinner

### DIFF
--- a/src/components/Spinner.js
+++ b/src/components/Spinner.js
@@ -40,6 +40,7 @@ export function Spinner({ classes = '', size = 'medium' }) {
 /**
  * Full-screen loading indicator.
  *
+ * @deprecated - Use `SpinnerOverlay` in the feedback group
  * @param {FullScreenSpinnerProps} props
  */
 export function FullScreenSpinner({ classes = '', containerClasses = '' }) {

--- a/src/pattern-library/components/patterns/SpinnerComponents.js
+++ b/src/pattern-library/components/patterns/SpinnerComponents.js
@@ -74,6 +74,20 @@ export default function SpinnerComponents() {
       </Library.Pattern>
 
       <Library.Pattern title="Full-Screen Spinner">
+        <Library.Example title="Status">
+          <Next.Changelog>
+            <Next.ChangelogItem status="deprecated">
+              This legacy implementation of
+              <s>
+                <code>FullScreenSpinner</code>
+              </s>{' '}
+              is deprecated and slated for removal in v6 of{' '}
+              <code>frontend-shared</code>. Use re-implemented
+              <code>SpinnerOverlay</code> component in the feedback group
+              instead.
+            </Next.ChangelogItem>
+          </Next.Changelog>
+        </Library.Example>
         <Library.Example>
           <p>
             A component that renders a full-screen spinner over an overlay.


### PR DESCRIPTION
Housekeeping PR: I neglected to deprecate `FullScreenSpinner` when earlier deprecating `Spinner`.