### PR TITLE
Add `Tab` and `TabList` components

### DIFF
--- a/src/components/navigation/Tab.tsx
+++ b/src/components/navigation/Tab.tsx
@@ -1,0 +1,88 @@
+import classnames from 'classnames';
+import type { JSX } from 'preact';
+
+import type { IconComponent, PresentationalProps } from '../../types';
+import { downcastRef } from '../../util/typing';
+
+import ButtonBase from '../input/ButtonBase';
+
+type ComponentProps = {
+  icon?: IconComponent;
+  /**
+   * Text string representing the content of the tab when selected. The tab
+   * button will be sized to accommodate this string in bold text. This can
+   * prevent tab jiggle.
+   */
+  textContent?: string;
+  selected?: boolean;
+  variant?: 'basic';
+};
+
+type HTMLAttributes = Omit<
+  JSX.HTMLAttributes<HTMLButtonElement>,
+  'size' | 'icon' | 'title'
+>;
+
+export type TabProps = PresentationalProps & ComponentProps & HTMLAttributes;
+
+/**
+ * Render a button with appropriate ARIA tab affordances
+ */
+const TabNext = function Tab({
+  children,
+  classes,
+  elementRef,
+
+  icon: Icon,
+  textContent,
+  selected = false,
+  variant = 'basic',
+
+  ...htmlAttributes
+}: TabProps) {
+  return (
+    <ButtonBase
+      {...htmlAttributes}
+      classes={classnames(
+        'gap-x-1.5 enabled:hover:text-brand-dark',
+        {
+          'font-bold': selected && variant === 'basic',
+        },
+        classes
+      )}
+      elementRef={downcastRef(elementRef)}
+      aria-selected={selected}
+      role="tab"
+      data-component="Tab"
+    >
+      {Icon && (
+        <Icon
+          className={classnames(
+            // A small padding value here sizes the icon down slightly in relation
+            // to the tab text, which results in nicer proportions.
+            'p-[0.125em] w-em h-em'
+          )}
+        />
+      )}
+      <span
+        data-content={textContent}
+        data-testid="sizing-wrapper"
+        className={classnames({
+          // Set the content of this span's ::before pseudo-element to
+          // `textContent` and make it bold.
+          'before:content-[attr(data-content)] before:font-bold': textContent,
+          // Make the ::before occupy space within the button, but make it
+          // invisible. This ensures that the tab button is wide enough to show
+          // bolded text even if the visible text is not currently bold. See
+          // https://css-tricks.com/bold-on-hover-without-the-layout-shift/
+          'before:block before:invisible before:h-0 before:overflow-hidden':
+            textContent,
+        })}
+      >
+        {children}
+      </span>
+    </ButtonBase>
+  );
+};
+
+export default TabNext;

--- a/src/components/navigation/TabList.tsx
+++ b/src/components/navigation/TabList.tsx
@@ -1,0 +1,58 @@
+import classnames from 'classnames';
+import type { JSX } from 'preact';
+
+import { useArrowKeyNavigation } from '../../hooks/use-arrow-key-navigation';
+import { useSyncedRef } from '../../hooks/use-synced-ref';
+import type { PresentationalProps } from '../../types';
+import { downcastRef } from '../../util/typing';
+
+type HTMLAttributes = Omit<JSX.HTMLAttributes<HTMLElement>, 'size'>;
+
+type ComponentProps = {
+  /**
+   * By default, TabLists are oriented horizontally. Vertically-oriented
+   * TabLists add up/down arrow-key navigation.
+   */
+  vertical?: boolean;
+};
+
+export type TabListProps = PresentationalProps &
+  ComponentProps &
+  HTMLAttributes;
+
+/**
+ * Render a tablist container for a set of tabs, with arrow key navigation per
+ * https://www.w3.org/WAI/ARIA/apg/patterns/tabpanel/
+ */
+const TabListNext = function TabList({
+  children,
+  classes,
+  elementRef,
+
+  vertical = false,
+
+  ...htmlAttributes
+}: TabListProps) {
+  const tabListRef = useSyncedRef(elementRef);
+
+  useArrowKeyNavigation(tabListRef, {
+    selector: 'button',
+    horizontal: true,
+    vertical,
+  });
+
+  return (
+    <div
+      {...htmlAttributes}
+      ref={downcastRef(tabListRef)}
+      className={classnames('flex', { 'flex-col': vertical }, classes)}
+      role="tablist"
+      aria-orientation={vertical ? 'vertical' : 'horizontal'}
+      data-component="TabList"
+    >
+      {children}
+    </div>
+  );
+};
+
+export default TabListNext;

--- a/src/components/navigation/index.js
+++ b/src/components/navigation/index.js
@@ -2,3 +2,5 @@ export { default as PointerButton } from './PointerButton';
 export { default as Link } from './Link';
 export { default as LinkBase } from './LinkBase';
 export { default as LinkButton } from './LinkButton';
+export { default as Tab } from './Tab';
+export { default as TabList } from './TabList';

--- a/src/components/navigation/test/Tab-test.js
+++ b/src/components/navigation/test/Tab-test.js
@@ -1,0 +1,52 @@
+import { mount } from 'enzyme';
+
+import { testPresentationalComponent } from '../../test/common-tests';
+
+import { ProfileIcon } from '../../icons';
+import Tab from '../Tab';
+
+const contentFn = (Component, props = {}) => {
+  return mount(
+    <div role="tablist">
+      <Component {...props}>This is child content</Component>
+    </div>
+  );
+};
+
+describe('Tab', () => {
+  testPresentationalComponent(Tab, {
+    createContent: contentFn,
+    elementSelector: 'button[data-component="Tab"]',
+  });
+
+  it('sets `aria-selected` when selected', () => {
+    const tab1 = contentFn(Tab, { selected: true });
+    const tab2 = contentFn(Tab, { selected: false });
+
+    assert.equal(
+      tab1.find('button').getDOMNode().getAttribute('aria-selected'),
+      'true'
+    );
+    assert.equal(
+      tab2.find('button').getDOMNode().getAttribute('aria-selected'),
+      'false'
+    );
+  });
+
+  it('sets content data attribute on sizing span when `textContent` provided', () => {
+    const wrapper = contentFn(Tab, { textContent: 'Tab Label' });
+    assert.equal(
+      wrapper
+        .find('[data-testid="sizing-wrapper"]')
+        .getDOMNode()
+        .getAttribute('data-content'),
+      'Tab Label'
+    );
+  });
+
+  it('renders an icon when provided', () => {
+    const wrapper = contentFn(Tab, { icon: ProfileIcon });
+
+    assert.isTrue(wrapper.find('ProfileIcon').exists());
+  });
+});

--- a/src/components/navigation/test/TabList-test.js
+++ b/src/components/navigation/test/TabList-test.js
@@ -1,0 +1,75 @@
+import { mount } from 'enzyme';
+
+import { testPresentationalComponent } from '../../test/common-tests';
+
+import TabList from '../TabList';
+import { $imports } from '../TabList';
+
+/**
+ * An element with `role="tablist"` needs at least one `role="tab"` child.
+ * Accessibility tests will fail without it.
+ */
+const contentFn = (Component, props = {}) => {
+  return mount(
+    <Component {...props}>
+      <button role="tab">Tab 1</button>
+    </Component>
+  );
+};
+
+describe('TabList', () => {
+  testPresentationalComponent(TabList, { createContent: contentFn });
+
+  describe('TabList orientation and keyboard navigation', () => {
+    let fakeUseArrowKeyNavigation;
+
+    beforeEach(() => {
+      fakeUseArrowKeyNavigation = sinon.stub();
+      $imports.$mock({
+        '../../hooks/use-arrow-key-navigation': {
+          useArrowKeyNavigation: fakeUseArrowKeyNavigation,
+        },
+      });
+    });
+
+    afterEach(() => {
+      $imports.$restore();
+    });
+
+    it('sets `aria-orientation` to `horizontal` or `vertical` based on `vertical` prop', () => {
+      const horizontalTabList = contentFn(TabList, {});
+      const verticalTabList = contentFn(TabList, { vertical: true });
+
+      assert.equal(
+        horizontalTabList
+          .find('[data-component="TabList"]')
+          .getDOMNode()
+          .getAttribute('aria-orientation'),
+        'horizontal'
+      );
+      assert.equal(
+        verticalTabList
+          .find('[data-component="TabList"]')
+          .getDOMNode()
+          .getAttribute('aria-orientation'),
+        'vertical'
+      );
+    });
+
+    it('applies horizontal (left/right) keyboard navigation when horizontal', () => {
+      contentFn(TabList, {});
+
+      const navOpts = fakeUseArrowKeyNavigation.getCall(0).args[1];
+
+      assert.include(navOpts, { horizontal: true, vertical: false });
+    });
+
+    it('applies horizontal and vertical (up/down) keyboard navigation when vertical', () => {
+      contentFn(TabList, { vertical: true });
+
+      const navOpts = fakeUseArrowKeyNavigation.getCall(0).args[1];
+
+      assert.include(navOpts, { horizontal: true, vertical: true });
+    });
+  });
+});

--- a/src/next.js
+++ b/src/next.js
@@ -41,4 +41,6 @@ export {
   Link,
   LinkBase,
   LinkButton,
+  Tab,
+  TabList,
 } from './components/navigation/';

--- a/src/pattern-library/components/patterns/navigation/TabPage.js
+++ b/src/pattern-library/components/patterns/navigation/TabPage.js
@@ -1,0 +1,390 @@
+import classnames from 'classnames';
+import { useState } from 'preact/hooks';
+
+import {
+  Card,
+  EmailIcon,
+  ProfileIcon,
+  SettingsIcon,
+  Tab,
+  TabList,
+} from '../../../../next';
+import Library from '../../Library';
+import Next from '../../LibraryNext';
+
+export default function TabPage() {
+  const [prefPanel, setPrefPanel] = useState('notifications');
+  const [sidebarPanel, setSidebarPanel] = useState('annotations');
+  const [sidebarPanel2, setSidebarPanel2] = useState('annotations');
+  const [sidebarPanel3, setSidebarPanel3] = useState('annotations');
+  const [verticalPanel, setVerticalPanel] = useState('notifications');
+  return (
+    <Library.Page
+      title="Tabs"
+      intro={
+        <p>
+          <code>Tab</code> and <code>TabList</code> are presentational
+          components for rendering accessible tabs.
+        </p>
+      }
+    >
+      <Library.Section
+        title="Tab"
+        intro={
+          <p>
+            <code>Tab</code> generates a button with appropriate ARIA
+            attributes.
+          </p>
+        }
+      >
+        <Library.Pattern title="Status">
+          <p>
+            <code>Tab</code> is a new component.
+          </p>
+        </Library.Pattern>
+
+        <Library.Pattern title="Usage">
+          <Next.Usage componentName="Tab" />
+          <Library.Example>
+            <Library.Demo title="Basic (non-interactive) example" withSource>
+              <div role="tablist" className="gap-x-6 flex">
+                <Tab>
+                  Annotations
+                  <span className="relative bottom-[3px] left-[2px] text-[10px]">
+                    {52}
+                  </span>
+                </Tab>
+                <Tab selected>
+                  Page Notes
+                  <span className="relative bottom-[3px] left-[2px] text-[10px]">
+                    {4}
+                  </span>
+                </Tab>
+                <Tab>
+                  Orphans
+                  <span className="relative bottom-[3px] left-[2px] text-[10px]">
+                    {2}
+                  </span>
+                </Tab>
+              </div>
+            </Library.Demo>
+          </Library.Example>
+
+          <ul>
+            <li>
+              <code>Tab</code>s <em>must</em> be direct children of an element
+              with <code>role={'"tablist"'}</code> (or use the{' '}
+              <code>TabList</code> component).
+            </li>
+            <li>
+              You <em>should</em> provide an{' '}
+              <a href="https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-controls">
+                <code>aria-controls</code>
+              </a>{' '}
+              attribute to each <code>Tab</code>. This is not always feasible in
+              our applications.
+            </li>
+          </ul>
+        </Library.Pattern>
+
+        <Library.Pattern title="Props">
+          <Library.Example title="aria-controls">
+            An element with <code>{'role="tab"'}</code> should set an{' '}
+            <code>aria-controls</code> attribute when possible. See the full{' '}
+            <code>TabList</code> example below.
+          </Library.Example>
+
+          <Library.Example title="icon">
+            <code>Tab</code>s may have icons. The icon will be displayed on the
+            left and sized proportionally to the inherited font size.
+            <Library.Demo title="Tabs with icon" withSource>
+              <div role="tablist">
+                <Tab icon={ProfileIcon}>Profile</Tab>
+                <Tab classes="text-lg" icon={ProfileIcon}>
+                  Profile
+                </Tab>
+                <Tab classes="text-xl" icon={ProfileIcon}>
+                  Profile
+                </Tab>
+              </div>
+            </Library.Demo>
+          </Library.Example>
+
+          <Library.Example title="selected">
+            This boolean property asserts that the <code>Tab</code> is currently
+            selected and the <code>tabpanel</code> it controls (where relevant)
+            is active and visible.
+          </Library.Example>
+
+          <Library.Example title="textContent">
+            <p>
+              Bolding is used in our design patterns to indicate a selected tab.
+              Without any intervention, textual tabs will jiggle around when
+              they are selected. This has a simple cause: bold text takes up
+              more room.
+            </p>
+            <p>
+              <code>textContent</code> is a string representing the text content
+              of the tab when selected.{' '}
+              <strong>
+                Setting <code>textContent</code> can help prevent jiggle in
+                selected tabs
+              </strong>
+              . The size of the tab will accommodate this string rendered in
+              bold text.
+            </p>
+            <Library.Demo
+              title="Tabs without textContent (jiggle when selected)"
+              withSource
+            >
+              <TabList classes="gap-x-6">
+                <Tab
+                  selected={sidebarPanel === 'annotations'}
+                  onClick={() => setSidebarPanel('annotations')}
+                >
+                  Annotations
+                  <span className="relative bottom-[3px] left-[2px] text-[10px]">
+                    {52}
+                  </span>
+                </Tab>
+                <Tab
+                  selected={sidebarPanel === 'pageNotes'}
+                  onClick={() => setSidebarPanel('pageNotes')}
+                >
+                  Page Notes
+                  <span className="relative bottom-[3px] left-[2px] text-[10px]">
+                    {48}
+                  </span>
+                </Tab>
+                <Tab
+                  selected={sidebarPanel === 'orphans'}
+                  onClick={() => setSidebarPanel('orphans')}
+                >
+                  Orphans
+                  <span className="relative bottom-[3px] left-[2px] text-[10px]">
+                    {4}
+                  </span>
+                </Tab>
+              </TabList>
+            </Library.Demo>
+            <p>
+              For tabs that have a simple text label, setting{' '}
+              <code>textContent</code> to that string avoids the jiggle. Text
+              will still change size (bold text is larger) but the tabs
+              themselves do not move.
+            </p>
+            <Library.Demo title="Tabs with textContent (no jiggle)" withSource>
+              <TabList classes="gap-x-6">
+                <Tab
+                  selected={sidebarPanel2 === 'annotations'}
+                  onClick={() => setSidebarPanel2('annotations')}
+                  textContent="Annotations"
+                >
+                  Annotations
+                </Tab>
+                <Tab
+                  selected={sidebarPanel2 === 'pageNotes'}
+                  onClick={() => setSidebarPanel2('pageNotes')}
+                  textContent="Page Notes"
+                >
+                  Page Notes
+                </Tab>
+                <Tab
+                  selected={sidebarPanel2 === 'orphans'}
+                  onClick={() => setSidebarPanel2('orphans')}
+                  textContent="Orphans"
+                >
+                  Orphans
+                </Tab>
+              </TabList>
+            </Library.Demo>
+            <p>
+              For tabs with styled or dynamic content, <code>textContent</code>{' '}
+              can be set to an estimated {'"widest-possible-text-content"'}{' '}
+              value. A trial and error approach worked here:
+            </p>
+            <Library.Demo
+              title="Tabs with estimated widest-value textContent"
+              withSource
+            >
+              <TabList classes="gap-x-6">
+                <Tab
+                  selected={sidebarPanel3 === 'annotations'}
+                  onClick={() => setSidebarPanel3('annotations')}
+                  textContent="Annotations##"
+                >
+                  Annotations
+                  <span className="relative bottom-[3px] left-[2px] text-[10px]">
+                    {52}
+                  </span>
+                </Tab>
+                <Tab
+                  selected={sidebarPanel3 === 'pageNotes'}
+                  onClick={() => setSidebarPanel3('pageNotes')}
+                  textContent="Page Notes##"
+                >
+                  Page Notes
+                  <span className="relative bottom-[3px] left-[2px] text-[10px]">
+                    {56}
+                  </span>
+                </Tab>
+                <Tab
+                  selected={sidebarPanel3 === 'orphans'}
+                  onClick={() => setSidebarPanel3('orphans')}
+                  textContent="Orphans##"
+                >
+                  Orphans
+                  <span className="relative bottom-[3px] left-[2px] text-[10px]">
+                    {2}
+                  </span>
+                </Tab>
+              </TabList>
+            </Library.Demo>
+          </Library.Example>
+        </Library.Pattern>
+      </Library.Section>
+      <Library.Section
+        title="TabList"
+        intro={
+          <p>
+            <code>TabList</code> is a presentational component that provides a{' '}
+            <code>{'role="tablist"'}</code> container and arrow-key navigation
+            as outlined by{' '}
+            <a href="https://www.w3.org/WAI/ARIA/apg/patterns/tabpanel/">
+              WAI-ARIA authoring practices
+            </a>
+            .
+          </p>
+        }
+      >
+        <Library.Pattern title="Status">
+          <p>
+            <code>TabList</code> is a new component.
+          </p>
+        </Library.Pattern>
+        <Library.Pattern title="Usage">
+          <Next.Usage componentName="TabList" />
+          <Library.Example>
+            <p>
+              This example demonstrates a full Tab pattern with{' '}
+              <code>TabList</code>, <code>Tab</code> and some tabpanels. The
+              tabpanels have been made focusable here as they contain no
+              focusable elements: pressing <kbd>tab</kbd> when in the tablist
+              will move focus to the active tabpanel. Tabs may be navigated with
+              the left and right arrows.
+            </p>
+            <Library.Demo withSource title="Full Tab pattern example">
+              <div>
+                <TabList classes="w-[400px] gap-x-6 my-4">
+                  <Tab
+                    aria-controls="profile-panel"
+                    textContent="Profile"
+                    selected={prefPanel === 'profile'}
+                    onClick={() => setPrefPanel('profile')}
+                  >
+                    Profile
+                  </Tab>
+                  <Tab
+                    aria-controls="notifications-panel"
+                    textContent="Notifications"
+                    selected={prefPanel === 'notifications'}
+                    onClick={() => setPrefPanel('notifications')}
+                  >
+                    Notifications
+                  </Tab>
+                  <Tab
+                    aria-controls="account-panel"
+                    textContent="Account"
+                    selected={prefPanel === 'account'}
+                    onClick={() => setPrefPanel('account')}
+                  >
+                    Account
+                  </Tab>
+                </TabList>
+                <Card
+                  classes={classnames(
+                    { hidden: prefPanel !== 'profile' },
+                    'p-2 focus-visible-ring'
+                  )}
+                  id="profile-panel"
+                  role="tabpanel"
+                  tabIndex={0}
+                  variant="flat"
+                >
+                  Profile
+                </Card>
+                <Card
+                  classes={classnames(
+                    { hidden: prefPanel !== 'notifications' },
+                    'p-2 focus-visible-ring'
+                  )}
+                  id="notifications-panel"
+                  role="tabpanel"
+                  tabIndex={0}
+                  variant="flat"
+                >
+                  Notifications
+                </Card>
+                <Card
+                  classes={classnames(
+                    { hidden: prefPanel !== 'account' },
+                    'p-2 focus-visible-ring'
+                  )}
+                  id="account-panel"
+                  role="tabpanel"
+                  tabIndex={0}
+                  variant="flat"
+                >
+                  Account
+                </Card>
+              </div>
+            </Library.Demo>
+          </Library.Example>
+        </Library.Pattern>
+
+        <Library.Pattern title="Props">
+          <Library.Example title="vertical">
+            <p>
+              By default, <code>TabList</code> layout is horizontal. Set the
+              boolean <code>vertical</code> prop for a vertical layout. This
+              will also enable arrow-key navigation using the up and down
+              arrows.
+            </p>
+            <p>
+              The following example demonstrates vertical layout and up/down
+              keyboard navigation.
+            </p>
+            <Library.Demo withSource title="Vertical TabList">
+              <TabList classes="gap-y-2" vertical>
+                <Tab
+                  icon={ProfileIcon}
+                  onClick={() => setVerticalPanel('profile')}
+                  selected={verticalPanel === 'profile'}
+                  textContent="Profile"
+                >
+                  Profile
+                </Tab>
+                <Tab
+                  icon={EmailIcon}
+                  onClick={() => setVerticalPanel('notifications')}
+                  selected={verticalPanel === 'notifications'}
+                  textContent="Notifications"
+                >
+                  Notifications
+                </Tab>
+                <Tab
+                  icon={SettingsIcon}
+                  onClick={() => setVerticalPanel('account')}
+                  selected={verticalPanel === 'account'}
+                  textContent="Account"
+                >
+                  Account
+                </Tab>
+              </TabList>
+            </Library.Demo>
+          </Library.Example>
+        </Library.Pattern>
+      </Library.Section>
+    </Library.Page>
+  );
+}

--- a/src/pattern-library/routes.ts
+++ b/src/pattern-library/routes.ts
@@ -29,6 +29,7 @@ import OverlayPage from './components/patterns/layout/OverlayPage';
 import PointerButtonPage from './components/patterns/navigation/PointerButtonPage';
 import LinkPage from './components/patterns/navigation/LinkPage';
 import LinkButtonPage from './components/patterns/navigation/LinkButtonPage';
+import TabPage from './components/patterns/navigation/TabPage';
 
 // Legacy pattern-library pages
 
@@ -210,6 +211,12 @@ const routes: PlaygroundRoute[] = [
     group: 'navigation',
     component: PointerButtonPage,
     route: '/navigation-pointerbutton',
+  },
+  {
+    title: 'Tabs',
+    group: 'navigation',
+    component: TabPage,
+    route: '/navigation-tab',
   },
   {
     route: '/components-buttons',


### PR DESCRIPTION
This PR adds new `Tab` and `TabList` components, and pattern-library documentation for same.

Why now: I believe we may wish to use a tabbed interface in upcoming new UI in the client and before building out new tabs, I wanted to:

* Extract the design pattern: Styling is based on the sidebar tabs (`SelectionTabs`) in the client, and extraction helps to better encapsulate the design pattern vs. the `SelectionsTab`-specific logic.
* Ensure that we are ticking accessibility boxes. The new `TabList` adds arrow-key navigation per https://www.w3.org/WAI/ARIA/apg/patterns/tabpanel/
* Fix a longstanding layout complexity to do with tabs jiggling when selected because of bold text. We've put various workarounds in place in the client over the years to try to account for it, but the new `Tab` component takes aim at alleviating it systematically (see documentation on `textContent` for that component).

As always with these new-component PRs, the lion's share of the diff is the pattern-library documentation page component. The components themselves were refreshingly simple to put together: I was able to scaffold out and concentrate on the specific problems I wanted to solve (fixing the jiggle, applying keyboard navigation) and documentation. The toolbox is getting more robust and it's starting to pay dividends!

### Testing

Check out this branch, run `make dev` and visit [the Tabs page in the pattern library](http://localhost:4001/navigation-tab)

<img width="1225" alt="image" src="https://user-images.githubusercontent.com/439947/215201093-722c5b9b-203b-4e7f-9d48-f2879a9e4d5a.png">
