### PR TITLE
Remove explicit height from `Select` component

### DIFF
--- a/src/components/input/Select.tsx
+++ b/src/components/input/Select.tsx
@@ -31,7 +31,7 @@ const SelectNext = function Select({
   return (
     <InputRoot
       classes={classnames(
-        'appearance-none h-touch-minimum',
+        'appearance-none',
         // position the down-arrow image centered at the right, offset from the
         // right edge by 0.5rem. Arrow image width (4 units) + horizontal
         // padding (3 units) = 7 units of right padding needed.


### PR DESCRIPTION
Setting a fixed height here is too restrictive for a presentational component. Applications should be able to style the height of this component as desired.

See related PR here https://github.com/hypothesis/lms/pull/5008