### PR TITLE
Improve `PlaygroundRoute`, add flexibility for custom routes

### DIFF
--- a/src/pattern-library/components/PlaygroundApp.js
+++ b/src/pattern-library/components/PlaygroundApp.js
@@ -8,6 +8,7 @@ import { useRoute } from '../router';
 
 /**
  * @typedef {import("../routes").PlaygroundRoute} PlaygroundRoute
+ * @typedef {import("../routes").CustomPlaygroundRoute} CustomPlaygroundRoute
  * @typedef {import("../routes").PlaygroundRouteGroup} PlaygroundRouteGroup
  * @typedef {import('preact').ComponentChildren} Children
  */
@@ -15,8 +16,11 @@ import { useRoute } from '../router';
 /**
  * @typedef PlaygroundAppProps
  * @prop {string} [baseURL]
- * @prop {PlaygroundRoute[]} [extraRoutes] - Local-/application-specific routes
- *   to add to this pattern library in addition to the shared/common routes
+ * @prop {CustomPlaygroundRoute[]} [extraRoutes] -
+ *   Local-/application-specific routes to add to this pattern library in
+ *   addition to the shared/common routes
+ * @prop {string} extraRoutesTitle - Title to show above any extra routes
+ * provided
  */
 
 /**
@@ -29,9 +33,15 @@ import { useRoute } from '../router';
 export default function PlaygroundApp({
   baseURL = '/ui-playground',
   extraRoutes = [],
+  extraRoutesTitle,
 }) {
   const routes = getRoutes();
-  const allRoutes = routes.concat(extraRoutes);
+
+  // Put all of the custom routes into the "custom" group
+  const customRoutes = extraRoutes.map(route => {
+    return /** @type PlaygroundRoute */ ({ ...route, group: 'custom' });
+  });
+  const allRoutes = routes.concat(customRoutes);
   const [activeRoute] = useRoute(baseURL, allRoutes);
   const content =
     activeRoute && activeRoute.component ? (
@@ -152,15 +162,15 @@ export default function PlaygroundApp({
               );
             })}
 
-            <NavHeader>Legacy Components</NavHeader>
-            <NavList routes={getRoutes('components')} />
-
             {extraRoutes.length > 0 && (
               <>
-                <NavHeader>Application</NavHeader>
-                <NavList routes={extraRoutes} />
+                <NavHeader>{extraRoutesTitle}</NavHeader>
+                <NavList routes={customRoutes} />
               </>
             )}
+
+            <NavHeader>Legacy Components</NavHeader>
+            <NavList routes={getRoutes('components')} />
           </nav>
         </div>
         <div className="bg-white pb-16">{content}</div>

--- a/src/pattern-library/index.js
+++ b/src/pattern-library/index.js
@@ -9,17 +9,21 @@ import iconSet from './icons';
 import PlaygroundApp from './components/PlaygroundApp';
 
 /**
- * @typedef {import("./components/PlaygroundApp").PlaygroundRoute} PlaygroundRoute
+ * @typedef {import("./components/PlaygroundApp").CustomPlaygroundRoute} CustomPlaygroundRoute
  */
 
 /**
  * @typedef PatternLibraryAppOptions
  * @prop {string} [baseURL] - The path relative to web root where the pattern
  *   library is served. Defaults to `/ui-playground`.
- * @prop {PlaygroundRoute[]} [extraRoutes] - Local-/application-specific routes
- *   to add to this pattern library in addition to the shared/common routes
- * @prop {Record<string, string>} [icons] - Icons, additional to default pattern-library icons,
- *   to register for use in patterns/components in the pattern library
+ * @prop {CustomPlaygroundRoute[]} [extraRoutes] -
+ *   Local-/application-specific routes to add to this pattern library in
+ *   addition to the shared/common routes
+ * @prop {string} [extraRoutesTitle] - Optional title to use as a header above
+ *   any custom routes shown in the navigation menu
+ * @prop {Record<string, string>} [icons] - Icons, additional to default
+ *   pattern-library icons, to register for use in patterns/components in the
+ *   pattern library
  */
 
 /**
@@ -27,12 +31,21 @@ import PlaygroundApp from './components/PlaygroundApp';
  *
  * @param {PatternLibraryAppOptions} options
  */
-export function startApp({ baseURL = '', extraRoutes = [], icons = {} } = {}) {
+export function startApp({
+  baseURL = '',
+  extraRoutes = [],
+  extraRoutesTitle = 'Playground',
+  icons = {},
+} = {}) {
   const allIcons = { ...iconSet, ...icons };
   registerIcons(allIcons);
   const container = document.querySelector('#app');
   render(
-    <PlaygroundApp baseURL={baseURL} extraRoutes={extraRoutes} />,
+    <PlaygroundApp
+      baseURL={baseURL}
+      extraRoutes={extraRoutes}
+      extraRoutesTitle={extraRoutesTitle}
+    />,
     /** @type Element */ (container)
   );
 }

--- a/src/pattern-library/routes.js
+++ b/src/pattern-library/routes.js
@@ -50,7 +50,7 @@ export const componentGroups = {
 };
 
 /**
- * @typedef {keyof componentGroups|'home'|'foundations'|'components'} PlaygroundRouteGroup
+ * @typedef {keyof componentGroups|'home'|'foundations'|'components'|'custom'} PlaygroundRouteGroup
  *
  * @typedef PlaygroundRoute - Route "handler" that provides a component (function)
  *   that should be rendered for the indicated route
@@ -59,6 +59,8 @@ export const componentGroups = {
  * @prop {string} title
  * @prop {import("preact").FunctionComponent<{}>} [component]
  * @prop {PlaygroundRouteGroup} group
+ *
+ * @typedef {Omit<PlaygroundRoute, 'group'>} CustomPlaygroundRoute
  */
 
 /** @type {PlaygroundRoute[]} */


### PR DESCRIPTION
The pattern library is designed (at least semi-designed) to be used within consuming projects, and allows projects to add "extra routes" to the set of its own common routes, for prototyping or documenting UI patterns specific to the given project. (See LMS, which has a single custom route to demonstrate error dialogs). It's quite rudimentary.

This PR makes it just a bit easier to provide custom routes the pattern library ("PlaygroundApp") by removing the asinine requirement to provide a `group` for each custom route (i.e. create a custom route type that doesn't require that field). Also add the option to customize the navigation list heading for the group of provided custom routes.

This is a little bit hard to conceptualize in the abstract. If I update `scripts/pattern-library` in this package to set a custom route, like so:

```js
// Entry point for local webserver pattern-library bundle
import { startApp } from '../src/pattern-library';

import UserPreferencesPage from '../src/pattern-library/components/prototypes/UserPreferences';

const extraRoutes = [
  {
    title: 'User Preferences',
    component: UserPreferencesPage,
    route: '/prototype-preferences',
  },
];

startApp({ extraRoutes, extraRoutesTitle: 'Prototypes' });
```

The (partial) navigation will look like this:

<img width="441" alt="image" src="https://user-images.githubusercontent.com/439947/214946602-47577d1d-1d4f-49e9-8824-e9b1469c1aaa.png">

### Why now?

The screenshot might give it away, but I'd like to do some UI prototyping in the pattern library for a current project, and this makes it a little easier.