### PR TITLE
Fix default `baseURL` in pattern library

### DIFF
--- a/src/pattern-library/components/PlaygroundApp.tsx
+++ b/src/pattern-library/components/PlaygroundApp.tsx
@@ -16,7 +16,7 @@ import type { PlaygroundAppProps } from '../';
  * by the component handling the current route.
  */
 export default function PlaygroundApp({
-  baseURL = '/ui-playground',
+  baseURL = '',
   extraRoutes = [],
   extraRoutesTitle = 'Playground',
 }: PlaygroundAppProps) {


### PR DESCRIPTION
Previously, both the entry point and `PlaygroundApp` set defaults for the same prop, `baseURL`, and they were setting a different default. Now only `PlaygroundApp` sets this default, and it should be `''`, not `/ui-playground/`.

This fixes routing such that reloading works and the router-generated URL is correct (in this project's pattern library).

## Testing (not required, but this is a description)

* Check out `main` branch. Run `make dev`, then visit the pattern library at `localhost:4001`. Click on any nav item in the left channel. Now reload your browser window. You should see an error.
* Check out this branch and run through the same steps. Reloading (or otherwise visiting the URL in the browser's location bar) should work.