### PR TITLE
Handle layout of tables with sparse row data

### DIFF
--- a/src/components/data/DataTable.tsx
+++ b/src/components/data/DataTable.tsx
@@ -13,6 +13,7 @@ import TableHead from './TableHead';
 import TableBody from './TableBody';
 import TableRow from './TableRow';
 import TableCell from './TableCell';
+import TableFoot from './TableFoot';
 
 export type TableColumn = {
   field: string;
@@ -121,6 +122,10 @@ const DataTableNext = function DataTable<Row>({
     }
   }, [selectedRow, tableRef, scrollContext]);
 
+  // Render a <tfoot> element when there are any row data. This absorbs any
+  // excess vertical space in tables with sparse rows data.
+  const withFoot = !loading && rows.length > 0;
+
   return (
     <Table
       {...htmlAttributes}
@@ -171,6 +176,7 @@ const DataTableNext = function DataTable<Row>({
         )}
       </TableBody>
       {children}
+      {withFoot && <TableFoot />}
     </Table>
   );
 };

--- a/src/components/data/TableCell.tsx
+++ b/src/components/data/TableCell.tsx
@@ -1,14 +1,14 @@
 import classnames from 'classnames';
+import type { JSX } from 'preact';
 import { useContext } from 'preact/hooks';
 
+import type { PresentationalProps } from '../../types';
 import { downcastRef } from '../../util/typing';
 
 import TableSectionContext from './TableSectionContext';
 
-/**
- * @typedef {import('../../types').PresentationalProps} CommonProps
- * @typedef {Omit<import('preact').JSX.HTMLAttributes<HTMLElement>, 'size'>} HTMLAttributes
- */
+export type TableCellProps = PresentationalProps &
+  Omit<JSX.HTMLAttributes<HTMLElement>, 'size'>;
 
 /**
  * Render a single table cell
@@ -21,7 +21,7 @@ const TableCellNext = function TableCell({
   elementRef,
 
   ...htmlAttributes
-}) {
+}: TableCellProps) {
   const sectionContext = useContext(TableSectionContext);
   const isHeadCell = sectionContext && sectionContext.section === 'head';
   const Cell = isHeadCell ? 'th' : 'td';

--- a/src/components/data/TableCell.tsx
+++ b/src/components/data/TableCell.tsx
@@ -38,6 +38,13 @@ const TableCellNext = function TableCell({
           // on scroll with sticky headers.
           'text-left border-t border-b border-b-grey-5': isHeadCell,
           'border-none': !isHeadCell,
+          // Apply a very subtle bottom border to the last row in the table (not
+          // in the head). This can help delineate the end of data in tables
+          // with sparse row data. Only apply border if row is not selected.
+          // This uses Tailwind's nested-group syntax. See
+          // https://tailwindcss.com/docs/hover-focus-and-other-states#differentiating-nested-groups
+          'group-last/unselected:border-b group-last/unselected:border-grey-2 group-last/unselected:border-dotted':
+            !isHeadCell,
         },
         classes
       )}

--- a/src/components/data/TableFoot.tsx
+++ b/src/components/data/TableFoot.tsx
@@ -1,0 +1,48 @@
+import classnames from 'classnames';
+import type { JSX } from 'preact';
+
+import type { PresentationalProps } from '../../types';
+import { downcastRef } from '../../util/typing';
+
+import TableSectionContext from './TableSectionContext';
+import type { TableSection } from './TableSectionContext';
+
+type HTMLAttributes = JSX.HTMLAttributes<HTMLTableSectionElement>;
+
+export type TableFootProps = PresentationalProps & HTMLAttributes;
+
+/**
+ * Render a table footer section
+ */
+const TableFootNext = function TableFoot({
+  children,
+  classes,
+  elementRef,
+
+  ...htmlAttributes
+}: TableFootProps) {
+  const sectionContext: TableSection = {
+    section: 'foot',
+  };
+
+  return (
+    <TableSectionContext.Provider value={sectionContext}>
+      <tfoot
+        {...htmlAttributes}
+        data-component="TableFoot"
+        ref={downcastRef(elementRef)}
+        className={classnames(
+          // This tfoot element will take up available extra vertical space when
+          // a Table has sparse data. This prevents <TableRow>s from stretching
+          // vertically to fill extra space.
+          'h-full',
+          classes
+        )}
+      >
+        {children}
+      </tfoot>
+    </TableSectionContext.Provider>
+  );
+};
+
+export default TableFootNext;

--- a/src/components/data/TableRow.tsx
+++ b/src/components/data/TableRow.tsx
@@ -51,6 +51,8 @@ const TableRowNext = function TableRow({
           'bg-slate-7 text-color-text-inverted': selected,
           'focus-visible-ring ring-inset': tableContext?.interactive,
           'hover:bg-slate-9/[.08]': tableContext?.interactive && !selected,
+          'group/unselected': !selected,
+          'group/selected': selected,
         },
         classes
       )}

--- a/src/components/data/index.js
+++ b/src/components/data/index.js
@@ -7,6 +7,7 @@ export { default as ScrollBox } from './ScrollBox';
 export { default as Table } from './Table';
 export { default as TableBody } from './TableBody';
 export { default as TableCell } from './TableCell';
+export { default as TableFoot } from './TableFoot';
 export { default as TableHead } from './TableHead';
 export { default as TableRow } from './TableRow';
 export { default as Thumbnail } from './Thumbnail';

--- a/src/components/data/test/DataTable-test.js
+++ b/src/components/data/test/DataTable-test.js
@@ -64,6 +64,9 @@ describe('DataTable', () => {
     assert.isFalse(outer.prop('interactive'));
 
     assert.isTrue(interactiveWrapper.find('Table').props().interactive);
+    assert.isTrue(
+      interactiveWrapper.find('[data-component="TableFoot"]').exists()
+    );
   });
 
   describe('table columns', () => {
@@ -190,6 +193,11 @@ describe('DataTable', () => {
       const wrapper = createComponent(DataTable, { loading: true });
       assert.equal(wrapper.find('thead tr th').length, 3);
     });
+
+    it('does not render a TableFoot', () => {
+      const wrapper = createComponent(DataTable, { loading: true });
+      assert.isFalse(wrapper.find('[data-component="TableFoot"]').exists());
+    });
   });
 
   context('when empty', () => {
@@ -207,6 +215,13 @@ describe('DataTable', () => {
         rows: [],
       });
       assert.equal(wrapper.find('thead tr th').length, 3);
+    });
+
+    it('does not render a TableFoot', () => {
+      const wrapper = createComponent(DataTable, {
+        rows: [],
+      });
+      assert.isFalse(wrapper.find('[data-component="TableFoot"]').exists());
     });
   });
 

--- a/src/components/data/test/TableFoot-test.js
+++ b/src/components/data/test/TableFoot-test.js
@@ -1,0 +1,26 @@
+import { mount } from 'enzyme';
+
+import { testPresentationalComponent } from '../../test/common-tests';
+
+import TableFoot from '../TableFoot';
+
+describe('TableFoot', () => {
+  // Content function for shared presentational test does not wrap with context
+  // This is to ensure the component functions as expected without context
+  const contentFn = (Component, props = {}) => {
+    return mount(
+      <table>
+        <Component {...props}>
+          <tr>
+            <td>Cell content</td>
+          </tr>
+        </Component>
+      </table>
+    );
+  };
+
+  testPresentationalComponent(TableFoot, {
+    createContent: contentFn,
+    elementSelector: '[data-component="TableFoot"]',
+  });
+});

--- a/src/next.js
+++ b/src/next.js
@@ -14,6 +14,7 @@ export {
   Table,
   TableBody,
   TableCell,
+  TableFoot,
   TableHead,
   TableRow,
   Thumbnail,


### PR DESCRIPTION
This PR solves layout issues for tables with sparse row data (i.e. not enough rows to fill the table's allotted vertical space). This will allow us to use the newer `DataTable` component in some LMS contexts.

Before these changes:

![image](https://user-images.githubusercontent.com/439947/219379475-0bcbbb51-dcb2-4ee0-8ba6-213a0444711f.png)

This PR addresses this by:

* Adding an empty `<tfoot>` element to the table, via a new `TableFoot` component, which acts as a stretchy element to consume extra vertical space.
* Adding a very subtle, intentionally nearly-invisible, border to the last row of a table. This provides just the barest visual separation in case the table data ends on a row without a striped background.

After these changes:

<img width="813" alt="image" src="https://user-images.githubusercontent.com/439947/219380183-a090510e-7888-4a91-8376-de75cca78674.png">