### PR TITLE
Add default `type="button"` to all button components

### DIFF
--- a/src/components/input/ButtonBase.js
+++ b/src/components/input/ButtonBase.js
@@ -62,6 +62,9 @@ const ButtonBaseNext = function ButtonBase({
       data-base-component="ButtonBase"
       /* data-component will be overwritten unless this component is used directly */
       data-component="ButtonBase"
+      // Setting a default `type` can prevent undesired form submissions in
+      // certain cases
+      type="button"
       {...htmlAttributes}
       className={classNames(
         {


### PR DESCRIPTION
This simple PR ensures that buttons default to a `type` of `button`, which should untangle the frustrating situation in https://github.com/hypothesis/lms/pull/5017 (button elements with `type="button"` will not submit forms).

This change is on `ButtonBase`, so applies to all button components.