### PR TITLE
Add flexibility for scrolling partial content in `Panel` and `Modal`

### DIFF
--- a/src/components/feedback/Modal.tsx
+++ b/src/components/feedback/Modal.tsx
@@ -28,7 +28,11 @@ type ComponentProps = {
   initialFocus?: RefObject<HTMLOrSVGElement | null> | 'auto' | 'manual';
 };
 
-export type ModalProps = PresentationalProps & ComponentProps & PanelProps;
+// This component forwards a number of props on to `Panel` but always sets the
+// `fullWidthHeader` prop to `true`.
+export type ModalProps = PresentationalProps &
+  ComponentProps &
+  Omit<PanelProps, 'fullWidthHeader'>;
 
 const noop = () => {};
 
@@ -48,6 +52,7 @@ const ModalNext = function Modal({
   icon,
   onClose,
   paddingSize = 'md',
+  scrollable = true,
   title,
 
   ...htmlAttributes
@@ -138,11 +143,12 @@ const ModalNext = function Modal({
       >
         <Panel
           buttons={buttons}
+          fullWidthHeader={true}
           icon={icon}
           onClose={onClose}
           paddingSize={paddingSize}
           title={title}
-          scrollable
+          scrollable={scrollable}
         >
           {children}
         </Panel>

--- a/src/components/layout/Panel.tsx
+++ b/src/components/layout/Panel.tsx
@@ -69,18 +69,27 @@ const PanelNext = function Panel({
 
   ...htmlAttributes
 }: PanelProps) {
+  // These classes are set on the content container hierarchy in this component
+  // to ensure that the overall height is constrained to height rules set on
+  // parent elements. This allows for control over scrolling content,
+  // specifically.
+  const heightConstraintClasses = 'flex flex-col min-h-0 h-full';
   const panelContent =
     paddingSize === 'none' ? (
       children
     ) : (
-      <CardContent data-testid="panel-content-wrapper" size={paddingSize}>
+      <CardContent
+        classes={heightConstraintClasses}
+        data-testid="panel-content-wrapper"
+        size={paddingSize}
+      >
         {children}
       </CardContent>
     );
   return (
     <Card
       {...htmlAttributes}
-      classes={'flex flex-col min-h-0 h-full'}
+      classes={heightConstraintClasses}
       elementRef={downcastRef(elementRef)}
       data-composite-component="Panel"
     >

--- a/src/components/layout/test/Panel-test.js
+++ b/src/components/layout/test/Panel-test.js
@@ -92,7 +92,7 @@ describe('Panel', () => {
       );
 
       assert.isAbove(
-        wrapper.find('div[data-component="CardContent"]').first().getDOMNode()
+        wrapper.find('div[data-component="CardContent"] p').first().getDOMNode()
           .clientHeight,
         200
       );

--- a/src/pattern-library/components/patterns/feedback/ModalPage.tsx
+++ b/src/pattern-library/components/patterns/feedback/ModalPage.tsx
@@ -3,17 +3,26 @@ import { useState, useRef } from 'preact/hooks';
 import {
   ArrowRightIcon,
   Button,
+  DataTable,
   EditIcon,
   IconButton,
   Input,
   InputGroup,
   Modal,
+  Scroll,
 } from '../../../../next';
 import type { ModalProps } from '../../../../components/feedback/Modal';
 import Library from '../../Library';
 import Next from '../../LibraryNext';
 
-import { LoremIpsum } from '../samples';
+import { LoremIpsum, nabokovNovels } from '../samples';
+
+const nabokovRows = nabokovNovels();
+const nabokovColumns = [
+  { field: 'title', label: 'Title' },
+  { field: 'year', label: 'Year' },
+  { field: 'language', label: 'Language' },
+];
 
 function ModalButtons() {
   return (
@@ -204,8 +213,8 @@ export default function ModalPage() {
           </ul>
           <Library.Example title="Handling long content">
             <p>
-              Content in a modal will scroll as needed to keep the modal from
-              exceeding viewport capacity.
+              By default, content in a modal will scroll as needed to keep the
+              modal from exceeding viewport capacity.
             </p>
             <Library.Demo title="Modal with overflowing content" withSource>
               <Modal_
@@ -240,51 +249,74 @@ export default function ModalPage() {
             </Library.Demo>
           </Library.Example>
 
-          <Library.Example title="Use case: setting preferred height for modal content">
+          <Library.Example title="Managing modal height">
             <p>
-              In some cases it might be desirable to set a preferred height for
-              the content of a modal, so that the modal container does not
-              resize or jump around if content changes.
+              By default, the height of a modal is dependent on the content
+              inside of it. It will grow in height as needed for the content
+              until it fills the available vertical space in the viewport, after
+              which it will (unless disabled) scroll overheight content.
             </p>
-            <p>To do this, set a minimum height on the modal content.</p>
             <p>
-              Styling in the <code>Modal</code> component should prevent content
-              from escaping the bounds of the viewport.
+              But you may wish to control the height of your modals. There are
+              two options:
             </p>
+            <ul>
+              <li>
+                <strong>Set a height on the Modal</strong> itself. The Modal
+                will always render at this height. If contained content height
+                exceeds this height, it will scroll.
+              </li>
+              <li>
+                <strong>Set a minimum height on the {"Modal's"} content</strong>
+                . The Modal will always render at least this height, but will
+                grow in height if needed to accommodate longer content (up to
+                the bounds of the viewport).
+              </li>
+            </ul>
+            <Library.Demo title="Modal with a fixed height" withSource>
+              <Modal_
+                title="Modal with a fixed height"
+                buttons={<ModalButtons />}
+                classes="h-[25rem]"
+                onClose={() => {}}
+              >
+                <p>
+                  This Modal has a height of <code>25rem</code>.
+                </p>
+              </Modal_>
+            </Library.Demo>
+
             <Library.Demo
-              title="Modal with a minimum height and not much content"
+              title="Modal with a fixed height: long content"
               withSource
             >
               <Modal_
                 title="Modal with a fixed height"
+                buttons={<ModalButtons />}
+                classes="h-[25rem]"
+                onClose={() => {}}
+              >
+                <p>
+                  This Modal has a height of <code>25rem</code> and long
+                  content.
+                </p>
+                <LoremIpsum size="lg" />
+              </Modal_>
+            </Library.Demo>
+
+            <Library.Demo
+              title="Modal with a minimum content height and not much content"
+              withSource
+            >
+              <Modal_
+                title="Modal with minimum height set on content"
                 buttons={<ModalButtons />}
                 onClose={() => {}}
               >
                 <div className="min-h-[15rem]">
                   <p>
-                    This content has a preferred height of 15rem set by a CSS
-                    class.
-                  </p>
-                </div>
-              </Modal_>
-            </Library.Demo>
-
-            <Library.Demo
-              title="Modal with a minimum height and more content"
-              withSource
-            >
-              <Modal_
-                title="Modal with a fixed height"
-                buttons={<ModalButtons />}
-                onClose={() => {}}
-              >
-                <div className="min-h-[15rem] space-y-3">
-                  <p>
-                    This modal has a preferred height of 15rem, but its content
-                    needs more space, so the modal height grows.{' '}
-                  </p>
-                  <p>
-                    <LoremIpsum size="md" />
+                    This {"Modal's"} content has a preferred height of 15rem set
+                    by a CSS class.
                   </p>
                 </div>
               </Modal_>
@@ -295,7 +327,7 @@ export default function ModalPage() {
               withSource
             >
               <Modal_
-                title="Modal with a fixed height"
+                title="Modal with a minimum height and tall content"
                 buttons={<ModalButtons />}
                 onClose={() => {}}
               >
@@ -304,6 +336,7 @@ export default function ModalPage() {
                     This modal has a preferred height of 15rem, but its content
                     exceeds the height of the viewport, and scrolls.
                   </p>
+                  <hr />
                   <p>
                     <LoremIpsum size="lg" />
                   </p>
@@ -319,6 +352,9 @@ export default function ModalPage() {
               These props are forwarded to <code>Panel</code>:{' '}
               <code>buttons</code>, <code>icon</code>, <code>onClose</code>,{' '}
               <code>paddingSize</code> and <code>title</code>.
+            </p>
+            <p>
+              <code>fullWidthHeader</code> is always <code>true</code>.
             </p>
           </Library.Example>
           <Library.Example title="initialFocus">
@@ -385,6 +421,40 @@ export default function ModalPage() {
                 width="custom"
               >
                 <LoremIpsum size="md" />
+              </Modal_>
+            </Library.Demo>
+          </Library.Example>
+
+          <Library.Example title="scrollable (default true)">
+            <p>
+              By default, Modals will scroll overflowing content. In some cases,
+              it is desireable to scroll only a portion of the content, or to
+              disable scrolling entirely.
+            </p>
+            <p>
+              This example demonstrates setting the boolean{' '}
+              <code>scrollable</code> prop to <code>false</code> and using a{' '}
+              <code>Scroll</code> component within Modal content to scroll only
+              a portion of the content.
+            </p>
+            <Library.Demo title="Manually controlling scrolling" withSource>
+              <Modal_
+                buttons={<ModalButtons />}
+                classes="h-[25rem]"
+                onClose={() => {}}
+                title="Modal with scrollable disabled"
+                scrollable={false}
+              >
+                <p>
+                  Fake {'>'} breadcrumbs {'>'} example
+                </p>
+                <Scroll>
+                  <DataTable
+                    rows={nabokovRows}
+                    columns={nabokovColumns}
+                    title="Nabokov novels"
+                  />
+                </Scroll>
               </Modal_>
             </Library.Demo>
           </Library.Example>

--- a/src/pattern-library/components/patterns/layout/PanelPage.tsx
+++ b/src/pattern-library/components/patterns/layout/PanelPage.tsx
@@ -1,5 +1,5 @@
 import { Panel } from '../../../../next';
-import { Button, EditIcon } from '../../../../next';
+import { Button, EditIcon, ScrollBox } from '../../../../next';
 import Library from '../../Library';
 import Next from '../../LibraryNext';
 
@@ -83,6 +83,33 @@ export default function PanelPage() {
                   scrollable
                 >
                   <LoremIpsum />
+                </Panel>
+              </div>
+            </Library.Demo>
+          </Library.Example>
+
+          <Library.Example title="Scrolling certain content">
+            <p>
+              It is also possible to scroll some of the content of a Panel but
+              not all of it.
+            </p>
+
+            <Library.Demo withSource>
+              <div className="h-[350px]">
+                <Panel
+                  title="Scrolling selected content"
+                  buttons={
+                    <>
+                      <Button>Buttons</Button>
+                      <Button>do not</Button>
+                      <Button variant="primary">Scroll</Button>
+                    </>
+                  }
+                >
+                  <p>This content does not scroll.</p>
+                  <ScrollBox>
+                    <LoremIpsum />
+                  </ScrollBox>
                 </Panel>
               </div>
             </Library.Demo>


### PR DESCRIPTION
We've got some complex modal-contained layouts in our LMS app. It's been a bit of a beast, but I hope I've covered most if not all of the scrolling bases at this point.

This PR allows `scrollable` to be disabled on `Modal`s because sometimes we don't want to scroll _all_ content in a modal, but only _some_ of it. Modals still are scrollable by default.

Some use-case examples have been added to the [Panel](http://localhost:4001/layout-panel) and [Modal](http://localhost:4001/feedback-modal) pattern-library pages, which I hope demonstrate the point of these changes, because they're tedious to explain :).

This stuff is tricky 😅 