### PR TITLE
Ensure `useElementShouldClose` hook is available in `next` entrypoint

### DIFF
--- a/src/next.ts
+++ b/src/next.ts
@@ -1,5 +1,6 @@
 // Hooks
 export { useArrowKeyNavigation } from './hooks/use-arrow-key-navigation';
+export { useElementShouldClose } from './hooks/use-element-should-close';
 export { useSyncedRef } from './hooks/use-synced-ref';
 
 // Components


### PR DESCRIPTION
This tiny PR ensures that the still-used hook `useElementShouldClose` is available in the `next` entrypoint, which in v6.0 will be _the_ package entrypoint.

Part of https://github.com/hypothesis/frontend-shared/issues/876