### PR TITLE
Manually suppress warning from babel

### DIFF
--- a/src/hooks/test/use-arrow-key-navigation-test.js
+++ b/src/hooks/test/use-arrow-key-navigation-test.js
@@ -239,17 +239,11 @@ describe('useArrowKeyNavigation', () => {
       return <div />;
     }
 
-    // Suppress "Add @babel/plugin-transform-react-jsx-source to get a more
-    // detailed component stack" warning from the `render` call below.
-    sinon.stub(console, 'warn');
-
     let error;
     try {
       act(() => render(<BrokenToolbar />, container));
     } catch (e) {
       error = e;
-    } finally {
-      console.warn.restore();
     }
 
     assert.instanceOf(error, Error);

--- a/test/bootstrap.js
+++ b/test/bootstrap.js
@@ -9,6 +9,19 @@ import { Adapter } from 'enzyme-adapter-preact-pure';
 
 configure({ adapter: new Adapter() });
 
+// Suppress warning related with @babel/plugin-transform-react-jsx-source
+// See https://github.com/hypothesis/frontend-shared/issues/810
+const regularWarn = console.warn;
+console.warn = function (message, ...optionalParams) {
+  if (
+    !message?.startsWith(
+      'Add @babel/plugin-transform-react-jsx-source to get a more detailed component stack'
+    )
+  ) {
+    regularWarn(message, ...optionalParams);
+  }
+};
+
 // Ensure that uncaught exceptions between tests result in the tests failing.
 // This works around an issue with mocha / karma-mocha, see
 // https://github.com/hypothesis/client/issues/2249.


### PR DESCRIPTION
This is a hacky workaround to get rid of the babel warning reported in #810

It basically overwrites `console.warn` during tests bootstrapping, so that if the message being reported is the aforementioned warning, we can totally discard it, and use the original `console.warn` in any other case, preventing other side effects.

This is not the ideal solution, but finding the proper one is turning out to be challenging, and this is pretty simple.