### PR TITLE
Table "sparse-data" height problem demonstration

### DIFF
--- a/src/pattern-library/components/patterns/data/DataTablePage.tsx
+++ b/src/pattern-library/components/patterns/data/DataTablePage.tsx
@@ -5,6 +5,7 @@ import Library from '../../Library';
 import Next from '../../LibraryNext';
 
 import { nabokovNovels } from '../samples';
+import type { NabokovNovel } from '../samples';
 
 const nabokovRows = nabokovNovels();
 const nabokovColumns = [
@@ -14,18 +15,12 @@ const nabokovColumns = [
 ];
 
 export default function DataTablePage() {
-  const [selectedRow, setSelectedRow] = useState(
-    /** @type {nabokovRows[number]|null} */ (
-      nabokovRows[nabokovRows.length - 1]
-    )
+  const [selectedRow, setSelectedRow] = useState<NabokovNovel | null>(
+    nabokovRows[nabokovRows.length - 1]
   );
 
-  const [selectedRow2, setSelectedRow2] = useState(
-    /** @type {nabokovRows[number]|null} */ (null)
-  );
-  const [confirmedRow, setConfirmedRow] = useState(
-    /** @type {nabokovRows[number]|null} */ (null)
-  );
+  const [selectedRow2, setSelectedRow2] = useState<NabokovNovel | null>(null);
+  const [confirmedRow, setConfirmedRow] = useState<NabokovNovel | null>(null);
   return (
     <Library.Page
       title="DataTable"
@@ -152,6 +147,27 @@ export default function DataTablePage() {
               compatible with scrolling contexts. The examples on this page are
               constrained within <code>Scroll</code> components.
             </p>
+            <p>
+              <code>DataTable</code> is designed to fill its containing space
+              vertically. If there are sparse data (fewer rows than fill the
+              space), the <code>Table</code> will still occupy the full vertical
+              height.
+            </p>
+
+            <Library.Demo
+              withSource
+              title="Constrained Table with sparse content"
+            >
+              <div className="w-full h-[250px]">
+                <Scroll>
+                  <DataTable
+                    title="A subset of Nabokov's novels with publish date and original language"
+                    rows={[nabokovRows[0], nabokovRows[1]]}
+                    columns={nabokovColumns}
+                  />
+                </Scroll>
+              </div>
+            </Library.Demo>
           </Library.Example>
         </Library.Pattern>
 

--- a/src/pattern-library/components/patterns/samples.tsx
+++ b/src/pattern-library/components/patterns/samples.tsx
@@ -272,7 +272,14 @@ export function sampleTableContent() {
   };
 }
 
-export function nabokovNovels() {
+export type NabokovNovel = {
+  title: string;
+  year: string;
+  language: string;
+  translatedTitle?: string;
+};
+
+export function nabokovNovels(): NabokovNovel[] {
   return [
     {
       title: 'Машенька',


### PR DESCRIPTION
This PR is the first of a chain of work to fix the issue it demonstrates. This PR converts some sample components to TSX, and adds a "sparse data" example on the `DataTable` pattern-library page.

<img width="811" alt="image" src="https://user-images.githubusercontent.com/439947/219161784-e308de48-e4a8-4ae2-9b5f-67b14780c2a0.png">

The problem to solve is that the table rows stretch to fill the available space of the height-constrained table. We don't want that. I have a fix (that prevents the rows from stretching), but it requires touching a number of component modules (and I want to convert them to TSX as I go).