### PR TITLE
Ensure `listener-collection` passes `options` to `removeEventListener`

### DIFF
--- a/src/util/listener-collection.ts
+++ b/src/util/listener-collection.ts
@@ -37,10 +37,10 @@ export class ListenerCollection {
   /**
    * Add a listener and return an ID that can be used to remove it later
    */
-  add(
-    eventTarget: EventTarget,
-    eventType: string,
-    listener: (event: EventType<EventTarget, string>) => void,
+  add<ListenerTarget extends EventTarget, Type extends string>(
+    eventTarget: ListenerTarget,
+    eventType: Type,
+    listener: (event: EventType<ListenerTarget, Type>) => void,
     options?: AddEventListenerOptions
   ) {
     eventTarget.addEventListener(eventType, listener, options);

--- a/src/util/listener-collection.ts
+++ b/src/util/listener-collection.ts
@@ -2,6 +2,7 @@ export type Listener = {
   eventTarget: EventTarget;
   eventType: string;
   listener: EventListener;
+  options?: AddEventListenerOptions;
 };
 
 /**
@@ -48,6 +49,7 @@ export class ListenerCollection {
       eventTarget,
       eventType,
       listener,
+      options,
     });
     return symbol;
   }
@@ -58,15 +60,15 @@ export class ListenerCollection {
   remove(listenerId: symbol) {
     const event = this._listeners.get(listenerId);
     if (event) {
-      const { eventTarget, eventType, listener } = event;
-      eventTarget.removeEventListener(eventType, listener);
+      const { eventTarget, eventType, listener, options } = event;
+      eventTarget.removeEventListener(eventType, listener, options);
       this._listeners.delete(listenerId);
     }
   }
 
   removeAll() {
-    this._listeners.forEach(({ eventTarget, eventType, listener }) => {
-      eventTarget.removeEventListener(eventType, listener);
+    this._listeners.forEach(({ eventTarget, eventType, listener, options }) => {
+      eventTarget.removeEventListener(eventType, listener, options);
     });
     this._listeners.clear();
   }

--- a/src/util/test/listener-collection-test.js
+++ b/src/util/test/listener-collection-test.js
@@ -25,13 +25,24 @@ describe('ListenerCollection', () => {
     it('unregisters the specified listener', () => {
       const listener1 = sinon.stub();
       const listener2 = sinon.stub();
+      const listener3 = sinon.stub();
       listeners.add(window, 'resize', listener1);
       const listenerId = listeners.add(window, 'resize', listener2);
+      const capturePhaseListenerId = listeners.add(
+        window,
+        'resize',
+        listener3,
+        {
+          capture: true,
+        }
+      );
       listeners.remove(listenerId);
+      listeners.remove(capturePhaseListenerId);
 
       window.dispatchEvent(new Event('resize'));
       assert.calledOnce(listener1);
       assert.notCalled(listener2);
+      assert.notCalled(listener3);
     });
   });
 
@@ -39,13 +50,18 @@ describe('ListenerCollection', () => {
     it('unregisters all event listeners', () => {
       const listener1 = sinon.stub();
       const listener2 = sinon.stub();
+      const listener3 = sinon.stub();
       listeners.add(window, 'resize', listener1);
       listeners.add(window, 'resize', listener2);
+      listeners.add(window, 'resize', listener3, {
+        capture: true,
+      });
       listeners.removeAll();
 
       window.dispatchEvent(new Event('resize'));
       assert.notCalled(listener1);
       assert.notCalled(listener2);
+      assert.notCalled(listener3);
     });
   });
 });


### PR DESCRIPTION
I ran into a confusion today while converting some hooks over to more consistently use `listener-collection`. Some worked, but a focus-event-related hook did not. I realized it was because `listener-collection` wasn't passing the `options` parameter (when provided) to `removeEventListener`. This matters if you have an event that was registered with options (specifically `capture: true`) as they don't get removed if you don't pass them options!

Converted it to TS while I was in there.

The tests added to the tests module will fail without the change made to the module.