### PR TITLE
Add `modal` prop to `Dialog`

### DIFF
--- a/src/components/feedback/test/Dialog-test.js
+++ b/src/components/feedback/test/Dialog-test.js
@@ -132,4 +132,38 @@ describe('Dialog', () => {
       assert.isNull(content.getAttribute('aria-describedby'));
     });
   });
+
+  describe('modal Dialogs', () => {
+    let nonModalWrapper;
+    let modalWrapper;
+
+    beforeEach(() => {
+      nonModalWrapper = mount(
+        <Dialog title="My dialog">
+          <p>Dialog content</p>
+        </Dialog>
+      );
+
+      modalWrapper = mount(
+        <Dialog title="My dialog" modal>
+          <p>Modal Dialog content</p>
+        </Dialog>
+      );
+    });
+
+    it('should render a backdrop for modal dialogs', () => {
+      assert.isFalse(nonModalWrapper.find('Overlay').exists());
+      assert.isTrue(modalWrapper.find('Overlay').exists());
+    });
+
+    it('should set aria-modal for modal dialogs', () => {
+      const nonModalContainer = nonModalWrapper
+        .find('[role="dialog"]')
+        .getDOMNode();
+      const modalContainer = modalWrapper.find('[role="dialog"]').getDOMNode();
+
+      assert.equal(nonModalContainer.getAttribute('aria-modal'), 'false');
+      assert.equal(modalContainer.getAttribute('aria-modal'), 'true');
+    });
+  });
 });

--- a/src/pattern-library/components/patterns/feedback/DialogPage.tsx
+++ b/src/pattern-library/components/patterns/feedback/DialogPage.tsx
@@ -60,17 +60,13 @@ function Dialog_({
         Show dialog
       </Button>
     );
-  } else {
-    return (
-      <Dialog
-        buttons={forwardedButtons}
-        {...dialogProps}
-        onClose={closeHandler}
-      >
-        {children}
-      </Dialog>
-    );
   }
+
+  return (
+    <Dialog buttons={forwardedButtons} {...dialogProps} onClose={closeHandler}>
+      {children}
+    </Dialog>
+  );
 }
 
 export default function DialogPage() {

--- a/src/pattern-library/components/patterns/feedback/DialogPage.tsx
+++ b/src/pattern-library/components/patterns/feedback/DialogPage.tsx
@@ -90,6 +90,49 @@ export default function DialogPage() {
             </strong>{' '}
             and is not yet part of this {"package's"} public API.
           </p>
+
+          <Library.Example title="Done">
+            <ul>
+              <li>
+                Differentiation between modal and non-modal Dialogs via a{' '}
+                <code>modal</code> prop.
+              </li>
+            </ul>
+          </Library.Example>
+
+          <Library.Example title="TODO">
+            <ul>
+              <li>
+                Close on ESC keypress: Defaults to enabled for modal dialogs,
+                off for non-modal dialogs. Can be controlled with a prop.
+              </li>
+              <li>
+                Close on click-away: Defaults to enabled for modal dialogs, off
+                for non-modal dialogs. Can be controlled with a prop.
+              </li>
+              <li>
+                Close on focus-away: Defaults to off for all dialogs. Can be
+                conrolled with a prop.
+              </li>
+              <li>
+                Focus trap: Defaults to enabled for modal dialogs, off for
+                non-modal dialogs. Can be controlled with a prop.
+              </li>
+              <li>
+                Initial focus: Should search for <code>autofocus</code> elements
+                when in {'"auto"'} mode. {"'manual'"} value should be renamed to{' '}
+                {"'custom'"} per conventions.
+              </li>
+              <li>Focus restoration after close.</li>
+              <li>
+                Control over using <code>Panel</code> or not.
+              </li>
+              <li>
+                <code>size</code> and <code>unstyled</code> support
+              </li>
+              <li>Vet automated accessibility tests.</li>
+            </ul>
+          </Library.Example>
         </Library.Pattern>
         <Library.Pattern title="Usage">
           <Library.Usage componentName="Dialog" />

--- a/src/pattern-library/components/patterns/feedback/DialogPage.tsx
+++ b/src/pattern-library/components/patterns/feedback/DialogPage.tsx
@@ -111,6 +111,51 @@ export default function DialogPage() {
               </InputGroup>
             </Dialog_>
           </Library.Demo>
+
+          <Library.Demo title="Basic modal Dialog" withSource>
+            <Dialog_
+              buttons={<DialogButtons />}
+              icon={EditIcon}
+              initialFocus={inputRef}
+              onClose={() => {}}
+              title="Basic dialog"
+              modal
+            >
+              <p>
+                This is a basic modal Dialog that routes focus initially to a
+                text input.
+              </p>
+              <InputGroup>
+                <Input name="my-input" elementRef={inputRef} />
+                <IconButton icon={ArrowRightIcon} variant="dark" title="go" />
+              </InputGroup>
+            </Dialog_>
+          </Library.Demo>
+        </Library.Pattern>
+
+        <Library.Pattern title="Props">
+          <p>
+            <em>Note</em>: At present these props only include those that are
+            additional to or differ from props accepted by the Modal component.
+            All component props will be documented before Dialog is released.
+          </p>
+          <Library.Example title="modal">
+            <p>
+              Setting the <code>modal</code> <code>boolean</code> prop (default{' '}
+              <code>false</code>) indicates that the Dialog should have modal
+              behavior.
+            </p>
+            <p>
+              <code>modal</code> Dialogs:
+            </p>
+            <ul>
+              <li>Have a full-screen backdrop</li>
+              <li>
+                Position themselves on the screen and constrain the Dialog
+                dimensions based on the viewport
+              </li>
+            </ul>
+          </Library.Example>
         </Library.Pattern>
       </Library.Section>
     </Library.Page>


### PR DESCRIPTION
This PR starts the division of `Dialog` into modal and non-modal sub-variants. It is possible that one day we will peel this into two components, but for now, one component that can have modal or non-modal behaviors.

More behavior differentiation will be applied to modal vs. non-modal Dialogs, but for now, modal Dialogs get a full-screen backdrop Overlay, sizing and positioning, while non-modal Dialogs do not. A modal example has been added to the `Dialog` page.

I've also added some next-step TODOs here on `Dialog`'s pattern-library page to sketch out where this is going next.

Next step: some hooks to handle events that should close modal `Dialog`s.

Part of #77