### PR TITLE
Allow override of `data*-component` attributes

### DIFF
--- a/plop-templates/composite-component.hbs
+++ b/plop-templates/composite-component.hbs
@@ -29,6 +29,7 @@ const {{name}}Next = function {{name}}({
 }:{{name}}Props) {
   return (
     <div
+      data-composite-component="{{name}}"
       {...htmlAttributes}
       ref={downcastRef(elementRef)}
       className={classnames(
@@ -43,7 +44,6 @@ const {{name}}Next = function {{name}}({
           'p-4': size === 'lg',
         },
       )}
-      data-composite-component="{{name}}"
     >
       {children}
     </div>

--- a/plop-templates/presentational-component.hbs
+++ b/plop-templates/presentational-component.hbs
@@ -28,6 +28,7 @@ const {{name}}Next = function {{name}}({
 }: {{name}}Props) {
   return (
     <div
+      data-component="{{name}}"
       {...htmlAttributes}
       ref={downcastRef(elementRef)}
       className={classnames(
@@ -43,7 +44,6 @@ const {{name}}Next = function {{name}}({
         },
         classes
       )}
-      data-component="{{name}}"
     >
       {children}
     </div>

--- a/src/components/data/DataTable.tsx
+++ b/src/components/data/DataTable.tsx
@@ -128,13 +128,13 @@ const DataTableNext = function DataTable<Row>({
 
   return (
     <Table
+      data-composite-component="DataTable"
+      role="grid"
       {...htmlAttributes}
       title={title}
       elementRef={downcastRef(tableRef)}
       interactive={!!(onSelectRow || onConfirmRow)}
       stickyHeader={true}
-      role="grid"
-      data-composite-component="DataTable"
     >
       <TableHead>
         <TableRow>

--- a/src/components/data/Scroll.js
+++ b/src/components/data/Scroll.js
@@ -38,6 +38,7 @@ const ScrollNext = function Scroll({
   return (
     <ScrollContext.Provider value={scrollContext}>
       <div
+        data-component="Scroll"
         {...htmlAttributes}
         ref={downcastRef(ref)}
         className={classnames(
@@ -48,7 +49,6 @@ const ScrollNext = function Scroll({
           { 'scroll-shadows': variant === 'raised' },
           classes
         )}
-        data-component="Scroll"
       >
         {children}
       </div>

--- a/src/components/data/ScrollBox.js
+++ b/src/components/data/ScrollBox.js
@@ -26,10 +26,10 @@ const ScrollBoxNext = function ScrollBox({
 }) {
   return (
     <ScrollContainer
+      data-composite-component="ScrollBox"
       {...htmlAttributes}
       borderless={borderless}
       elementRef={elementRef}
-      data-composite-component="ScrollBox"
     >
       <Scroll>
         <ScrollContent>{children}</ScrollContent>

--- a/src/components/data/ScrollContainer.js
+++ b/src/components/data/ScrollContainer.js
@@ -27,6 +27,7 @@ const ScrollContainerNext = function ScrollContainer({
 }) {
   return (
     <div
+      data-component="ScrollContainer"
       {...htmlAttributes}
       ref={downcastRef(elementRef)}
       className={classnames(
@@ -37,7 +38,6 @@ const ScrollContainerNext = function ScrollContainer({
         { border: !borderless },
         classes
       )}
-      data-component="ScrollContainer"
     >
       {children}
     </div>

--- a/src/components/data/ScrollContent.js
+++ b/src/components/data/ScrollContent.js
@@ -20,10 +20,10 @@ const ScrollContentNext = function ScrollContent({
 }) {
   return (
     <div
+      data-component="ScrollContent"
       {...htmlAttributes}
       ref={downcastRef(elementRef)}
       className={classnames('px-3 py-2', classes)}
-      data-component="ScrollContent"
     >
       {children}
     </div>

--- a/src/components/data/Table.js
+++ b/src/components/data/Table.js
@@ -42,6 +42,7 @@ const TableNext = function Table({
   return (
     <TableContext.Provider value={tableContext}>
       <table
+        data-component="Table"
         {...htmlAttributes}
         aria-label={title}
         className={classnames(
@@ -60,7 +61,6 @@ const TableNext = function Table({
           classes
         )}
         ref={downcastRef(ref)}
-        data-component="Table"
       >
         {children}
       </table>

--- a/src/components/data/TableBody.js
+++ b/src/components/data/TableBody.js
@@ -32,13 +32,13 @@ const TableBodyNext = function TableBody({
   return (
     <TableSectionContext.Provider value={sectionContext}>
       <tbody
+        data-component="TableBody"
         {...htmlAttributes}
         ref={downcastRef(elementRef)}
         className={classnames(
           { 'cursor-pointer': tableContext?.interactive },
           classes
         )}
-        data-component="TableBody"
       >
         {children}
       </tbody>

--- a/src/components/data/TableCell.tsx
+++ b/src/components/data/TableCell.tsx
@@ -28,6 +28,7 @@ const TableCellNext = function TableCell({
 
   return (
     <Cell
+      data-component="TableCell"
       {...htmlAttributes}
       ref={downcastRef(elementRef)}
       className={classnames(
@@ -48,7 +49,6 @@ const TableCellNext = function TableCell({
         },
         classes
       )}
-      data-component="TableCell"
       scope={isHeadCell ? 'col' : undefined}
     >
       {children}

--- a/src/components/data/TableFoot.tsx
+++ b/src/components/data/TableFoot.tsx
@@ -28,8 +28,8 @@ const TableFootNext = function TableFoot({
   return (
     <TableSectionContext.Provider value={sectionContext}>
       <tfoot
-        {...htmlAttributes}
         data-component="TableFoot"
+        {...htmlAttributes}
         ref={downcastRef(elementRef)}
         className={classnames(
           // This tfoot element will take up available extra vertical space when

--- a/src/components/data/TableHead.js
+++ b/src/components/data/TableHead.js
@@ -33,6 +33,7 @@ const TableHeadNext = function TableHead({
   return (
     <TableSectionContext.Provider value={sectionContext}>
       <thead
+        data-component="TableHead"
         {...htmlAttributes}
         ref={downcastRef(elementRef)}
         className={classnames(
@@ -42,7 +43,6 @@ const TableHeadNext = function TableHead({
           },
           classes
         )}
-        data-component="TableHead"
       >
         {children}
       </thead>

--- a/src/components/data/TableRow.tsx
+++ b/src/components/data/TableRow.tsx
@@ -40,6 +40,7 @@ const TableRowNext = function TableRow({
 
   return (
     <tr
+      data-component="TableRow"
       {...htmlAttributes}
       aria-selected={selected}
       ref={downcastRef(rowRef)}
@@ -56,7 +57,6 @@ const TableRowNext = function TableRow({
         },
         classes
       )}
-      data-component="TableRow"
       data-section={isHeadRow ? 'head' : 'body'}
     >
       {children}

--- a/src/components/data/Thumbnail.js
+++ b/src/components/data/Thumbnail.js
@@ -56,6 +56,7 @@ const ThumbnailNext = function Thumbnail({
 
   return (
     <div
+      data-composite-component="Thumbnail"
       {...htmlAttributes}
       ref={downcastRef(elementRef)}
       className={classnames('bg-grey-1 w-full h-full overflow-hidden', {
@@ -64,7 +65,6 @@ const ThumbnailNext = function Thumbnail({
         'p-4': size === 'lg' && !borderless,
         'p-0': borderless,
       })}
-      data-composite-component="Thumbnail"
     >
       <div className="bg-white h-full w-full flex items-center justify-center overflow-hidden">
         <AspectRatio ratio={ratio}>

--- a/src/components/feedback/Modal.tsx
+++ b/src/components/feedback/Modal.tsx
@@ -113,6 +113,7 @@ const ModalNext = function Modal({
   return (
     <Overlay>
       <div
+        data-component="Modal"
         tabIndex={-1}
         // NB: Role can be overridden with an HTML attribute; this is purposeful
         role="dialog"
@@ -138,7 +139,6 @@ const ModalNext = function Modal({
           },
           classes
         )}
-        data-component="Modal"
         ref={downcastRef(modalRef)}
       >
         <Panel

--- a/src/components/feedback/SpinnerOverlay.js
+++ b/src/components/feedback/SpinnerOverlay.js
@@ -13,9 +13,9 @@ import Spinner from './Spinner';
 const SpinnerOverlayNext = function SpinnerOverlay({ ...htmlAttributes }) {
   return (
     <Overlay
+      data-composite-component="SpinnerOverlay"
       {...htmlAttributes}
       variant="light"
-      data-composite-component="SpinnerOverlay"
     >
       <Spinner size="lg" />
     </Overlay>

--- a/src/components/input/Button.js
+++ b/src/components/input/Button.js
@@ -40,6 +40,7 @@ const ButtonNext = function Button({
 }) {
   return (
     <ButtonBase
+      data-component="Button"
       {...htmlAttributes}
       classes={classnames(
         'focus-visible-ring transition-colors whitespace-nowrap flex items-center',
@@ -64,7 +65,6 @@ const ButtonNext = function Button({
       expanded={expanded}
       pressed={pressed}
       title={title}
-      data-component="Button"
       unstyled
     >
       {Icon && <Icon className="w-em h-em" />}

--- a/src/components/input/IconButton.js
+++ b/src/components/input/IconButton.js
@@ -46,6 +46,7 @@ const IconButtonNext = function IconButton({
 }) {
   return (
     <ButtonBase
+      data-component="IconButton"
       {...htmlAttributes}
       classes={classnames(
         'focus-visible-ring transition-colors whitespace-nowrap flex items-center',
@@ -77,7 +78,6 @@ const IconButtonNext = function IconButton({
       title={title}
       pressed={pressed}
       expanded={expanded}
-      data-component="IconButton"
       unstyled
     >
       {Icon && <Icon className="w-em h-em" />}

--- a/src/components/input/Input.tsx
+++ b/src/components/input/Input.tsx
@@ -26,11 +26,11 @@ const InputNext = function Input({
 }: InputProps) {
   return (
     <InputRoot
+      data-component="Input"
       elementRef={downcastRef(elementRef)}
       type={type}
       hasError={hasError}
       {...htmlAttributes}
-      data-component="Input"
     />
   );
 };

--- a/src/components/input/InputGroup.js
+++ b/src/components/input/InputGroup.js
@@ -32,6 +32,7 @@ const InputGroupNext = function InputGroup({
 }) {
   return (
     <div
+      data-component="InputGroup"
       {...htmlAttributes}
       ref={downcastRef(elementRef)}
       className={classnames(
@@ -41,7 +42,6 @@ const InputGroupNext = function InputGroup({
         'flex items-stretch w-full justify-center',
         classes
       )}
-      data-component="InputGroup"
     >
       {children}
     </div>

--- a/src/components/input/Select.tsx
+++ b/src/components/input/Select.tsx
@@ -30,6 +30,7 @@ const SelectNext = function Select({
 }: SelectProps) {
   return (
     <InputRoot
+      data-component="Select"
       classes={classnames(
         'appearance-none',
         // position the down-arrow image centered at the right, offset from the
@@ -45,7 +46,6 @@ const SelectNext = function Select({
         backgroundImage: arrowImage,
       }}
       {...htmlAttributes}
-      data-component="Select"
     >
       {children}
     </InputRoot>

--- a/src/components/layout/Card.js
+++ b/src/components/layout/Card.js
@@ -34,6 +34,7 @@ const CardNext = function Card({
 }) {
   return (
     <div
+      data-component="Card"
       {...htmlAttributes}
       ref={downcastRef(elementRef)}
       className={classnames(
@@ -49,7 +50,6 @@ const CardNext = function Card({
         },
         classes
       )}
-      data-component="Card"
     >
       {children}
     </div>

--- a/src/components/layout/CardActions.js
+++ b/src/components/layout/CardActions.js
@@ -21,10 +21,10 @@ const CardActionsNext = function CardActions({
 }) {
   return (
     <div
+      data-component="CardActions"
       {...htmlAttributes}
       className={classnames('flex items-center justify-end space-x-3', classes)}
       ref={downcastRef(elementRef)}
-      data-component="CardActions"
     >
       {children}
     </div>

--- a/src/components/layout/CardContent.js
+++ b/src/components/layout/CardContent.js
@@ -26,6 +26,7 @@ const CardContentNext = function CardContent({
 }) {
   return (
     <div
+      data-component="CardContent"
       {...htmlAttributes}
       ref={downcastRef(elementRef)}
       className={classnames(
@@ -36,7 +37,6 @@ const CardContentNext = function CardContent({
         },
         classes
       )}
-      data-component="CardContent"
     >
       {children}
     </div>

--- a/src/components/layout/CardHeader.tsx
+++ b/src/components/layout/CardHeader.tsx
@@ -46,6 +46,7 @@ const CardHeaderNext = function CardHeader({
 }: CardHeaderProps) {
   return (
     <div
+      data-component="CardHeader"
       {...htmlAttributes}
       className={classnames(
         'flex items-center gap-x-2 border-b py-2',
@@ -53,7 +54,6 @@ const CardHeaderNext = function CardHeader({
         classes
       )}
       ref={downcastRef(elementRef)}
-      data-component="CardHeader"
     >
       {title && <CardTitle>{title}</CardTitle>}
       {children}

--- a/src/components/layout/CardTitle.js
+++ b/src/components/layout/CardTitle.js
@@ -22,10 +22,10 @@ const CardTitleNext = function CardTitle({
 }) {
   return (
     <div
+      data-component="CardTitle"
       {...htmlAttributes}
       className={classnames('grow text-lg text-brand font-semibold', classes)}
       ref={downcastRef(elementRef)}
-      data-component="CardTitle"
     >
       {children}
     </div>

--- a/src/components/layout/Overlay.js
+++ b/src/components/layout/Overlay.js
@@ -32,6 +32,7 @@ const OverlayNext = function Overlay({
 
   return (
     <div
+      data-component="Overlay"
       {...htmlAttributes}
       ref={downcastRef(elementRef)}
       className={classnames(
@@ -42,7 +43,6 @@ const OverlayNext = function Overlay({
         },
         classes
       )}
-      data-component="Overlay"
     >
       {children}
     </div>

--- a/src/components/layout/Panel.tsx
+++ b/src/components/layout/Panel.tsx
@@ -88,10 +88,10 @@ const PanelNext = function Panel({
     );
   return (
     <Card
+      data-composite-component="Panel"
       {...htmlAttributes}
       classes={heightConstraintClasses}
       elementRef={downcastRef(elementRef)}
-      data-composite-component="Panel"
     >
       <CardHeader onClose={onClose} fullWidth={scrollable || fullWidthHeader}>
         {Icon && <Icon className="w-em h-em" />}

--- a/src/components/navigation/Link.js
+++ b/src/components/navigation/Link.js
@@ -30,6 +30,7 @@ const LinkNext = function Link({
 }) {
   return (
     <LinkBase
+      data-component="Link"
       {...htmlAttributes}
       classes={classnames(
         'rounded-sm',
@@ -49,7 +50,6 @@ const LinkNext = function Link({
         classes
       )}
       elementRef={downcastRef(elementRef)}
-      data-component="Link"
     >
       {children}
     </LinkBase>

--- a/src/components/navigation/LinkButton.js
+++ b/src/components/navigation/LinkButton.js
@@ -35,6 +35,7 @@ const LinkButtonNext = function LinkButton({
 }) {
   return (
     <ButtonBase
+      data-component="LinkButton"
       {...htmlAttributes}
       elementRef={downcastRef(elementRef)}
       classes={classnames(
@@ -65,7 +66,6 @@ const LinkButtonNext = function LinkButton({
         },
         classes
       )}
-      data-component="LinkButton"
       unstyled
     >
       {children}

--- a/src/components/navigation/PointerButton.tsx
+++ b/src/components/navigation/PointerButton.tsx
@@ -51,6 +51,7 @@ const PointerButtonNext = function PointerButton({
 }: PointerButtonProps) {
   return (
     <ButtonBase
+      data-component="PointerButton"
       {...htmlAttributes}
       elementRef={downcastRef(elementRef)}
       classes={classnames(
@@ -122,7 +123,6 @@ const PointerButtonNext = function PointerButton({
         },
         classes
       )}
-      data-component="PointerButton"
       expanded={expanded}
       pressed={pressed}
       title={title}

--- a/src/components/navigation/Tab.tsx
+++ b/src/components/navigation/Tab.tsx
@@ -42,6 +42,7 @@ const TabNext = function Tab({
 }: TabProps) {
   return (
     <ButtonBase
+      data-component="Tab"
       {...htmlAttributes}
       classes={classnames(
         'gap-x-1.5 enabled:hover:text-brand-dark',
@@ -53,7 +54,6 @@ const TabNext = function Tab({
       elementRef={downcastRef(elementRef)}
       aria-selected={selected}
       role="tab"
-      data-component="Tab"
     >
       {Icon && (
         <Icon

--- a/src/components/navigation/TabList.tsx
+++ b/src/components/navigation/TabList.tsx
@@ -43,12 +43,12 @@ const TabListNext = function TabList({
 
   return (
     <div
+      data-component="TabList"
       {...htmlAttributes}
       ref={downcastRef(tabListRef)}
       className={classnames('flex', { 'flex-col': vertical }, classes)}
       role="tablist"
       aria-orientation={vertical ? 'vertical' : 'horizontal'}
-      data-component="TabList"
     >
       {children}
     </div>


### PR DESCRIPTION
There are legitimate reasons for components to override the `data-component` or `data-composite-component` attributes of another component, and I'm moving toward a philosophy — which I need to articulate in the near future — that permissiveness on overrides and control is the path to success. This PR ensures that all relevant components allow override of these attributes.

In one case, the `DataTable` component, `role` has been changed to be override-able, but otherwise I've kept my hands off other (non-`data*-component`) attributes.

Fixes #705