### PR TITLE
Refactor and add basic tests for `jsx-to-string` utility

### DIFF
--- a/src/pattern-library/components/patterns/feedback/ModalPage.tsx
+++ b/src/pattern-library/components/patterns/feedback/ModalPage.tsx
@@ -32,25 +32,25 @@ function ModalButtons() {
   );
 }
 
-type ModalWrapperProps = ModalProps & {
+type Modal_Props = ModalProps & {
   /** Pattern-wrapping prop. Not visible in source view */
-  nonCloseableWrapperProp?: boolean;
+  _nonCloseable?: boolean;
 };
 
 /**
  * Wrap the Modal component with some state management to make reuse in
  * multiple examples plausible and convenient.
  */
-function ModalWrapper({
+function Modal_({
   buttons,
-  nonCloseableWrapperProp,
+  _nonCloseable,
   children,
   ...modalProps
-}: ModalWrapperProps) {
+}: Modal_Props) {
   const [modalOpen, setModalOpen] = useState(false);
   const closeModal = () => setModalOpen(false);
 
-  const closeHandler = nonCloseableWrapperProp ? undefined : closeModal;
+  const closeHandler = _nonCloseable ? undefined : closeModal;
   const forwardedButtons = buttons ? (
     buttons
   ) : (
@@ -162,7 +162,7 @@ export default function ModalPage() {
         <Library.Pattern title="Usage">
           <Next.Usage componentName="Modal" />
           <Library.Demo title="Basic modal" withSource>
-            <ModalWrapper
+            <Modal_
               buttons={<ModalButtons />}
               icon={EditIcon}
               initialFocus={inputRef}
@@ -177,7 +177,7 @@ export default function ModalPage() {
                 <Input name="my-input" elementRef={inputRef} />
                 <IconButton icon={ArrowRightIcon} variant="dark" title="go" />
               </InputGroup>
-            </ModalWrapper>
+            </Modal_>
           </Library.Demo>
         </Library.Pattern>
 
@@ -209,13 +209,13 @@ export default function ModalPage() {
               exceeding viewport capacity.
             </p>
             <Library.Demo title="Modal with overflowing content" withSource>
-              <ModalWrapper
+              <Modal_
                 buttons={<ModalButtons />}
                 onClose={() => {}}
                 title="Modal with long content"
               >
                 <LoremIpsum size="lg" />
-              </ModalWrapper>
+              </Modal_>
             </Library.Demo>
           </Library.Example>
 
@@ -229,10 +229,7 @@ export default function ModalPage() {
             </p>
 
             <Library.Demo title="Non-closeable modal" withSource>
-              <ModalWrapper
-                title="Non-closeable modal"
-                nonCloseableWrapperProp={true}
-              >
+              <Modal_ title="Non-closeable modal" _nonCloseable={true}>
                 <p>
                   This is a non-closeable modal. There is no close button at the
                   top of the panel, and the modal cannot be dismissed by
@@ -240,7 +237,7 @@ export default function ModalPage() {
                   hatch has been provided for you below (typically non-closeable
                   modals do not have any buttons).
                 </p>
-              </ModalWrapper>
+              </Modal_>
             </Library.Demo>
           </Library.Example>
 
@@ -259,7 +256,7 @@ export default function ModalPage() {
               title="Modal with a minimum height and not much content"
               withSource
             >
-              <ModalWrapper
+              <Modal_
                 title="Modal with a fixed height"
                 buttons={<ModalButtons />}
                 onClose={() => {}}
@@ -270,14 +267,14 @@ export default function ModalPage() {
                     class.
                   </p>
                 </div>
-              </ModalWrapper>
+              </Modal_>
             </Library.Demo>
 
             <Library.Demo
               title="Modal with a minimum height and more content"
               withSource
             >
-              <ModalWrapper
+              <Modal_
                 title="Modal with a fixed height"
                 buttons={<ModalButtons />}
                 onClose={() => {}}
@@ -291,14 +288,14 @@ export default function ModalPage() {
                     <LoremIpsum size="md" />
                   </p>
                 </div>
-              </ModalWrapper>
+              </Modal_>
             </Library.Demo>
 
             <Library.Demo
               title="Modal with a minimum height and scrolling content"
               withSource
             >
-              <ModalWrapper
+              <Modal_
                 title="Modal with a fixed height"
                 buttons={<ModalButtons />}
                 onClose={() => {}}
@@ -312,7 +309,7 @@ export default function ModalPage() {
                     <LoremIpsum size="lg" />
                   </p>
                 </div>
-              </ModalWrapper>
+              </Modal_>
             </Library.Demo>
           </Library.Example>
         </Library.Pattern>
@@ -335,36 +332,36 @@ export default function ModalPage() {
 
           <Library.Example title="width">
             <Library.Demo title="width='sm'" withSource>
-              <ModalWrapper
+              <Modal_
                 buttons={<ModalButtons />}
                 onClose={() => {}}
                 title="Small modal"
                 width="sm"
               >
                 <LoremIpsum size="sm" />
-              </ModalWrapper>
+              </Modal_>
             </Library.Demo>
 
             <Library.Demo title="width='md' (default)" withSource>
-              <ModalWrapper
+              <Modal_
                 buttons={<ModalButtons />}
                 onClose={() => {}}
                 title="Medium-width modal"
                 width="md"
               >
                 <LoremIpsum size="md" />
-              </ModalWrapper>
+              </Modal_>
             </Library.Demo>
 
             <Library.Demo title="width='lg'" withSource>
-              <ModalWrapper
+              <Modal_
                 buttons={<ModalButtons />}
                 onClose={() => {}}
                 title="Wide modal"
                 width="lg"
               >
                 <LoremIpsum size="md" />
-              </ModalWrapper>
+              </Modal_>
             </Library.Demo>
 
             <p>
@@ -374,7 +371,7 @@ export default function ModalPage() {
             </p>
 
             <Library.Demo title="width='custom'" withSource>
-              <ModalWrapper
+              <Modal_
                 buttons={<ModalButtons />}
                 classes="w-[40em]"
                 onClose={() => {}}
@@ -382,7 +379,7 @@ export default function ModalPage() {
                 width="custom"
               >
                 <LoremIpsum size="md" />
-              </ModalWrapper>
+              </Modal_>
             </Library.Demo>
           </Library.Example>
         </Library.Pattern>

--- a/src/pattern-library/util/test/jsx-to-string-test.js
+++ b/src/pattern-library/util/test/jsx-to-string-test.js
@@ -1,0 +1,249 @@
+import { jsxToString } from '../jsx-to-string';
+
+function Widget_(children, { ...props }) {
+  return <div {...props}>{children}</div>;
+}
+
+function Widget$1(children, { ...props }) {
+  return <div {...props}>{children}</div>;
+}
+
+function Widget_$1(children, { ...props }) {
+  return <div {...props}>{children}</div>;
+}
+
+function Widget(children, { ...props }) {
+  return <div {...props}>{children}</div>;
+}
+
+describe('jsx-to-string', () => {
+  [
+    {
+      jsx: <Widget />,
+      expected: '<Widget />',
+      description: 'it renders component name',
+    },
+    {
+      jsx: <Widget_ />,
+      expected: '<Widget />',
+      description: 'it removes trailing underscore',
+    },
+    {
+      jsx: <Widget$1 />,
+      expected: '<Widget />',
+      description: 'it removes name conflict characters',
+    },
+    {
+      jsx: <Widget_$1 />,
+      expected: '<Widget />',
+      description: 'it removes underscore and name conflict characters',
+    },
+  ].forEach(({ jsx, expected, description }) => {
+    it(`normalizes component names: ${description}`, () => {
+      assert.equal(jsxToString(jsx), expected);
+    });
+  });
+
+  describe('non-component content', () => {
+    [
+      {
+        jsx: 'foo',
+        expected: 'foo',
+        description: 'type: string',
+      },
+      {
+        jsx: 5,
+        expected: '5',
+        description: 'type: number',
+      },
+      {
+        jsx: BigInt(9007199254740991),
+        expected: '9007199254740991',
+        description: 'type: bigint',
+      },
+      {
+        jsx: true,
+        expected: '',
+        description: 'type: boolean',
+      },
+    ].forEach(({ jsx, expected, description }) => {
+      it(`renders non-component content: ${description}`, () => {
+        assert.equal(jsxToString(jsx), expected);
+      });
+    });
+  });
+
+  describe('props and their values', () => {
+    [
+      {
+        jsx: <Widget _ignored={true} />,
+        expected: '<Widget />',
+        description: 'props with leading underscore ignored',
+      },
+      {
+        jsx: <Widget ignored={true} />,
+        expected: '<Widget ignored />',
+        description: 'truthy booleans',
+      },
+      {
+        jsx: <Widget ignored={false} />,
+        expected: '<Widget ignored={false} />',
+        description: 'falsey booleans',
+      },
+    ].forEach(({ jsx, expected, description }) => {
+      it(`renders boolean props: ${description}`, () => {
+        assert.equal(jsxToString(jsx), expected);
+      });
+    });
+
+    [
+      {
+        jsx: <Widget _greeting={'Hello'} />,
+        expected: '<Widget />',
+        description: 'props with leading underscore ignored',
+      },
+      {
+        jsx: <Widget greeting={'Hello'} />,
+        expected: '<Widget greeting="Hello" />',
+        description: 'renders strings without brackets',
+      },
+      {
+        jsx: <Widget greeting={'He"llo'} />,
+        expected: '<Widget greeting="He\\"llo" />',
+        description: 'quotes strings correctly',
+      },
+    ].forEach(({ jsx, expected, description }) => {
+      it(`renders string props: ${description}`, () => {
+        assert.equal(jsxToString(jsx), expected);
+      });
+    });
+
+    [
+      {
+        jsx: <Widget _count={5} />,
+        expected: '<Widget />',
+        description: 'props with leading underscore ignored',
+      },
+      {
+        jsx: <Widget count={5} />,
+        expected: '<Widget count={5} />',
+        description: 'truthy numbers',
+      },
+      {
+        jsx: <Widget count={0} />,
+        expected: '<Widget count={0} />',
+        description: 'falsey numbers',
+      },
+      {
+        jsx: <Widget count={BigInt(1234567890)} />,
+        expected: '<Widget count={1234567890} />',
+        description: 'BigInt numbers',
+      },
+    ].forEach(({ jsx, expected, description }) => {
+      it(`renders numeric props: ${description}`, () => {
+        assert.equal(jsxToString(jsx), expected);
+      });
+    });
+
+    [
+      {
+        jsx: <Widget _onChange={() => {}} />,
+        expected: '<Widget />',
+        description: 'props with leading underscore ignored',
+      },
+      {
+        jsx: <Widget onChange={function foo() {}} />,
+        expected: '<Widget onChange={foo} />',
+        description: 'renders name of function as value when available',
+      },
+      {
+        jsx: <Widget onChange={() => {}} />,
+        expected: '<Widget onChange={onChange} />',
+        description: 'renders prop name as value if no function name available',
+      },
+    ].forEach(({ jsx, expected, description }) => {
+      it(`renders function props: ${description}`, () => {
+        assert.equal(jsxToString(jsx), expected);
+      });
+    });
+
+    [
+      {
+        jsx: <Widget _helmet={{ foo: 'bar' }} />,
+        expected: '<Widget />',
+        description: 'props with leading underscore ignored',
+      },
+      {
+        jsx: <Widget helmet={{ foo: 'bar' }} />,
+        expected: '<Widget helmet={helmet} />',
+        description: 'renders name of prop for value if value is truthy',
+      },
+      {
+        jsx: <Widget helmet={null} />,
+        expected: '<Widget helmet={null} />',
+        description: 'renders value of object if value is falsey',
+      },
+    ].forEach(({ jsx, expected, description }) => {
+      it(`renders object props: ${description}`, () => {
+        assert.equal(jsxToString(jsx), expected);
+      });
+    });
+
+    [
+      {
+        jsx: <Widget _other={Symbol('five')} />,
+        expected: '<Widget />',
+        description: 'props with leading underscore ignored',
+      },
+      {
+        jsx: <Widget other={Symbol('five')} />,
+        expected: '<Widget other={Symbol(five)} />',
+        description: 'renders string representation of prop value',
+      },
+    ].forEach(({ jsx, expected, description }) => {
+      it(`other prop types: ${description}`, () => {
+        assert.equal(jsxToString(jsx), expected);
+      });
+    });
+
+    [
+      {
+        jsx: <Widget _widget={<Widget_ />} />,
+        expected: '<Widget />',
+        description: 'props with leading underscore ignored',
+      },
+      {
+        jsx: <Widget widget={<Widget_ />} />,
+        expected: '<Widget widget={<Widget />} />',
+        description: 'JSX component props',
+      },
+    ].forEach(({ jsx, expected, description }) => {
+      it(`renders JSX props: ${description}`, () => {
+        assert.equal(jsxToString(jsx), expected);
+      });
+    });
+  });
+
+  describe('rendering children', () => {
+    [
+      {
+        jsx: <Widget>With children</Widget>,
+        expected: `<Widget>
+  With children
+</Widget>`,
+        description: 'children are rendered and indented',
+      },
+      {
+        jsx: <Widget widget={<Widget_>Prop children</Widget_>} />,
+        expected: `<Widget widget={<Widget>
+  Prop children
+</Widget>} />`,
+        description: 'children in JSX props',
+      },
+    ].forEach(({ jsx, expected, description }) => {
+      it(`renders children: ${description}`, () => {
+        assert.equal(jsxToString(jsx), expected);
+      });
+    });
+  });
+});


### PR DESCRIPTION
This PR addresses a few follow-up tasks for the `jsx-to-string` utility. It:

* refactors `jsx-to-string` lightly to ensure that the ordering of prop evaluation is not fragile, and ensures broader support of basic JS types;
* updates the conventions for wrapper-component naming and ignored props: these have been changed to a single trailing underscore and a single leading underscore, respectively. Updates the pattern-library page that takes advantage of these.
* Adds rudimentary tests for the `jsx-to-string` function. The other exported function `jsxToHTML` is still untested. (This module is in a path ignored by code coverage, which is fine for now, I think.)