### PR TITLE
Panel: Do not render container for buttons if there are no buttons

### DIFF
--- a/src/components/layout/Panel.tsx
+++ b/src/components/layout/Panel.tsx
@@ -98,9 +98,11 @@ const PanelNext = function Panel({
         <CardTitle>{title}</CardTitle>
       </CardHeader>
       {scrollable ? <Scroll>{panelContent}</Scroll> : <>{panelContent}</>}
-      <CardContent>
-        {buttons && <CardActions>{buttons}</CardActions>}
-      </CardContent>
+      {buttons && (
+        <CardContent data-testid="panel-buttons">
+          <CardActions>{buttons}</CardActions>
+        </CardContent>
+      )}
     </Card>
   );
 };

--- a/src/components/layout/test/Panel-test.js
+++ b/src/components/layout/test/Panel-test.js
@@ -32,6 +32,17 @@ describe('Panel', () => {
     assert.calledOnce(onClose);
   });
 
+  it('does not render a container for `buttons` if none provided', () => {
+    const buttons = <button>click me</button>;
+    const wrapper = createComponent(Panel, { buttons });
+    const noButtonWrapper = createComponent(Panel);
+
+    assert.isTrue(wrapper.find('[data-testid="panel-buttons"]').exists());
+    assert.isFalse(
+      noButtonWrapper.find('[data-testid="panel-buttons"]').exists()
+    );
+  });
+
   it('renders `buttons` as CardActions', () => {
     const buttons = <button>click me</button>;
     const wrapper = createComponent(Panel, { buttons });


### PR DESCRIPTION
This PR fixes a regression with padding at the bottom of `Panel`s that do not have any buttons.

[This commit](https://github.com/hypothesis/frontend-shared/commit/36fd07b0605fcbf878b6bab9a11dc2202701b2a1) makes a change such that `Panel` children and `Panel` buttons are rendered within separate `CardContent` components. When there are `buttons` provided to the panel, this works fine, but when there are no `buttons`, an empty `CardContent` component was being rendered. This causes excess padding on the bottom of `Panel`s. 

Before this fix:

<img width="715" alt="Screen Shot 2023-02-20 at 1 29 57 PM" src="https://user-images.githubusercontent.com/439947/220179425-57a22bdb-ec43-4056-b385-5c45ebc3a933.png">

After:

<img width="708" alt="Screen Shot 2023-02-20 at 1 30 14 PM" src="https://user-images.githubusercontent.com/439947/220179440-83d61125-9c26-46ec-b0c7-d131e41e37a7.png">



