### PR TITLE
Fix typing in pattern-library entry point

### DIFF
--- a/src/pattern-library/index.tsx
+++ b/src/pattern-library/index.tsx
@@ -46,7 +46,7 @@ export function startApp({
   icons = {},
 
   ...componentProps
-} = {}) {
+}: PatternLibraryAppOptions = {}) {
   const allIcons = { ...iconSet, ...icons };
   registerIcons(allIcons);
   const container = document.querySelector('#app');


### PR DESCRIPTION
`PatternLibraryAppOptions` was not getting applied to `startApp`'s parameters.

(Found when testing a build of this project's `main` branch against another app, which is part of the pre-release process).