### PR TITLE
Remove no-longer needed TS error suppression

### DIFF
--- a/src/components/input/InputRoot.tsx
+++ b/src/components/input/InputRoot.tsx
@@ -30,8 +30,6 @@ const InputRootNext = function InputRoot({
 
   ...htmlAttributes
 }: InputRootProps) {
-  // TODO Remove next line once updated to preact 10.13.0
-  // @ts-ignore-next - "aria-label" is missing from HTMLInputAttributes.
   if (!htmlAttributes.id && !htmlAttributes['aria-label']) {
     console.warn(
       '`Input` component should have either an `id` or an `aria-label` attribute'


### PR DESCRIPTION
Now that we have updated to preact 10.13, this TS error suppression is no longer needed.