### PR TITLE
Add updated `Modal` component and documentation

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -16,6 +16,7 @@
     "@typescript-eslint/ban-ts-comment": "off",
     "@typescript-eslint/no-empty-function": "off",
     "@typescript-eslint/no-explicit-any": "off",
+    "@typescript-eslint/no-non-null-assertion": "off",
     "@typescript-eslint/no-this-alias": "off",
 
     // Enforce consistency in cases where TypeScript supports old and new

--- a/src/components/Dialog.js
+++ b/src/components/Dialog.js
@@ -65,6 +65,7 @@ function useUniqueId(prefix) {
  * Dialog container element, or `initialFocus` HTMLElement if provided.
  *
  * @param {DialogProps} props
+ * @deprecated
  */
 export function Dialog({
   buttons,

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -22,6 +22,7 @@ import { LabeledButton } from './buttons';
  * if user clicks/taps outside of it.
  *
  * @param {ModalProps} props
+ * @deprecated
  */
 export function Modal({ children, onCancel, ...restProps }) {
   const modalContainerRef = /** @type {{ current: HTMLDivElement }} */ (
@@ -61,6 +62,7 @@ export function Modal({ children, onCancel, ...restProps }) {
  * request a boolean yes/no confirmation from the user.
  *
  * @param {ConfirmModalProps} props
+ * @deprecated
  */
 export function ConfirmModal({
   message,

--- a/src/components/feedback/Modal.tsx
+++ b/src/components/feedback/Modal.tsx
@@ -22,10 +22,10 @@ type ComponentProps = {
   width?: 'sm' | 'md' | 'lg' | 'custom';
   /**
    * Element that should take focus when the Dialog is first rendered. When not
-   * provided, the dialog's outer element will take focus. Setting this prop to
-   * `null` will opt out of focus routing.
+   * provided ("auto"), the dialog's outer element will take focus. Setting this
+   * prop to "manual" will opt out of focus routing.
    */
-  initialFocus?: RefObject<HTMLElement | null> | null;
+  initialFocus?: RefObject<HTMLOrSVGElement | null> | 'auto' | 'manual';
 };
 
 export type ModalProps = PresentationalProps & ComponentProps & PanelProps;
@@ -41,7 +41,7 @@ const ModalNext = function Modal({
 
   classes,
   elementRef,
-  initialFocus,
+  initialFocus = 'auto',
 
   // Forwarded to Panel
   buttons,
@@ -58,18 +58,28 @@ const ModalNext = function Modal({
   const dialogDescriptionId = useUniqueId('dialog-description');
 
   useEffect(() => {
-    // Route focus unless `initialFocus` is set to `null`
-    if (initialFocus !== null) {
-      const focusEl = initialFocus?.current as HTMLInputElement;
-      if (focusEl && !focusEl.disabled) {
-        focusEl.focus();
-      } else {
-        // The `initialFocus` prop has not been set, so use automatic focus
-        // handling. Modern accessibility guidance is to focus the dialog itself
-        // rather than trying to be smart about focusing a particular control
-        // within the dialog.
-        modalRef.current?.focus();
-      }
+    if (initialFocus === 'manual') {
+      return;
+    }
+    if (initialFocus === 'auto') {
+      // An explicit `initialFocus` has not be set, so use automatic focus
+      // handling. Modern accessibility guidance is to focus the dialog itself
+      // rather than trying to be smart about focusing a particular control
+      // within the dialog.
+      modalRef.current?.focus();
+      return;
+    }
+
+    const focusEl = initialFocus?.current as HTMLElement & {
+      disabled?: boolean;
+    };
+
+    if (focusEl && !focusEl.disabled) {
+      focusEl.focus();
+    } else {
+      // Fall back to focusing the modal itself
+      modalRef.current?.focus();
+      return;
     }
 
     // We only want to run this effect once when the dialog is mounted.

--- a/src/components/feedback/Modal.tsx
+++ b/src/components/feedback/Modal.tsx
@@ -1,0 +1,136 @@
+import classnames from 'classnames';
+import type { RefObject } from 'preact';
+import { useEffect, useLayoutEffect } from 'preact/hooks';
+
+import { useElementShouldClose } from '../../hooks/use-element-should-close';
+import { useSyncedRef } from '../../hooks/use-synced-ref';
+import { useUniqueId } from '../../hooks/use-unique-id';
+
+import type { PresentationalProps } from '../../types';
+import { downcastRef } from '../../util/typing';
+
+import Overlay from '../layout/Overlay';
+import Panel from '../layout/Panel';
+import type { PanelProps } from '../layout/Panel';
+
+type ComponentProps = {
+  /**
+   * Modal _should_ be provided with a close handler. We have a few edge use
+   * cases, however, in which we need to render a "non-closeable" modal.
+   */
+  onClose?: () => void;
+  width?: 'sm' | 'md' | 'lg' | 'custom';
+  /**
+   * Element that should take focus when the Dialog is first rendered. When not
+   * provided, the dialog's outer element will take focus. Setting this prop to
+   * `null` will opt out of focus routing.
+   */
+  initialFocus?: RefObject<HTMLElement | null> | null;
+};
+
+export type ModalProps = PresentationalProps & ComponentProps & PanelProps;
+
+const noop = () => {};
+
+/**
+ * Show a modal
+ */
+const ModalNext = function Modal({
+  children,
+  width = 'md',
+
+  classes,
+  elementRef,
+  initialFocus,
+
+  // Forwarded to Panel
+  buttons,
+  icon,
+  onClose,
+  title,
+
+  ...htmlAttributes
+}: ModalProps) {
+  const modalRef = useSyncedRef(elementRef);
+  const closeHandler = onClose ?? noop;
+  useElementShouldClose(modalRef, true, closeHandler);
+
+  const dialogDescriptionId = useUniqueId('dialog-description');
+
+  useEffect(() => {
+    // Route focus unless `initialFocus` is set to `null`
+    if (initialFocus !== null) {
+      const focusEl = initialFocus?.current as HTMLInputElement;
+      if (focusEl && !focusEl.disabled) {
+        focusEl.focus();
+      } else {
+        // The `initialFocus` prop has not been set, so use automatic focus
+        // handling. Modern accessibility guidance is to focus the dialog itself
+        // rather than trying to be smart about focusing a particular control
+        // within the dialog.
+        modalRef.current?.focus();
+      }
+    }
+
+    // We only want to run this effect once when the dialog is mounted.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useLayoutEffect(
+    /**
+     * Try to assign the dialog an accessible description, using the content of
+     * the first paragraph of text within it.
+     *
+     * A limitation of this approach is that it doesn't update if the dialog's
+     * content changes after the initial render.
+     */
+    () => {
+      const description = modalRef?.current?.querySelector('p');
+      if (description) {
+        description.id = dialogDescriptionId;
+        modalRef.current!.setAttribute('aria-describedby', dialogDescriptionId);
+      }
+    },
+    [dialogDescriptionId, modalRef]
+  );
+
+  return (
+    <Overlay>
+      <div
+        tabIndex={-1}
+        // NB: Role can be overridden with an HTML attribute; this is purposeful
+        role="dialog"
+        {...htmlAttributes}
+        className={classnames(
+          // Maximum width and height should not exceed 90vw/h
+          'max-w-[90vw] max-h-[90vh]',
+          // Overlay sets up a flex layout centered on both axes. For taller
+          // viewports, remove this modal container from the flex flow with
+          // fixed positioning and position it 10vh from the top of the
+          // viewport. This feels more balanced on taller screens. Ensure an
+          // equal 10vh gap at the bottom of the screen by adjusting max-height
+          // to `80vh`.
+          'tall:fixed tall:max-h-[80vh] tall:top-[10vh]',
+          // Column-flex layout to constrain content to max-height
+          'flex flex-col',
+          {
+            // Max-width rules will ensure actual width never exceeds 90vw
+            'w-[30rem]': width === 'sm',
+            'w-[36rem]': width === 'md', // default
+            'w-[42rem]': width === 'lg',
+            // No width classes are added if width is 'custom'
+          },
+          classes
+        )}
+        data-component="Modal"
+        ref={downcastRef(modalRef)}
+      >
+        <Panel buttons={buttons} icon={icon} onClose={onClose} title={title}>
+          {children}
+        </Panel>
+      </div>
+    </Overlay>
+  );
+};
+
+export default ModalNext;

--- a/src/components/feedback/index.js
+++ b/src/components/feedback/index.js
@@ -1,2 +1,3 @@
+export { default as Modal } from './Modal';
 export { default as Spinner } from './Spinner';
 export { default as SpinnerOverlay } from './SpinnerOverlay';

--- a/src/components/feedback/test/Modal-test.js
+++ b/src/components/feedback/test/Modal-test.js
@@ -58,10 +58,10 @@ describe('Modal', () => {
       );
     });
 
-    it('does not set focus if `initialFocus` is set to `null`', () => {
+    it('does not set focus if `initialFocus` is set to "manual"', () => {
       const focusedBefore = document.activeElement;
       mount(
-        <Modal initialFocus={null} title="My modal">
+        <Modal initialFocus={'manual'} title="My modal">
           <div>Test</div>
         </Modal>,
         { attachTo: container }

--- a/src/components/feedback/test/Modal-test.js
+++ b/src/components/feedback/test/Modal-test.js
@@ -1,0 +1,136 @@
+import { mount } from 'enzyme';
+import { createRef } from 'preact';
+
+import { testPresentationalComponent } from '../../test/common-tests';
+
+import Modal from '../Modal';
+
+const createComponent = (Component, props = {}) => {
+  return mount(
+    <Component title="Test title" onClose={() => {}} {...props}>
+      This is child content
+    </Component>
+  );
+};
+
+describe('Modal', () => {
+  testPresentationalComponent(Modal, {
+    createContent: createComponent,
+    elementSelector: 'div[data-component="Modal"]',
+  });
+
+  describe('initial focus', () => {
+    let container;
+
+    beforeEach(() => {
+      container = document.createElement('div');
+      document.body.appendChild(container);
+    });
+
+    afterEach(() => {
+      container.remove();
+    });
+
+    it('focuses the element referred to by `initialFocus`', () => {
+      const inputRef = createRef();
+
+      mount(
+        <Modal initialFocus={inputRef} title="My modal">
+          <input ref={inputRef} />
+        </Modal>,
+        { attachTo: container }
+      );
+
+      assert.equal(document.activeElement, inputRef.current);
+    });
+
+    it('focuses the modal itself if `initialFocus` prop is missing', () => {
+      const wrapper = mount(
+        <Modal title="My modal">
+          <div>Test</div>
+        </Modal>,
+        { attachTo: container }
+      );
+
+      assert.equal(
+        document.activeElement,
+        wrapper.find('[role="dialog"]').getDOMNode()
+      );
+    });
+
+    it('does not set focus if `initialFocus` is set to `null`', () => {
+      const focusedBefore = document.activeElement;
+      mount(
+        <Modal initialFocus={null} title="My modal">
+          <div>Test</div>
+        </Modal>,
+        { attachTo: container }
+      );
+
+      assert.equal(document.activeElement, focusedBefore);
+    });
+
+    it('focuses the modal if `initialFocus` element is disabled', () => {
+      const inputRef = createRef();
+
+      const wrapper = mount(
+        <Modal initialFocus={inputRef} title="My modal">
+          <button ref={inputRef} disabled={true} />
+        </Modal>,
+        { attachTo: container }
+      );
+
+      assert.equal(
+        document.activeElement,
+        wrapper.find('[role="dialog"]').getDOMNode()
+      );
+    });
+  });
+
+  describe('closing the modal', () => {
+    it('closes when `ESC` pressed', () => {
+      const onClose = sinon.stub();
+      const container = document.createElement('div');
+      document.body.appendChild(container);
+      mount(
+        <Modal title="Test modal" onClose={onClose}>
+          This is my modal
+        </Modal>,
+        {
+          attachTo: container,
+        }
+      );
+
+      const event = new Event('keydown');
+      event.key = 'Escape';
+      document.body.dispatchEvent(event);
+      assert.called(onClose);
+      container.remove();
+    });
+  });
+
+  describe('aria-describedby', () => {
+    it("marks the first `<p>` in the modal's content as the accessible description", () => {
+      const wrapper = mount(
+        <Modal title="My modal">
+          <p>Enter a URL</p>
+        </Modal>
+      );
+      const content = wrapper.find('[role="dialog"]').getDOMNode();
+      const paragraphEl = wrapper.find('p').getDOMNode();
+
+      assert.ok(content.getAttribute('aria-describedby'));
+      assert.equal(content.getAttribute('aria-describedby'), paragraphEl.id);
+    });
+
+    it("does not set an accessible description if the modal's content does not have a `<p>`", () => {
+      const wrapper = mount(
+        <Modal title="My modal">
+          <button>Click me</button>
+        </Modal>
+      );
+      const content = wrapper.find('[role="dialog"]').getDOMNode();
+      assert.isNull(content.getAttribute('aria-describedby'));
+    });
+  });
+});

--- a/src/next.js
+++ b/src/next.js
@@ -18,7 +18,7 @@ export {
   TableRow,
   Thumbnail,
 } from './components/data';
-export { Spinner, SpinnerOverlay } from './components/feedback';
+export { Modal, Spinner, SpinnerOverlay } from './components/feedback';
 export {
   Button,
   ButtonBase,

--- a/src/pattern-library/components/patterns/DialogComponents.js
+++ b/src/pattern-library/components/patterns/DialogComponents.js
@@ -3,6 +3,7 @@ import { useState } from 'preact/hooks';
 
 import { Scrollbox } from '../../..';
 import Library from '../Library';
+import Next from '../LibraryNext';
 
 import {
   ConfirmModal,
@@ -225,6 +226,30 @@ function ConfirmModalExample() {
 export default function DialogComponents() {
   return (
     <Library.Page title="Dialogs">
+      <Library.Pattern title="Status">
+        <Next.Changelog>
+          <Next.ChangelogItem status="deprecated">
+            The legacy implementation of
+            <s>
+              <code>Modal</code>
+            </s>{' '}
+            is deprecated and slated for removal in v6 of{' '}
+            <code>frontend-shared</code>. Use re-implemented
+            <code>Modal</code> component in the feedback group instead.
+          </Next.ChangelogItem>
+          <Next.ChangelogItem status="deprecated">
+            The legacy implementation of
+            <s>
+              <code>Dialog</code>
+            </s>{' '}
+            is deprecated and slated for removal in v6 of{' '}
+            <code>frontend-shared</code>. Use re-implemented
+            <code>Modal</code> component in the feedback group instead: it
+            combines the functionality of <code>Dialog</code> and{' '}
+            <code>Modal</code>.
+          </Next.ChangelogItem>
+        </Next.Changelog>
+      </Library.Pattern>
       <Library.Pattern title="Dialog">
         <p>
           A <code>Dialog</code> prompts for user interaction and will take focus

--- a/src/pattern-library/components/patterns/feedback/ModalPage.tsx
+++ b/src/pattern-library/components/patterns/feedback/ModalPage.tsx
@@ -1,0 +1,388 @@
+import { useState, useRef } from 'preact/hooks';
+
+import {
+  ArrowRightIcon,
+  Button,
+  EditIcon,
+  IconButton,
+  Input,
+  InputGroup,
+  Modal,
+} from '../../../../next';
+import type { ModalProps } from '../../../../components/feedback/Modal';
+import Library from '../../Library';
+import Next from '../../LibraryNext';
+
+import { LoremIpsum } from '../samples';
+
+function ModalButtons() {
+  return (
+    <>
+      <Button key="maybe" onClick={() => alert('You chose maybe')}>
+        Maybe
+      </Button>
+      <Button
+        key="yep"
+        onClick={() => alert('You chose yep')}
+        variant="primary"
+      >
+        Do it!
+      </Button>
+    </>
+  );
+}
+
+type ModalWrapperProps = ModalProps & {
+  /** Pattern-wrapping prop. Not visible in source view */
+  nonCloseableWrapperProp?: boolean;
+};
+
+/**
+ * Wrap the Modal component with some state management to make reuse in
+ * multiple examples plausible and convenient.
+ */
+function ModalWrapper({
+  buttons,
+  nonCloseableWrapperProp,
+  children,
+  ...modalProps
+}: ModalWrapperProps) {
+  const [modalOpen, setModalOpen] = useState(false);
+  const closeModal = () => setModalOpen(false);
+
+  const closeHandler = nonCloseableWrapperProp ? undefined : closeModal;
+  const forwardedButtons = buttons ? (
+    buttons
+  ) : (
+    <Button onClick={closeModal}>Escape!</Button>
+  );
+
+  if (!modalOpen) {
+    return (
+      <Button onClick={() => setModalOpen(!modalOpen)} variant="primary">
+        Show modal
+      </Button>
+    );
+  } else {
+    return (
+      <Modal buttons={forwardedButtons} {...modalProps} onClose={closeHandler}>
+        {children}
+      </Modal>
+    );
+  }
+}
+
+export default function ModalPage() {
+  const inputRef = useRef(null);
+  return (
+    <Library.Page
+      title="Modal"
+      intro={
+        <p>
+          <code>Modal</code> is a presentational component for rendering modal
+          dialogs. It currently renders modal content inside of a{' '}
+          <code>Panel</code>.
+        </p>
+      }
+    >
+      <Library.Section title="Modal">
+        <Library.Pattern title="Status">
+          <p>
+            <code>Modal</code> is a presentational component that combines
+            aspects of legacy <code>Modal</code> and <code>Dialog</code>{' '}
+            components.
+          </p>
+          <p>
+            This is an interim implementation of a modal dialog that conforms to
+            updated styling and API conventions. It does not yet fully implement
+            an accessible dialog. It routes focus, but does not trap or restore
+            focus, e.g.
+          </p>
+          <p>
+            This implementation should, however, provide a more flexible and
+            simplified API compared to its legacy counterpart.
+          </p>
+          <Library.Example title="Migrating to this component">
+            <Next.Changelog>
+              <Next.ChangelogItem status="breaking">
+                Prop removed:{' '}
+                <s>
+                  <code>contentClass</code>
+                </s>{' '}
+                ➜ use <code>classes</code> instead to style the outer container.
+              </Next.ChangelogItem>
+              <Next.ChangelogItem status="breaking">
+                Prop removed:{' '}
+                <s>
+                  <code>cancelLabel</code>
+                </s>{' '}
+                ➜ A cancel button is no longer automatically added when a close
+                handler is present. Pass a cancel button with the other buttons
+                in the <code>buttons</code> prop instead, and label it however
+                you like.
+              </Next.ChangelogItem>
+              <Next.ChangelogItem status="breaking">
+                Prop name:{' '}
+                <s>
+                  <code>onCancel</code>
+                </s>{' '}
+                ➜ <code>onClose</code>: This prop is forwarded to{' '}
+                <code>Panel</code> and its naming more clearly indicates that
+                its purpose is to handle the closing of the modal.
+              </Next.ChangelogItem>
+              <Next.ChangelogItem status="breaking">
+                Props removed:{' '}
+                <s>
+                  <code>withCancelButton</code>
+                </s>{' '}
+                and{' '}
+                <s>
+                  <code>withCloseButton</code>
+                </s>
+                ➜ Cancel buttons are no longer automatically rendered based on
+                the presence of the close handler. A close button will now
+                always be rendered if <code>onClose</code> is provided.
+              </Next.ChangelogItem>
+              <Next.ChangelogItem status="changed">
+                <code>icon</code> prop: Now takes an <code>IconComponent</code>{' '}
+                instead of a <code>string</code>.
+              </Next.ChangelogItem>
+              <Next.ChangelogItem status="added">
+                Optional <code>width</code> prop
+              </Next.ChangelogItem>
+            </Next.Changelog>
+          </Library.Example>
+        </Library.Pattern>
+
+        <Library.Pattern title="Usage">
+          <Next.Usage componentName="Modal" />
+          <Library.Demo title="Basic modal" withSource>
+            <ModalWrapper
+              buttons={<ModalButtons />}
+              icon={EditIcon}
+              initialFocus={inputRef}
+              onClose={() => {}}
+              title="Basic modal"
+            >
+              <p>
+                This is a basic modal that routes focus initially to a text
+                input.
+              </p>
+              <InputGroup>
+                <Input name="my-input" elementRef={inputRef} />
+                <IconButton icon={ArrowRightIcon} variant="dark" title="go" />
+              </InputGroup>
+            </ModalWrapper>
+          </Library.Demo>
+        </Library.Pattern>
+
+        <Library.Pattern title="Working with modals">
+          <ul>
+            <li>
+              <code>Modal</code> supports and forwards several props to{' '}
+              <code>Panel</code>: <code>buttons</code>, <code>icon</code>,{' '}
+              <code>onClose</code>, <code>title</code>.
+            </li>
+            <li>
+              <code>Modal</code> does not currently manage state. If a{' '}
+              <code>Modal</code> is rendered, it is open, visible and active.
+            </li>
+            <li>
+              Modals will invoke their <code>onClose</code> handler (unless they
+              are non-closeable) when there are clicks or focus events outside
+              of the modal, or if the <kbd>ESC</kbd> key is pressed.
+            </li>
+            <li>
+              Modals will route focus initially to any provided{' '}
+              <code>initialFocus</code> Ref. If none is provided, a modal will
+              focus its outer element when first rendered.
+            </li>
+            <li>Modals do not (yet) trap focus. They should.</li>
+          </ul>
+          <Library.Example title="Handling long content">
+            <p>
+              Content in a modal will scroll as needed to keep the modal from
+              exceeding viewport capacity.
+            </p>
+            <Library.Demo title="Modal with overflowing content" withSource>
+              <ModalWrapper
+                buttons={<ModalButtons />}
+                onClose={() => {}}
+                title="Modal with long content"
+              >
+                <LoremIpsum size="lg" />
+              </ModalWrapper>
+            </Library.Demo>
+          </Library.Example>
+
+          <Library.Example title="Non-closeable modals">
+            <p>
+              Modals <em>should</em> be given a <code>onClose</code> handler,
+              but there are some edge use cases in which our applications render
+              a non-closeable modal in uncoverable error states. A non-closeable
+              modal can be achieved by not passing an <code>onClose</code>{' '}
+              handler.
+            </p>
+
+            <Library.Demo title="Non-closeable modal" withSource>
+              <ModalWrapper
+                title="Non-closeable modal"
+                nonCloseableWrapperProp={true}
+              >
+                <p>
+                  This is a non-closeable modal. There is no close button at the
+                  top of the panel, and the modal cannot be dismissed by
+                  pressing escape or clicking outside of it. However, an escape
+                  hatch has been provided for you below (typically non-closeable
+                  modals do not have any buttons).
+                </p>
+              </ModalWrapper>
+            </Library.Demo>
+          </Library.Example>
+
+          <Library.Example title="Use case: setting preferred height for modal content">
+            <p>
+              In some cases it might be desirable to set a preferred height for
+              the content of a modal, so that the modal container does not
+              resize or jump around if content changes.
+            </p>
+            <p>To do this, set a minimum height on the modal content.</p>
+            <p>
+              Styling in the <code>Modal</code> component should prevent content
+              from escaping the bounds of the viewport.
+            </p>
+            <Library.Demo
+              title="Modal with a minimum height and not much content"
+              withSource
+            >
+              <ModalWrapper
+                title="Modal with a fixed height"
+                buttons={<ModalButtons />}
+                onClose={() => {}}
+              >
+                <div className="min-h-[15rem]">
+                  <p>
+                    This content has a preferred height of 15rem set by a CSS
+                    class.
+                  </p>
+                </div>
+              </ModalWrapper>
+            </Library.Demo>
+
+            <Library.Demo
+              title="Modal with a minimum height and more content"
+              withSource
+            >
+              <ModalWrapper
+                title="Modal with a fixed height"
+                buttons={<ModalButtons />}
+                onClose={() => {}}
+              >
+                <div className="min-h-[15rem] space-y-3">
+                  <p>
+                    This modal has a preferred height of 15rem, but its content
+                    needs more space, so the modal height grows.{' '}
+                  </p>
+                  <p>
+                    <LoremIpsum size="md" />
+                  </p>
+                </div>
+              </ModalWrapper>
+            </Library.Demo>
+
+            <Library.Demo
+              title="Modal with a minimum height and scrolling content"
+              withSource
+            >
+              <ModalWrapper
+                title="Modal with a fixed height"
+                buttons={<ModalButtons />}
+                onClose={() => {}}
+              >
+                <div className="min-h-[15rem] space-y-3">
+                  <p>
+                    This modal has a preferred height of 15rem, but its content
+                    exceeds the height of the viewport, and scrolls.
+                  </p>
+                  <p>
+                    <LoremIpsum size="lg" />
+                  </p>
+                </div>
+              </ModalWrapper>
+            </Library.Demo>
+          </Library.Example>
+        </Library.Pattern>
+
+        <Library.Pattern title="Props">
+          <Library.Example title="initialFocus">
+            <p>
+              <code>Modal</code> will route focus when it is rendered. By
+              default, focus will be set on the outermost <code>Modal</code>{' '}
+              element. When a Ref is provided as <code>initialFocus</code>,
+              focus will be routed to the element referenced by the Ref,
+              instead.
+            </p>
+            <p>
+              To opt out of focus routing entirely, e.g. in cases where the
+              consumer wants to handle its own focus routing, set{' '}
+              <code>initialFocus</code> to <code>null</code>.
+            </p>
+          </Library.Example>
+
+          <Library.Example title="width">
+            <Library.Demo title="width='sm'" withSource>
+              <ModalWrapper
+                buttons={<ModalButtons />}
+                onClose={() => {}}
+                title="Small modal"
+                width="sm"
+              >
+                <LoremIpsum size="sm" />
+              </ModalWrapper>
+            </Library.Demo>
+
+            <Library.Demo title="width='md' (default)" withSource>
+              <ModalWrapper
+                buttons={<ModalButtons />}
+                onClose={() => {}}
+                title="Medium-width modal"
+                width="md"
+              >
+                <LoremIpsum size="md" />
+              </ModalWrapper>
+            </Library.Demo>
+
+            <Library.Demo title="width='lg'" withSource>
+              <ModalWrapper
+                buttons={<ModalButtons />}
+                onClose={() => {}}
+                title="Wide modal"
+                width="lg"
+              >
+                <LoremIpsum size="md" />
+              </ModalWrapper>
+            </Library.Demo>
+
+            <p>
+              To style your <code>Modal</code> with a custom width, set{' '}
+              <code>width</code> to <code>{"'custom'"}</code> and provide sizing
+              CSS class(es) via the <code>classes</code> prop.
+            </p>
+
+            <Library.Demo title="width='custom'" withSource>
+              <ModalWrapper
+                buttons={<ModalButtons />}
+                classes="w-[40em]"
+                onClose={() => {}}
+                title="Custom-width modal"
+                width="custom"
+              >
+                <LoremIpsum size="md" />
+              </ModalWrapper>
+            </Library.Demo>
+          </Library.Example>
+        </Library.Pattern>
+      </Library.Section>
+    </Library.Page>
+  );
+}

--- a/src/pattern-library/components/patterns/feedback/ModalPage.tsx
+++ b/src/pattern-library/components/patterns/feedback/ModalPage.tsx
@@ -147,6 +147,11 @@ export default function ModalPage() {
                 <code>icon</code> prop: Now takes an <code>IconComponent</code>{' '}
                 instead of a <code>string</code>.
               </Next.ChangelogItem>
+              <Next.ChangelogItem status="changed">
+                <code>initialFocus</code> prop: Set to <code>{"'manual'"}</code>{' '}
+                to opt out of automatic focus routing (formerly{' '}
+                <code>null</code>).
+              </Next.ChangelogItem>
               <Next.ChangelogItem status="added">
                 Optional <code>width</code> prop
               </Next.ChangelogItem>
@@ -193,9 +198,8 @@ export default function ModalPage() {
               of the modal, or if the <kbd>ESC</kbd> key is pressed.
             </li>
             <li>
-              Modals will route focus initially to any provided{' '}
-              <code>initialFocus</code> Ref. If none is provided, a modal will
-              focus its outer element when first rendered.
+              Modals route initial focus unless directed not to do so. See
+              documentation for the <code>initialFocus</code> prop.
             </li>
             <li>Modals do not (yet) trap focus. They should.</li>
           </ul>
@@ -325,7 +329,7 @@ export default function ModalPage() {
             <p>
               To opt out of focus routing entirely, e.g. in cases where the
               consumer wants to handle its own focus routing, set{' '}
-              <code>initialFocus</code> to <code>null</code>.
+              <code>initialFocus</code> to <code>{"'manual'"}</code>.
             </p>
           </Library.Example>
 

--- a/src/pattern-library/routes.ts
+++ b/src/pattern-library/routes.ts
@@ -15,6 +15,7 @@ import ScrollBoxPage from './components/patterns/data/ScrollBoxPage';
 import TablePage from './components/patterns/data/TablePage';
 import ThumbnailPage from './components/patterns/data/ThumbnailPage';
 
+import ModalPage from './components/patterns/feedback/ModalPage';
 import SpinnerPage from './components/patterns/feedback/SpinnerPage';
 
 import ButtonsPage from './components/patterns/input/ButtonPage';
@@ -145,7 +146,12 @@ const routes: PlaygroundRoute[] = [
     component: ThumbnailPage,
     route: '/data-thumbnail',
   },
-  { title: 'Dialog', group: 'feedback' },
+  {
+    title: 'Modal',
+    group: 'feedback',
+    component: ModalPage,
+    route: '/feedback-modal',
+  },
   {
     title: 'Spinner',
     group: 'feedback',

--- a/src/tailwind.preset.js
+++ b/src/tailwind.preset.js
@@ -84,6 +84,7 @@ export default /** @type {Partial<import('tailwindcss').Config>} */ ({
         DEFAULT: '2px',
       },
       screens: {
+        tall: { raw: '(min-height: 32rem)' },
         touch: { raw: '(pointer: coarse)' },
       },
       spacing: {


### PR DESCRIPTION
Depends on #825

Don't panic: More than half the diff is the pattern-library documentation.

This PR adds a `Modal` component that conforms to the current API and styling conventions for shared components. It combines the functionality of legacy `Dialog` and `Modal` components[^1].

<img width="1791" alt="image" src="https://user-images.githubusercontent.com/439947/216440994-884c4d3d-3369-4da5-8848-0d61a59c97cb.png">

This implementation should be considered a bridge implementation until we have a little time to 
focus on a full-featured `dialog` component.

It retains from `Dialog` and `Modal`, unchanged:

* initial focus-routing behavior
* `aria-describedby` behavior
* `useElementShouldClose` handling
* `Modal`s use a `Panel` layout still

What it does add is, I hope, more sane modal sizing and positioning configuration. There are some size defaults, and a `width` prop, and some styling guard rails to ensure that modal dialogs never get too big or stupid for their viewports. I've combined sizing and positioning use cases from LMS, the client and the previous implementations of this component. The API is simpler than previously.

The [pattern-library page](http://localhost:4001/feedback-modal) for this new component documents and exemplifies its aims. I suggest starting there...

[^1]: `Dialog` is not actually used anywhere in our applications directly. Legacy `Modal` wraps `Dialog`.