### PR TITLE
Add new `Select` component

### DIFF
--- a/src/components/input/Select.tsx
+++ b/src/components/input/Select.tsx
@@ -1,0 +1,55 @@
+import classnames from 'classnames';
+import type { ComponentChildren, JSX } from 'preact';
+
+import type { PresentationalProps } from '../../types';
+
+import InputRoot from './InputRoot';
+
+type ComponentProps = {
+  children?: ComponentChildren;
+  hasError?: boolean;
+};
+export type SelectProps = PresentationalProps &
+  ComponentProps &
+  JSX.HTMLAttributes<HTMLSelectElement>;
+
+// URI-encoded source of `CaretDownIcon`
+// Currently, the color (stroke) is hard-coded
+const arrowImage = `url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 16 16' aria-hidden='true' focusable='false'%3E%3Cg fill-rule='evenodd'%3E%3Crect fill='none' stroke='none' x='0' y='0' width='16' height='16'%3E%3C/rect%3E%3Cpath fill='none' stroke='%239c9c9c' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M12 6l-4 4-4-4'%3E%3C/path%3E%3C/g%3E%3C/svg%3E")`;
+
+/**
+ * Style a native `<select>` element.
+ */
+const SelectNext = function Select({
+  children,
+  classes,
+  hasError,
+  type = 'text',
+
+  ...htmlAttributes
+}: SelectProps) {
+  return (
+    <InputRoot
+      classes={classnames(
+        'appearance-none h-touch-minimum',
+        // position the down-arrow image centered at the right, offset from the
+        // right edge by 0.5rem. Arrow image width (4 units) + horizontal
+        // padding (3 units) = 7 units of right padding needed.
+        'bg-no-repeat bg-[center_right_0.5rem] pr-7',
+        classes
+      )}
+      element="select"
+      type={type}
+      hasError={hasError}
+      style={{
+        backgroundImage: arrowImage,
+      }}
+      {...htmlAttributes}
+      data-component="Select"
+    >
+      {children}
+    </InputRoot>
+  );
+};
+
+export default SelectNext;

--- a/src/components/input/index.js
+++ b/src/components/input/index.js
@@ -4,3 +4,4 @@ export { default as Checkbox } from './Checkbox';
 export { default as IconButton } from './IconButton';
 export { default as Input } from './Input';
 export { default as InputGroup } from './InputGroup';
+export { default as Select } from './Select';

--- a/src/components/input/test/Select-test.js
+++ b/src/components/input/test/Select-test.js
@@ -1,0 +1,13 @@
+import { mount } from 'enzyme';
+
+import { testPresentationalComponent } from '../../test/common-tests';
+
+import Select from '../Select';
+
+const contentFn = (Component, props = {}) => {
+  return mount(<Component aria-label="Test input" {...props} />);
+};
+
+describe('Select', () => {
+  testPresentationalComponent(Select, { createContent: contentFn });
+});

--- a/src/next.js
+++ b/src/next.js
@@ -26,6 +26,7 @@ export {
   IconButton,
   Input,
   InputGroup,
+  Select,
 } from './components/input';
 export {
   Card,

--- a/src/pattern-library/components/patterns/input/SelectPage.tsx
+++ b/src/pattern-library/components/patterns/input/SelectPage.tsx
@@ -1,0 +1,117 @@
+import {
+  ArrowLeftIcon,
+  ArrowRightIcon,
+  IconButton,
+  InputGroup,
+  Select,
+} from '../../../../next';
+import Library from '../../Library';
+import Next from '../../LibraryNext';
+
+import type { SelectProps } from '../../../../components/input/Select';
+
+function SelectWrapper({ children, ...selectProps }: SelectProps) {
+  const options = children ?? (
+    <>
+      <option value={-1}>All students</option>
+      <option value="a">Albert Banana</option>
+      <option value="b">Bernard California</option>
+      <option value="c">Cecelia Davenport</option>
+      <option value="d">Doris Evanescence</option>
+    </>
+  );
+  return <Select {...selectProps}>{options}</Select>;
+}
+
+export default function SelectPage() {
+  return (
+    <Library.Page
+      title="Select"
+      intro={
+        <p>
+          <code>Select</code> is a presentational component that styles native{' '}
+          <code>{'<select>'}</code> elements.
+        </p>
+      }
+    >
+      <Library.Section
+        title="Select"
+        intro={
+          <p>
+            <code>Select</code> styles <code>{'<select>'}</code> elements. Note
+            that <code>{'<option>'}</code> elements, with a few browser-specific
+            exceptions, cannot be styled with CSS.
+          </p>
+        }
+      >
+        <Library.Pattern title="Status">
+          <p>
+            <code>Select</code> is a new component.
+          </p>
+        </Library.Pattern>
+        <Library.Pattern title="Usage">
+          <Next.Usage componentName="Select" />
+
+          <Library.Example>
+            <Library.Demo title="Basic Select" withSource>
+              <div>
+                <SelectWrapper aria-label="Example input">
+                  <option value={-1}>All students</option>
+                  <option value="a">Albert Banana</option>
+                  <option value="b">Bernard California</option>
+                  <option value="c">Cecelia Davenport</option>
+                </SelectWrapper>
+              </div>
+            </Library.Demo>
+
+            <Library.Demo title="Setting Select width" withSource>
+              <div className="w-[250px]">
+                <SelectWrapper aria-label="Example input" />
+              </div>
+            </Library.Demo>
+
+            <Library.Demo title="Select in an InputGroup" withSource>
+              <div className="w-[380px]">
+                <InputGroup>
+                  <IconButton
+                    icon={ArrowLeftIcon}
+                    title="Previous student"
+                    variant="dark"
+                  />
+                  <SelectWrapper aria-label="Example input" />
+                  <IconButton
+                    icon={ArrowRightIcon}
+                    title="Next student"
+                    variant="dark"
+                  />
+                </InputGroup>
+              </div>
+            </Library.Demo>
+          </Library.Example>
+        </Library.Pattern>
+
+        <Library.Pattern title="Props">
+          <Library.Example title="hasError">
+            <p>
+              Set <code>hasError</code> to indicate that there is an associated
+              error.
+            </p>
+            <Library.Demo withSource>
+              <div className="w-[350px]">
+                <SelectWrapper aria-label="Example input" hasError />
+              </div>
+            </Library.Demo>
+          </Library.Example>
+
+          <Library.Example title="disabled">
+            <Library.Demo withSource>
+              <div className="w-[350px]">
+                <SelectWrapper aria-label="Example input" disabled />
+              </div>
+            </Library.Demo>
+          </Library.Example>
+        </Library.Pattern>
+      </Library.Section>
+    </Library.Page>
+  );
+}

--- a/src/pattern-library/routes.ts
+++ b/src/pattern-library/routes.ts
@@ -22,6 +22,7 @@ import ButtonsPage from './components/patterns/input/ButtonPage';
 import CheckboxPage from './components/patterns/input/CheckboxPage';
 import InputPage from './components/patterns/input/InputPage';
 import InputGroupPage from './components/patterns/input/InputGroupPage';
+import SelectPage from './components/patterns/input/SelectPage';
 
 import CardPage from './components/patterns/layout/CardPage';
 import PanelPage from './components/patterns/layout/PanelPage';
@@ -181,6 +182,12 @@ const routes: PlaygroundRoute[] = [
     group: 'input',
     component: InputGroupPage,
     route: '/input-input-group',
+  },
+  {
+    title: 'Select',
+    group: 'input',
+    component: SelectPage,
+    route: '/input-select',
   },
   {
     title: 'Card',


### PR DESCRIPTION
Depends on #827 

This PR adds a basic `Select` component, building on `InputRoot`. Its purpose right now is to capture, standardize and simplify the design pattern used in the grading toolbar in LMS:

![image](https://user-images.githubusercontent.com/439947/216691846-b7c1c208-09e2-4996-80f9-5a3251baacf3.png)

This is to support some UI improvements in that area.

The component is simple and young. You can see its documentation on this branch at http://localhost:4001/input-select

<img width="1292" alt="image" src="https://user-images.githubusercontent.com/439947/216692204-c5251343-b53b-4a47-bead-c799b81d6752.png">
