### PR TITLE
Remove custom `aria-` Tailwind variants

### DIFF
--- a/src/pattern-library/components/patterns/UtilitiesPage.js
+++ b/src/pattern-library/components/patterns/UtilitiesPage.js
@@ -53,26 +53,7 @@ export default function UtilitiesPage() {
           This package also provides some tailwind variants (modifiers) that can
           be combined with other tailwind utility classes.
         </p>
-        <Library.Example title="ARIA variants">
-          <p>
-            Tailwind does not provide out-of-the-box <code>aria-*</code>{' '}
-            variants. This package provides <code>aria-pressed</code> and{' '}
-            <code>aria-expanded</code>.
-          </p>
-          <Library.Demo title="button with `aria-pressed` styling" withSource>
-            <button aria-pressed className="border p-2 aria-pressed:bg-slate-1">
-              Button
-            </button>
-          </Library.Demo>
-          <Library.Demo title="button with `aria-expanded` styling" withSource>
-            <button
-              aria-expanded
-              className="border p-2 aria-expanded:bg-slate-7 aria-expanded:text-color-text-inverted"
-            >
-              Button
-            </button>
-          </Library.Demo>
-        </Library.Example>
+
         <Library.Example title="Styling groups of inputs">
           <p>
             The <code>input-group</code> modifier allows adaptation of styling

--- a/src/tailwind.preset.js
+++ b/src/tailwind.preset.js
@@ -121,9 +121,6 @@ export default /** @type {Partial<import('tailwindcss').Config>} */ ({
       // only apply (set the element's background color to white) if a parent
       // element had the `.theme-clean` class.
       addVariant('theme-clean', '.theme-clean &');
-      // Tailwind does not provide variants for ARIA-attributes out of the box
-      addVariant('aria-pressed', '&[aria-pressed="true"]');
-      addVariant('aria-expanded', '&[aria-expanded="true"]');
     }),
   ],
 });


### PR DESCRIPTION
As of Tailwind 3.2, `aria-*` variants are now provided out of the box. We implemented our own custom versions exactly as the Tailwind-provided variants work, so these variants will continue to work as they did without having to define them in config.

Part of #743