### PR TITLE
Extract `InputRoot` component

### DIFF
--- a/src/components/input/Input.tsx
+++ b/src/components/input/Input.tsx
@@ -1,10 +1,9 @@
-import classnames from 'classnames';
 import type { JSX } from 'preact';
 
 import type { PresentationalProps } from '../../types';
 import { downcastRef } from '../../util/typing';
 
-import { inputGroupStyles } from './InputGroup';
+import InputRoot from './InputRoot';
 
 type ComponentProps = {
   hasError?: boolean;
@@ -19,39 +18,20 @@ export type InputProps = PresentationalProps &
  * Render a text field input
  */
 const InputNext = function Input({
-  children,
-  classes,
   elementRef,
-
   hasError,
   type = 'text',
 
   ...htmlAttributes
 }: InputProps) {
-  // @ts-expect-error - "aria-label" is missing from HTMLInputAttributes
-  if (!htmlAttributes.id && !htmlAttributes['aria-label']) {
-    console.warn(
-      '`Input` component should have either an `id` or an `aria-label` attribute'
-    );
-  }
   return (
-    <input
-      {...htmlAttributes}
+    <InputRoot
+      elementRef={downcastRef(elementRef)}
       type={type}
-      ref={downcastRef(elementRef)}
-      className={classnames(
-        'focus-visible-ring ring-inset border rounded-sm w-full p-2',
-        'bg-grey-0 focus:bg-white disabled:bg-grey-1',
-        'placeholder:text-color-grey-5 disabled:placeholder:color-grey-6',
-        { 'ring-inset ring-2 ring-red-error': hasError },
-        // Adapt styles when this component is inside an InputGroup
-        inputGroupStyles,
-        classes
-      )}
+      hasError={hasError}
+      {...htmlAttributes}
       data-component="Input"
-    >
-      {children}
-    </input>
+    />
   );
 };
 

--- a/src/components/input/Input.tsx
+++ b/src/components/input/Input.tsx
@@ -1,22 +1,22 @@
 import classnames from 'classnames';
+import type { JSX } from 'preact';
 
+import type { PresentationalProps } from '../../types';
 import { downcastRef } from '../../util/typing';
 
 import { inputGroupStyles } from './InputGroup';
 
-/**
- * @typedef {import('../../types').PresentationalProps} CommonProps
- * @typedef {import('preact').JSX.HTMLAttributes<HTMLInputElement>} HTMLInputAttributes
- *
- * @typedef InputProps
- * @prop {boolean} [hasError=false]
- * @prop {'email'|'search'|'text'|'url'} [type="text"]
- */
+type ComponentProps = {
+  hasError?: boolean;
+  type?: 'email' | 'search' | 'text' | 'url';
+};
+
+export type InputProps = PresentationalProps &
+  ComponentProps &
+  JSX.HTMLAttributes<HTMLInputElement>;
 
 /**
  * Render a text field input
- *
- * @param {CommonProps & InputProps & Omit<HTMLInputAttributes, 'type'>} props
  */
 const InputNext = function Input({
   children,
@@ -27,7 +27,7 @@ const InputNext = function Input({
   type = 'text',
 
   ...htmlAttributes
-}) {
+}: InputProps) {
   // @ts-expect-error - "aria-label" is missing from HTMLInputAttributes
   if (!htmlAttributes.id && !htmlAttributes['aria-label']) {
     console.warn(

--- a/src/components/input/InputRoot.tsx
+++ b/src/components/input/InputRoot.tsx
@@ -1,0 +1,62 @@
+import classnames from 'classnames';
+import type { JSX } from 'preact';
+
+import type { PresentationalProps } from '../../types';
+import { downcastRef } from '../../util/typing';
+
+import { inputGroupStyles } from './InputGroup';
+
+type RootComponentProps = {
+  element?: 'input' | 'select';
+  hasError?: boolean;
+};
+
+export type InputRootProps = PresentationalProps &
+  RootComponentProps &
+  (
+    | Omit<JSX.HTMLAttributes<HTMLInputElement>, 'size' | 'icon'>
+    | Omit<JSX.HTMLAttributes<HTMLSelectElement>, 'size' | 'icon'>
+  );
+
+/**
+ * Root component for various input types that applies a consistent design
+ * pattern.
+ */
+const InputRootNext = function InputRoot({
+  element: Element = 'input',
+  children,
+  classes,
+  elementRef,
+  hasError,
+
+  ...htmlAttributes
+}: InputRootProps) {
+  // @ts-expect-error - "aria-label" is missing from HTMLInputAttributes
+  if (!htmlAttributes.id && !htmlAttributes['aria-label']) {
+    console.warn(
+      '`Input` component should have either an `id` or an `aria-label` attribute'
+    );
+  }
+
+  return (
+    <Element
+      data-component="InputRoot"
+      {...htmlAttributes}
+      // @ts-ignore-next
+      ref={downcastRef(elementRef)}
+      className={classnames(
+        'focus-visible-ring ring-inset border rounded-sm w-full p-2',
+        'bg-grey-0 focus:bg-white disabled:bg-grey-1',
+        'placeholder:text-color-grey-5 disabled:placeholder:color-grey-6',
+        { 'ring-inset ring-2 ring-red-error': hasError },
+        // Adapt styles when this component is inside an InputGroup
+        inputGroupStyles,
+        classes
+      )}
+    >
+      {children}
+    </Element>
+  );
+};
+
+export default InputRootNext;

--- a/src/components/input/test/Input-test.js
+++ b/src/components/input/test/Input-test.js
@@ -10,17 +10,4 @@ const contentFn = (Component, props = {}) => {
 
 describe('Input', () => {
   testPresentationalComponent(Input, { createContent: contentFn });
-
-  it('should warn in console if accessibility attributes are missing', () => {
-    sinon.stub(console, 'warn');
-
-    mount(<Input placeholder="..." />);
-
-    assert.calledWith(
-      console.warn,
-      '`Input` component should have either an `id` or an `aria-label` attribute'
-    );
-
-    console.warn.restore();
-  });
 });

--- a/src/components/input/test/InputRoot-test.js
+++ b/src/components/input/test/InputRoot-test.js
@@ -1,0 +1,26 @@
+import { mount } from 'enzyme';
+
+import { testPresentationalComponent } from '../../test/common-tests';
+
+import InputRoot from '../InputRoot';
+
+const contentFn = (Component, props = {}) => {
+  return mount(<Component aria-label="Test input" {...props} />);
+};
+
+describe('InputRoot', () => {
+  testPresentationalComponent(InputRoot, { createContent: contentFn });
+
+  it('should warn in console if accessibility attributes are missing', () => {
+    sinon.stub(console, 'warn');
+
+    mount(<InputRoot placeholder="..." />);
+
+    assert.calledWith(
+      console.warn,
+      '`Input` component should have either an `id` or an `aria-label` attribute'
+    );
+
+    console.warn.restore();
+  });
+});


### PR DESCRIPTION
This PR establishes a root component for textual input elements. The purpose of this is to be able to share design patterns and behavior across those input elements. I'm terming this a "Root" element, as distinct from a "Base" element, because it is private to the package. Early days here; I want to feel this out.

Expect to see a `Select` component based on this imminently. A `TextArea` component is probably not far off, either, but doesn't have as immediate of a need as `Select`.

There should be no visible or behavioral changes to the existing `Input` component. You can verify that on the [Input pattern-library page](http://localhost:4001/input-input).