### PR TITLE
Establish new `Dialog` component and assets

### DIFF
--- a/src/components/feedback/Dialog.tsx
+++ b/src/components/feedback/Dialog.tsx
@@ -1,0 +1,158 @@
+import classnames from 'classnames';
+import type { RefObject } from 'preact';
+import { useEffect, useLayoutEffect } from 'preact/hooks';
+
+import { useElementShouldClose } from '../../hooks/use-element-should-close';
+import { useSyncedRef } from '../../hooks/use-synced-ref';
+import { useUniqueId } from '../../hooks/use-unique-id';
+import type { PresentationalProps } from '../../types';
+import { downcastRef } from '../../util/typing';
+import Overlay from '../layout/Overlay';
+import Panel from '../layout/Panel';
+import type { PanelProps } from '../layout/Panel';
+
+type ComponentProps = {
+  /**
+   * Dialog _should_ be provided with a close handler. We have a few edge use
+   * cases, however, in which we need to render a "non-closeable" modal.
+   */
+  onClose?: () => void;
+  width?: 'sm' | 'md' | 'lg' | 'custom';
+  /**
+   * Element that should take focus when the Dialog is first rendered. When not
+   * provided ("auto"), the dialog's outer element will take focus. Setting this
+   * prop to "manual" will opt out of focus routing.
+   */
+  initialFocus?: RefObject<HTMLOrSVGElement | null> | 'auto' | 'manual';
+};
+
+// This component forwards a number of props on to `Panel` but always sets the
+// `fullWidthHeader` prop to `true`.
+export type DialogProps = PresentationalProps &
+  ComponentProps &
+  Omit<PanelProps, 'fullWidthHeader'>;
+
+const noop = () => {};
+
+/**
+ * Show a modal
+ */
+const DialogNext = function Dialog({
+  children,
+  width = 'md',
+
+  classes,
+  elementRef,
+  initialFocus = 'auto',
+
+  // Forwarded to Panel
+  buttons,
+  icon,
+  onClose,
+  paddingSize = 'md',
+  scrollable = true,
+  title,
+
+  ...htmlAttributes
+}: DialogProps) {
+  const modalRef = useSyncedRef(elementRef);
+  const closeHandler = onClose ?? noop;
+  useElementShouldClose(modalRef, true, closeHandler);
+
+  const dialogDescriptionId = useUniqueId('dialog-description');
+
+  useEffect(() => {
+    if (initialFocus === 'manual') {
+      return;
+    }
+    if (initialFocus === 'auto') {
+      // An explicit `initialFocus` has not be set, so use automatic focus
+      // handling. Modern accessibility guidance is to focus the dialog itself
+      // rather than trying to be smart about focusing a particular control
+      // within the dialog.
+      modalRef.current?.focus();
+      return;
+    }
+
+    const focusEl = initialFocus?.current as HTMLElement & {
+      disabled?: boolean;
+    };
+
+    if (focusEl && !focusEl.disabled) {
+      focusEl.focus();
+    } else {
+      // Fall back to focusing the modal itself
+      modalRef.current?.focus();
+      return;
+    }
+
+    // We only want to run this effect once when the dialog is mounted.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useLayoutEffect(
+    /**
+     * Try to assign the dialog an accessible description, using the content of
+     * the first paragraph of text within it.
+     *
+     * A limitation of this approach is that it doesn't update if the dialog's
+     * content changes after the initial render.
+     */
+    () => {
+      const description = modalRef?.current?.querySelector('p');
+      if (description) {
+        description.id = dialogDescriptionId;
+        modalRef.current!.setAttribute('aria-describedby', dialogDescriptionId);
+      }
+    },
+    [dialogDescriptionId, modalRef]
+  );
+
+  return (
+    <Overlay>
+      <div
+        data-component="Dialog"
+        tabIndex={-1}
+        // NB: Role can be overridden with an HTML attribute; this is purposeful
+        role="dialog"
+        {...htmlAttributes}
+        className={classnames(
+          // Maximum width and height should not exceed 90vw/h
+          'max-w-[90vw] max-h-[90vh]',
+          // Overlay sets up a flex layout centered on both axes. For taller
+          // viewports, remove this modal container from the flex flow with
+          // fixed positioning and position it 10vh from the top of the
+          // viewport. This feels more balanced on taller screens. Ensure an
+          // equal 10vh gap at the bottom of the screen by adjusting max-height
+          // to `80vh`.
+          'tall:fixed tall:max-h-[80vh] tall:top-[10vh]',
+          // Column-flex layout to constrain content to max-height
+          'flex flex-col',
+          {
+            // Max-width rules will ensure actual width never exceeds 90vw
+            'w-[30rem]': width === 'sm',
+            'w-[36rem]': width === 'md', // default
+            'w-[42rem]': width === 'lg',
+            // No width classes are added if width is 'custom'
+          },
+          classes
+        )}
+        ref={downcastRef(modalRef)}
+      >
+        <Panel
+          buttons={buttons}
+          fullWidthHeader={true}
+          icon={icon}
+          onClose={onClose}
+          paddingSize={paddingSize}
+          title={title}
+          scrollable={scrollable}
+        >
+          {children}
+        </Panel>
+      </div>
+    </Overlay>
+  );
+};
+
+export default DialogNext;

--- a/src/components/feedback/index.ts
+++ b/src/components/feedback/index.ts
@@ -1,7 +1,9 @@
+export { default as Dialog } from './Dialog';
 export { default as Modal } from './Modal';
 export { default as Spinner } from './Spinner';
 export { default as SpinnerOverlay } from './SpinnerOverlay';
 
+export type { DialogProps } from './Dialog';
 export type { ModalProps } from './Modal';
 export type { SpinnerProps } from './Spinner';
 export type { SpinnerOverlayProps } from './SpinnerOverlay';

--- a/src/components/feedback/test/Dialog-test.js
+++ b/src/components/feedback/test/Dialog-test.js
@@ -1,0 +1,135 @@
+import { mount } from 'enzyme';
+import { createRef } from 'preact';
+
+import { testPresentationalComponent } from '../../test/common-tests';
+import Dialog from '../Dialog';
+
+const createComponent = (Component, props = {}) => {
+  return mount(
+    <Component title="Test title" onClose={() => {}} {...props}>
+      This is child content
+    </Component>
+  );
+};
+
+describe('Dialog', () => {
+  testPresentationalComponent(Dialog, {
+    createContent: createComponent,
+    elementSelector: 'div[data-component="Dialog"]',
+  });
+
+  describe('initial focus', () => {
+    let container;
+
+    beforeEach(() => {
+      container = document.createElement('div');
+      document.body.appendChild(container);
+    });
+
+    afterEach(() => {
+      container.remove();
+    });
+
+    it('focuses the element referred to by `initialFocus`', () => {
+      const inputRef = createRef();
+
+      mount(
+        <Dialog initialFocus={inputRef} title="My dialog">
+          <input ref={inputRef} />
+        </Dialog>,
+        { attachTo: container }
+      );
+
+      assert.equal(document.activeElement, inputRef.current);
+    });
+
+    it('focuses the dialog itself if `initialFocus` prop is missing', () => {
+      const wrapper = mount(
+        <Dialog title="My dialog">
+          <div>Test</div>
+        </Dialog>,
+        { attachTo: container }
+      );
+
+      assert.equal(
+        document.activeElement,
+        wrapper.find('[role="dialog"]').getDOMNode()
+      );
+    });
+
+    it('does not set focus if `initialFocus` is set to "manual"', () => {
+      const focusedBefore = document.activeElement;
+      mount(
+        <Dialog initialFocus={'manual'} title="My dialog">
+          <div>Test</div>
+        </Dialog>,
+        { attachTo: container }
+      );
+
+      assert.equal(document.activeElement, focusedBefore);
+    });
+
+    it('focuses the dialog if `initialFocus` element is disabled', () => {
+      const inputRef = createRef();
+
+      const wrapper = mount(
+        <Dialog initialFocus={inputRef} title="My dialog">
+          <button ref={inputRef} disabled={true} />
+        </Dialog>,
+        { attachTo: container }
+      );
+
+      assert.equal(
+        document.activeElement,
+        wrapper.find('[role="dialog"]').getDOMNode()
+      );
+    });
+  });
+
+  describe('closing the dialog', () => {
+    it('closes when `ESC` pressed', () => {
+      const onClose = sinon.stub();
+      const container = document.createElement('div');
+      document.body.appendChild(container);
+      mount(
+        <Dialog title="Test dialog" onClose={onClose}>
+          This is my dialog
+        </Dialog>,
+        {
+          attachTo: container,
+        }
+      );
+
+      const event = new Event('keydown');
+      event.key = 'Escape';
+      document.body.dispatchEvent(event);
+      assert.called(onClose);
+      container.remove();
+    });
+  });
+
+  describe('aria-describedby', () => {
+    it("marks the first `<p>` in the dialog's content as the accessible description", () => {
+      const wrapper = mount(
+        <Dialog title="My dialog">
+          <p>Enter a URL</p>
+        </Dialog>
+      );
+      const content = wrapper.find('[role="dialog"]').getDOMNode();
+      const paragraphEl = wrapper.find('p').getDOMNode();
+
+      assert.ok(content.getAttribute('aria-describedby'));
+      assert.equal(content.getAttribute('aria-describedby'), paragraphEl.id);
+    });
+
+    it("does not set an accessible description if the dialog's content does not have a `<p>`", () => {
+      const wrapper = mount(
+        <Dialog title="My dialog">
+          <button>Click me</button>
+        </Dialog>
+      );
+      const content = wrapper.find('[role="dialog"]').getDOMNode();
+      assert.isNull(content.getAttribute('aria-describedby'));
+    });
+  });
+});

--- a/src/pattern-library/components/patterns/feedback/DialogPage.tsx
+++ b/src/pattern-library/components/patterns/feedback/DialogPage.tsx
@@ -1,0 +1,122 @@
+import { useState, useRef } from 'preact/hooks';
+
+import { Dialog } from '../../../../components/feedback';
+import type { DialogProps } from '../../../../components/feedback/Dialog';
+import {
+  ArrowRightIcon,
+  Button,
+  EditIcon,
+  IconButton,
+  Input,
+  InputGroup,
+} from '../../../../next';
+import Library from '../../Library';
+
+function DialogButtons() {
+  return (
+    <>
+      <Button key="maybe" onClick={() => alert('You chose maybe')}>
+        Maybe
+      </Button>
+      <Button
+        key="yep"
+        onClick={() => alert('You chose yep')}
+        variant="primary"
+      >
+        Do it!
+      </Button>
+    </>
+  );
+}
+
+type Dialog_Props = DialogProps & {
+  /** Pattern-wrapping prop. Not visible in source view */
+  _nonCloseable?: boolean;
+};
+
+/**
+ * Wrap the Dialog component with some state management to make reuse in
+ * multiple examples plausible and convenient.
+ */
+function Dialog_({
+  buttons,
+  _nonCloseable,
+  children,
+  ...dialogProps
+}: Dialog_Props) {
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const closeDialog = () => setDialogOpen(false);
+
+  const closeHandler = _nonCloseable ? undefined : closeDialog;
+  const forwardedButtons = buttons ? (
+    buttons
+  ) : (
+    <Button onClick={closeDialog}>Escape!</Button>
+  );
+
+  if (!dialogOpen) {
+    return (
+      <Button onClick={() => setDialogOpen(!dialogOpen)} variant="primary">
+        Show dialog
+      </Button>
+    );
+  } else {
+    return (
+      <Dialog
+        buttons={forwardedButtons}
+        {...dialogProps}
+        onClose={closeHandler}
+      >
+        {children}
+      </Dialog>
+    );
+  }
+}
+
+export default function DialogPage() {
+  const inputRef = useRef(null);
+  return (
+    <Library.Page
+      title="Dialog"
+      intro={
+        <p>
+          <code>Dialog</code> is intended as a more full-featured replacement
+          for the <code>Modal</code> component, supporting both modal and
+          non-modal dialogs.
+        </p>
+      }
+    >
+      <Library.Section title="Dialog">
+        <Library.Pattern title="Status">
+          <p>
+            <strong>
+              <code>Dialog</code> is under development
+            </strong>{' '}
+            and is not yet part of this {"package's"} public API.
+          </p>
+        </Library.Pattern>
+        <Library.Pattern title="Usage">
+          <Library.Usage componentName="Dialog" />
+          <Library.Demo title="Basic Dialog" withSource>
+            <Dialog_
+              buttons={<DialogButtons />}
+              icon={EditIcon}
+              initialFocus={inputRef}
+              onClose={() => {}}
+              title="Basic dialog"
+            >
+              <p>
+                This is a basic Dialog that routes focus initially to a text
+                input.
+              </p>
+              <InputGroup>
+                <Input name="my-input" elementRef={inputRef} />
+                <IconButton icon={ArrowRightIcon} variant="dark" title="go" />
+              </InputGroup>
+            </Dialog_>
+          </Library.Demo>
+        </Library.Pattern>
+      </Library.Section>
+    </Library.Page>
+  );
+}

--- a/src/pattern-library/routes.ts
+++ b/src/pattern-library/routes.ts
@@ -24,6 +24,7 @@ import IconsPage from './components/patterns/data/IconsPage';
 import ScrollBoxPage from './components/patterns/data/ScrollBoxPage';
 import TablePage from './components/patterns/data/TablePage';
 import ThumbnailPage from './components/patterns/data/ThumbnailPage';
+import DialogPage from './components/patterns/feedback/DialogPage';
 import ModalPage from './components/patterns/feedback/ModalPage';
 import SpinnerPage from './components/patterns/feedback/SpinnerPage';
 import ButtonsPage from './components/patterns/input/ButtonPage';
@@ -139,6 +140,12 @@ const routes: PlaygroundRoute[] = [
     group: 'data',
     component: ThumbnailPage,
     route: '/data-thumbnail',
+  },
+  {
+    title: 'Dialog',
+    group: 'feedback',
+    component: DialogPage,
+    route: '/feedback-dialog',
   },
   {
     title: 'Modal',


### PR DESCRIPTION
This PR establishes a new `Dialog` component and its associated boilerplate, tests, documentation assets.

It is currently an exact copy of the `Modal` component and tests. A stub pattern-library page is also added here. While under development, this component will not be exported from the package's entry point. This will allow us to add features iteratively before we ship this component.

Part of #77 