### PR TITLE
Provide more flexibility with headers and padding of Panels

### DIFF
--- a/src/components/feedback/Modal.tsx
+++ b/src/components/feedback/Modal.tsx
@@ -47,6 +47,7 @@ const ModalNext = function Modal({
   buttons,
   icon,
   onClose,
+  paddingSize = 'md',
   title,
 
   ...htmlAttributes
@@ -135,7 +136,14 @@ const ModalNext = function Modal({
         data-component="Modal"
         ref={downcastRef(modalRef)}
       >
-        <Panel buttons={buttons} icon={icon} onClose={onClose} title={title}>
+        <Panel
+          buttons={buttons}
+          icon={icon}
+          onClose={onClose}
+          paddingSize={paddingSize}
+          title={title}
+          scrollable
+        >
           {children}
         </Panel>
       </div>

--- a/src/components/layout/CardHeader.tsx
+++ b/src/components/layout/CardHeader.tsx
@@ -17,6 +17,11 @@ type ComponentProps = {
    * will be rendered.
    */
   onClose?: () => void;
+
+  /**
+   * Make the header take the full width of the Card, with a full-width border
+   */
+  fullWidth?: boolean;
 };
 
 type HTMLAttributes = JSX.HTMLAttributes<HTMLElement>;
@@ -33,6 +38,7 @@ const CardHeaderNext = function CardHeader({
   classes,
   elementRef,
 
+  fullWidth = false,
   onClose,
   title,
 
@@ -42,7 +48,8 @@ const CardHeaderNext = function CardHeader({
     <div
       {...htmlAttributes}
       className={classnames(
-        'flex items-center gap-x-2 mx-3 py-2 border-b',
+        'flex items-center gap-x-2 border-b py-2',
+        { 'mx-3': !fullWidth, 'px-3': fullWidth },
         classes
       )}
       ref={downcastRef(elementRef)}

--- a/src/components/layout/Panel.tsx
+++ b/src/components/layout/Panel.tsx
@@ -13,6 +13,19 @@ import CardActions from './CardActions';
 type ComponentProps = {
   /** Buttons are rendered at the bottom right of the Panel. */
   buttons?: ComponentChildren;
+
+  /**
+   * Make the header take the full width of the Panel, with a full-width border
+   */
+  fullWidthHeader?: boolean;
+
+  /**
+   * Forwarded to `CardContent`. If `none`, content is not wrapped with
+   * `CardContent`. This allows content to span the full width and height of
+   * the Panel's content area without any inset/padding.
+   */
+  paddingSize?: 'sm' | 'md' | 'lg' | 'none';
+
   /** Optional icon to render in the header */
   icon?: IconComponent;
 
@@ -21,6 +34,13 @@ type ComponentProps = {
    * this function as an onClick handler
    */
   onClose?: () => void;
+  /**
+   * The content of the Panel should scroll if it exceeds available vertical
+   * space. This will cause the `CardHeader` (and its bottom border) to span the
+   * full width of the Panel. This prevents scroll shadow hints from looking
+   * awkward.
+   */
+  scrollable?: boolean;
   title: string;
 };
 
@@ -40,12 +60,23 @@ const PanelNext = function Panel({
   elementRef,
 
   buttons,
+  fullWidthHeader = false,
   icon: Icon,
   onClose,
+  paddingSize = 'md',
+  scrollable = false,
   title,
 
   ...htmlAttributes
 }: PanelProps) {
+  const panelContent =
+    paddingSize === 'none' ? (
+      children
+    ) : (
+      <CardContent data-testid="panel-content-wrapper" size={paddingSize}>
+        {children}
+      </CardContent>
+    );
   return (
     <Card
       {...htmlAttributes}
@@ -53,13 +84,11 @@ const PanelNext = function Panel({
       elementRef={downcastRef(elementRef)}
       data-composite-component="Panel"
     >
-      <CardHeader onClose={onClose}>
+      <CardHeader onClose={onClose} fullWidth={scrollable || fullWidthHeader}>
         {Icon && <Icon className="w-em h-em" />}
         <CardTitle>{title}</CardTitle>
       </CardHeader>
-      <Scroll>
-        <CardContent>{children}</CardContent>
-      </Scroll>
+      {scrollable ? <Scroll>{panelContent}</Scroll> : <>{panelContent}</>}
       <CardContent>
         {buttons && <CardActions>{buttons}</CardActions>}
       </CardContent>

--- a/src/components/layout/test/Panel-test.js
+++ b/src/components/layout/test/Panel-test.js
@@ -57,7 +57,7 @@ describe('Panel', () => {
       unboundedContainer.remove();
     });
 
-    it('should not exceed height of parent container', () => {
+    it('should not exceed height of parent container if `scrollable` is set', () => {
       const loremWrapper = mount(<LoremIpsum />, {
         attachTo: unboundedContainer,
       });
@@ -65,7 +65,7 @@ describe('Panel', () => {
       // The lorem ipsum content in the Panel will be constrained and will scroll
       // within the allotted 200px height
       const wrapper = mount(
-        <Panel title="Constrained Panel">
+        <Panel title="Constrained Panel" scrollable>
           <LoremIpsum />
         </Panel>,
         { attachTo: container }
@@ -80,6 +80,33 @@ describe('Panel', () => {
         wrapper.find('div[data-composite-component="Panel"]').getDOMNode()
           .clientHeight,
         200
+      );
+    });
+
+    it('should not constrain content if `scrollable` is not set', () => {
+      const wrapper = mount(
+        <Panel title="Unconstrained Panel">
+          <LoremIpsum />
+        </Panel>,
+        { attachTo: container }
+      );
+
+      assert.isAbove(
+        wrapper.find('div[data-component="CardContent"]').first().getDOMNode()
+          .clientHeight,
+        200
+      );
+    });
+
+    it('should not wrap content in `CardContent` if paddingSize is `none`', () => {
+      const wrapper = createComponent(Panel);
+      const noPaddingWrapper = createComponent(Panel, { paddingSize: 'none' });
+
+      assert.isTrue(
+        wrapper.find('[data-testid="panel-content-wrapper"]').exists()
+      );
+      assert.isFalse(
+        noPaddingWrapper.find('[data-testid="panel-content-wrapper"]').exists()
       );
     });
   });

--- a/src/pattern-library/components/patterns/feedback/ModalPage.tsx
+++ b/src/pattern-library/components/patterns/feedback/ModalPage.tsx
@@ -185,8 +185,7 @@ export default function ModalPage() {
           <ul>
             <li>
               <code>Modal</code> supports and forwards several props to{' '}
-              <code>Panel</code>: <code>buttons</code>, <code>icon</code>,{' '}
-              <code>onClose</code>, <code>title</code>.
+              <code>Panel</code>: see Props section for details.
             </li>
             <li>
               <code>Modal</code> does not currently manage state. If a{' '}
@@ -315,6 +314,13 @@ export default function ModalPage() {
         </Library.Pattern>
 
         <Library.Pattern title="Props">
+          <Library.Example title="props forwarded to Panel">
+            <p>
+              These props are forwarded to <code>Panel</code>:{' '}
+              <code>buttons</code>, <code>icon</code>, <code>onClose</code>,{' '}
+              <code>paddingSize</code> and <code>title</code>.
+            </p>
+          </Library.Example>
           <Library.Example title="initialFocus">
             <p>
               <code>Modal</code> will route focus when it is rendered. By

--- a/src/pattern-library/components/patterns/layout/CardPage.tsx
+++ b/src/pattern-library/components/patterns/layout/CardPage.tsx
@@ -324,6 +324,31 @@ export default function CardPage() {
               </Card>
             </Library.Demo>
           </Library.Example>
+
+          <Library.Example title="fullWidth">
+            <p>
+              In some cases, it might be desirable for the{' '}
+              <code>CardHeader</code> and its border to span the full width of
+              the <code>Card</code>.
+            </p>
+            <Library.Demo
+              title="Making a CardHeader span the full width"
+              withSource
+            >
+              <Card>
+                <CardHeader
+                  title="Full-width header"
+                  onClose={() => alert('you clicked it')}
+                  fullWidth
+                />
+                <CardContent>
+                  <div>
+                    A <code>Card</code> with <code>CardHeader</code>.
+                  </div>
+                </CardContent>
+              </Card>
+            </Library.Demo>
+          </Library.Example>
         </Library.Pattern>
       </Library.Section>
 

--- a/src/pattern-library/components/patterns/layout/PanelPage.tsx
+++ b/src/pattern-library/components/patterns/layout/PanelPage.tsx
@@ -64,9 +64,9 @@ export default function PanelPage() {
           <Library.Example title="Scrolling long content">
             <p>
               If a <code>Panel</code> is a direct child of an element with a
-              height constraint, content will scroll as needed, but not the
-              heading or buttons. This can be useful if a <code>Panel</code> is
-              needed in a constrained interface, like a modal.
+              height constraint and the <code>scrollable</code> prop is set, its
+              content will scroll if it exceeds the available height. Header and
+              buttons do not scroll.
             </p>
 
             <Library.Demo withSource>
@@ -80,6 +80,7 @@ export default function PanelPage() {
                       <Button variant="primary">Scroll</Button>
                     </>
                   }
+                  scrollable
                 >
                   <LoremIpsum />
                 </Panel>
@@ -136,6 +137,83 @@ export default function PanelPage() {
                 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
                 eiusmod tempor incididunt ut labore et dolore magna aliqua.
               </Panel>
+            </Library.Demo>
+          </Library.Example>
+
+          <Library.Example title="paddingSize">
+            <p>
+              This sizing prop defines how much padding will be used around the
+              Panel content. Set to <code>none</code> to turn off padding
+              (background colors are set here to help show effect of padding).
+            </p>
+            <Library.Demo withSource>
+              <Panel title="paddingSize: 'sm'" paddingSize="sm">
+                <div className="bg-grey-1">
+                  <LoremIpsum size="sm" />
+                </div>
+              </Panel>
+            </Library.Demo>
+
+            <Library.Demo withSource>
+              <Panel title="paddingSize: 'md' (default)" paddingSize="md">
+                <div className="bg-grey-1">
+                  <LoremIpsum size="sm" />
+                </div>
+              </Panel>
+            </Library.Demo>
+
+            <Library.Demo withSource>
+              <Panel title="paddingSize: 'lg'" paddingSize="lg">
+                <div className="bg-grey-1">
+                  <LoremIpsum size="sm" />
+                </div>
+              </Panel>
+            </Library.Demo>
+
+            <Library.Demo withSource title="No padding">
+              <Panel title="paddingSize: 'none'" paddingSize="none">
+                <div className="bg-grey-1">
+                  <LoremIpsum size="sm" />
+                </div>
+              </Panel>
+            </Library.Demo>
+          </Library.Example>
+
+          <Library.Example title="fullWidthHeader">
+            <p>
+              This boolean prop (default <code>false</code>) determines whether
+              the header of the Panel and its bottom border stretches the full
+              width of the Panel.
+            </p>
+            <Library.Demo withSource>
+              <Panel title="Panel with full-width header" fullWidthHeader>
+                <LoremIpsum size="sm" />
+              </Panel>
+            </Library.Demo>
+          </Library.Example>
+
+          <Library.Example title="scrollable">
+            <p>
+              This boolean prop (default <code>false</code>) determines whether
+              content will scroll if it exceeds height constraints. Scrollable
+              Panels have a full-width header so that scrolling shadow hints{' '}
+              {"don't"} look funky.
+            </p>
+            <Library.Demo withSource>
+              <div className="h-[300px]">
+                <Panel
+                  title="Scrolling panel"
+                  buttons={
+                    <>
+                      <Button>Cancel</Button>
+                      <Button variant="primary">Do it</Button>
+                    </>
+                  }
+                  scrollable
+                >
+                  <LoremIpsum size="lg" />
+                </Panel>
+              </div>
             </Library.Demo>
           </Library.Example>
         </Library.Pattern>


### PR DESCRIPTION
This PR provides a set of additional props for `CardHeader`, `Panel` and `Modal` to give more flexibility in layout styling.

These changes will cause a visual change to existing Modals: the border under the modal's header will now extend all the way to the edges of the modal. Existing `Panel`s are unaffected. Other props introduced here are additive (no changes to existing usage of these components).

The first problem this work attempts to solve is to make `Panel`/`Modal` headers span the full width if there is scrollable content. This is to avoid scroll hint shadows looking funky (see https://github.com/hypothesis/frontend-shared/issues/839).

I also ran into a situation recently in which it was necessary to have more control over the way that padding is applied to Panel content.

The broader fix here, so we don't end up in an arms race, is to not force all `Modal` content to be in `Panel`s (i.e. allow Modals with arbitrary content, not just Panels). I intend to make the next-generation `Dialog` component more flexible in that respect.

These changes are documented on the pattern library pages for `Card` `Panel`, and `Modal`.

Fixes https://github.com/hypothesis/frontend-shared/issues/839