### PR TITLE
Allow pattern-library wrapper components to masquerade as the component they wrap

### DIFF
--- a/src/pattern-library/util/jsx-to-string.js
+++ b/src/pattern-library/util/jsx-to-string.js
@@ -14,7 +14,9 @@ function escapeQuotes(str) {
 
 /** @param {any} type */
 function componentName(type) {
-  const name = typeof type === 'string' ? type : type.displayName ?? type.name;
+  let name = typeof type === 'string' ? type : type.displayName ?? type.name;
+
+  name = name.replace('Wrapper', '');
   // Handle (display)name conflicts if there are two components with the same
   // name. e.g. if there are two components named `Foo`, the second of those
   // encountered will have a name of `Foo$1`. Strip the `$1` in this case.
@@ -71,6 +73,11 @@ export function jsxToString(vnode) {
     // (eg. from an index or item ID) so it doesn't make sense to include it either.
     let propStr = Object.entries(vnode.props)
       .map(([name, value]) => {
+        // Allow certain pattern-library-defined props to be invisible in source
+        // view
+        if (name.includes('WrapperProp')) {
+          return '';
+        }
         if (name === 'children') {
           return '';
         }

--- a/src/pattern-library/util/jsx-to-string.tsx
+++ b/src/pattern-library/util/jsx-to-string.tsx
@@ -3,20 +3,26 @@ import hljsXMLLang from 'highlight.js/lib/languages/xml';
 import hljsJavascriptLang from 'highlight.js/lib/languages/javascript';
 import { Fragment } from 'preact';
 
+import type { ComponentChildren, VNode } from 'preact';
+
 /**
  * Escape `str` for use in a "-quoted string.
- *
- * @param {string} str
  */
-function escapeQuotes(str) {
+function escapeQuotes(str: string) {
   return str.replace(/"/g, '\\"');
 }
 
-/** @param {any} type */
-function componentName(type) {
+/**
+ * Format a component's name for display
+ */
+function componentName(type: any) {
   let name = typeof type === 'string' ? type : type.displayName ?? type.name;
 
-  name = name.replace('Wrapper', '');
+  // Remove the string "Wrapper" from component names. This allows the pattern
+  // library to create a convenience wrapper component around a given component
+  // being documented, and have it appear that the documented component is being
+  // used directly in rendered source content.
+  name = name.replace(/\BWrapper$/, '');
   // Handle (display)name conflicts if there are two components with the same
   // name. e.g. if there are two components named `Foo`, the second of those
   // encountered will have a name of `Foo$1`. Strip the `$1` in this case.
@@ -25,11 +31,8 @@ function componentName(type) {
 
 /**
  * Indent a multi-line string by `indent` spaces.
- *
- * @param {string} str
- * @param {number} indent
  */
-function indentLines(str, indent) {
+function indentLines(str: string, indent: number) {
   const indentStr = ' '.repeat(indent);
   const lines = str.split('\n');
   return lines.map(line => indentStr + line).join('\n');
@@ -37,11 +40,8 @@ function indentLines(str, indent) {
 
 /**
  * Test if an element looks like a JSX element.
- *
- * @param {any} value
- * @return {value is import('preact').VNode<any>}
  */
-function isJSXElement(value) {
+function isJSXElement(value: any): value is VNode<any> {
   const elementType = value?.type;
   return typeof elementType === 'string' || typeof elementType === 'function';
 }
@@ -54,11 +54,8 @@ function isJSXElement(value) {
  *
  * @example
  *   jsxToString(<Widget expanded={true} label="Thing"/>) // returns `<Widget expanded label="Thing"/>`
- *
- * @param {import('preact').ComponentChildren} vnode
- * @return {string}
  */
-export function jsxToString(vnode) {
+export function jsxToString(vnode: ComponentChildren): string {
   if (
     typeof vnode === 'string' ||
     typeof vnode === 'number' ||
@@ -73,8 +70,8 @@ export function jsxToString(vnode) {
     // (eg. from an index or item ID) so it doesn't make sense to include it either.
     let propStr = Object.entries(vnode.props)
       .map(([name, value]) => {
-        // Allow certain pattern-library-defined props to be invisible in source
-        // view
+        // Don't render props that are for internal pattern-library wrapper
+        // component use only
         if (name.includes('WrapperProp')) {
           return '';
         }
@@ -134,12 +131,8 @@ export function jsxToString(vnode) {
  *
  * For the syntax highlighting to be visible, a Highlight.js CSS stylesheet must be
  * loaded on the page.
- *
- * @param {import('preact').ComponentChildren} vnode - JSX expression to render.
- *   See {@link jsxToString}
- * @return {string}
  */
-export function jsxToHTML(vnode) {
+export function jsxToHTML(vnode: ComponentChildren): string {
   // JSX support in Highlight.js involves a combination of the JS and XML
   // languages, so we need to load both.
   if (!hljs.getLanguage('javascript')) {


### PR DESCRIPTION
In the pattern library, it's often convenient to encapsulate some state or other logic in a reusable local example component. These example components tend to directly wrap the component being documented.

This PR extends the `jsx-to-string` module to allow components following the naming pattern `<ComponentWrapper>` to masquerade `<Component>` . It also allows certain props to be hidden similarly.

_Note_: I'd like to concede that this module needs attention: we've been glomming onto it for a while. I converted it to TSX here, but it could use a refactor. I considered doing that as part of this work but there's a lot else going on so I'm going to hold.

### Explanation

This change is better explained with an example. In the forthcoming PR to add a new `Modal` component, the associated pattern library has a local wrapper that takes props like so, forwarding most on to the `Modal` component it wraps:

```tsx
type ModalWrapperProps = ModalProps & {
  /** Pattern-wrapping prop. Not visible in source view */
  nonCloseableWrapperProp?: boolean;
};

function ModalWrapper({
  buttons,
  nonCloseableWrapperProp,
  children,
  ...modalProps
}: ModalWrapperProps) {
  // Renders an example, forwarding various props on to `Modal`
}
```

Then, later...

```tsx
            <Library.Demo title="Non-closeable modal" withSource>
              <ModalWrapper
                title="Non-closeable modal"
                nonCloseableWrapperProp={true}
              >
                <p>
                  This is a non-closeable modal. There is no close button at the
                  top of the panel, and the modal cannot be dismissed by
                  pressing escape or clicking outside of it. However, an escape
                  hatch has been provided for you below (typically non-closeable
                  modals do not have any buttons).
                </p>
              </ModalWrapper>
            </Library.Demo>
```

When this demo is rendered and the source panel activated:

<img width="787" alt="image" src="https://user-images.githubusercontent.com/439947/216436215-89be6d8d-b41f-4aa6-bb20-1e090536e3e2.png">

This allows the pattern library to "fake" source:

* It appears that `Modal` was used directly, and
* The internal `nonCloseableWrapperProp` is hidden


