### PR TITLE
Fix babel warning related with `@babel/plugin-transform-react-jsx-source` plugin

### DIFF
--- a/rollup-tests.config.js
+++ b/rollup-tests.config.js
@@ -12,6 +12,12 @@ export default {
     sourcemap: true,
   },
   treeshake: false,
+  // Suppress a warning (https://rollupjs.org/guide/en/#error-this-is-undefined)
+  // due to https://github.com/babel/babel/issues/9149.
+  //
+  // Any code string other than "undefined" which evaluates to `undefined` will
+  // work here.
+  context: 'void(0)',
   plugins: [
     // Replace some problematic dependencies which are imported but not actually
     // used with stubs. Per @rollup/plugin-virtual's docs, this must be listed
@@ -53,16 +59,19 @@ export default {
         [
           '@babel/preset-react',
           {
-            // Turn off the `development` setting in tests to prevent warnings
-            // about `this`. See https://github.com/babel/babel/issues/9149.
-            development: false,
+            development: true,
             runtime: 'automatic',
             importSource: 'preact',
           },
         ],
       ],
       plugins: [
-        'mockable-imports',
+        [
+          'mockable-imports',
+          {
+            excludeDirs: ['test', 'icons', 'pattern-library'],
+          },
+        ],
         [
           'babel-plugin-istanbul',
           {


### PR DESCRIPTION
This is a work in progress attempt to fix #810 

According to the warning, we need to install `@babel/plugin-transform-react-jsx-source`. This plugin comes with `@babel/preset-react`, which we are already using.

However, it only works if `development` is `true` on the preset's config.

We could not set that to `true` because it was causing another warning reported here: https://github.com/babel/babel/issues/9149

This PR does the following:

* Set `development: true` on babel's preset config
* ~Add a simple babel plugin which addresses https://github.com/babel/babel/issues/9149 (it comes from a comment in that same issue)~
* Set `context: 'void(0)'` in rollup's config, to address https://github.com/babel/babel/issues/9149
* Disable some paths on `babel-plugin-mockable-imports` which also have a miss-behavior when `development` is `true`.

**This does not yet fix the problem**, but takes us a bit closer.

The warning is still there, but by debugging the resulting file from transpiling the tests with babel, I have confirmed the information required to avoid the warning is there in "most?" of the cases.

I have also added some `console.log`'s in `preact/debug`, where the warning is triggered, and confirmed `__source` is most of the times set, but still `undefined` in a couple of scenarios. Before the changes made on this PR, it was always `undefined`.

If we manage to find the missing piece, #867 would no longer be required.