### PR TITLE
Convert Colors pattern-library page to TSX

### DIFF
--- a/src/pattern-library/components/patterns/ColorsPage.tsx
+++ b/src/pattern-library/components/patterns/ColorsPage.tsx
@@ -1,14 +1,12 @@
 import classnames from 'classnames';
 import Library from '../Library';
 
-/**
- * @typedef ColorSwatchProps
- * @prop {string} colorClass
- * @prop {string} colorName
- */
+type ColorSwatchProps = {
+  colorClass: string;
+  colorName: string;
+};
 
-/** @param {ColorSwatchProps} props */
-function ColorSwatch({ colorClass, colorName }) {
+function ColorSwatch({ colorClass, colorName }: ColorSwatchProps) {
   return (
     <div>
       <div className={classnames(colorClass, 'w-64 h-8 mr-4')} />


### PR DESCRIPTION
This basic little housekeeping PR was a quick proof that converting pattern-library pages to TSX was straightforward. It converts the "Colors" page in the pattern library to TSX.