### PR TITLE
Ensure Checkbox has a visible ring on `focus-visible`

### DIFF
--- a/src/components/input/Checkbox.js
+++ b/src/components/input/Checkbox.js
@@ -63,6 +63,8 @@ const CheckboxNext = function Checkbox({
     }
   }
 
+  const Icon = isChecked ? CheckedIcon : UncheckedIcon;
+
   return (
     <label
       className={classnames('relative flex items-center gap-x-1.5', {
@@ -77,6 +79,9 @@ const CheckboxNext = function Checkbox({
         type="checkbox"
         ref={downcastRef(elementRef)}
         className={classnames(
+          // Set the special Tailwind peer class to allow sibling elements
+          // to style themselves based on the state of this element
+          'peer',
           // Position this atop the icon and size it to the same dimensions
           'absolute w-em h-em',
           // Make checkbox input visually hidden, but
@@ -91,11 +96,15 @@ const CheckboxNext = function Checkbox({
         id={id}
         onChange={handleChange}
       />
-      {isChecked ? (
-        <CheckedIcon className="w-em h-em" />
-      ) : (
-        <UncheckedIcon className="w-em h-em" />
-      )}
+      <Icon
+        className={classnames(
+          // Add an outline ring to the icon when the input is focus-visible.
+          // The ring needs to be applied here because the `input` has an
+          // effectively-0 opacity.
+          'peer-focus-visible:ring',
+          'w-em h-em'
+        )}
+      />
       {children}
     </label>
   );


### PR DESCRIPTION
There has been a little defect kicking around for...well, kind of forever. The `Checkbox` component lacked a visible focus ring when focused by keyboard navigation (`focus-visible`).

In laying out a potential new user-preferences UI, this accessibility shortcoming is feeling more glaring. The fix required me to do a little Tailwind-thinking but ended up being straightforward (i.e. can be done via CSS alone; I thought we might have to track/manage focus state for a while there...).

## Testing

On this branch, navigating with the keyboard through/around checkboxes on the [Checkboxes component page](http://localhost:4001/input-checkbox) in the pattern library will cause focus rings to show up:

<img width="137" alt="image" src="https://user-images.githubusercontent.com/439947/215568077-21b41586-8b00-438a-a234-7c016b930b23.png">

On `main`, `Checkbox`es do not have any focus rings.

Fixes #627