### PR TITLE
Add granular event hooks (for use in closing `Dialog`s)

### DIFF
--- a/src/hooks/test/use-click-away-test.js
+++ b/src/hooks/test/use-click-away-test.js
@@ -1,0 +1,67 @@
+import { mount } from 'enzyme';
+import { useRef } from 'preact/hooks';
+import { act } from 'preact/test-utils';
+
+import { useClickAway } from '../use-click-away';
+
+describe('useClickAway', () => {
+  let handler;
+
+  const events = [new Event('mousedown'), new Event('click')];
+
+  // Create a fake component to mount in tests that uses the hook
+  function FakeComponent({ enabled = true }) {
+    const myRef = useRef();
+    useClickAway(myRef, handler, { enabled });
+    return (
+      <div ref={myRef}>
+        <button>Hi</button>
+      </div>
+    );
+  }
+
+  function createComponent(props) {
+    return mount(<FakeComponent {...props} />);
+  }
+
+  beforeEach(() => {
+    handler = sinon.stub();
+  });
+
+  events.forEach(event => {
+    it(`should invoke callback once for events outside of element (${event.type})`, () => {
+      const wrapper = createComponent();
+
+      act(() => {
+        document.body.dispatchEvent(event);
+      });
+      wrapper.update();
+
+      assert.calledOnce(handler);
+
+      wrapper.setProps({ enabled: false });
+
+      act(() => {
+        document.body.dispatchEvent(event);
+      });
+
+      // Cleanup of hook should have removed eventListeners, so the callback
+      // is not called again
+      assert.calledOnce(handler);
+    });
+  });
+
+  events.forEach(event => {
+    it(`should not invoke callback on events inside of container (${event.type})`, () => {
+      const wrapper = createComponent();
+      const button = wrapper.find('button');
+
+      act(() => {
+        button.getDOMNode().dispatchEvent(event);
+      });
+      wrapper.update();
+
+      assert.equal(handler.callCount, 0);
+    });
+  });
+});

--- a/src/hooks/test/use-click-away-test.js
+++ b/src/hooks/test/use-click-away-test.js
@@ -12,7 +12,8 @@ describe('useClickAway', () => {
   // Create a fake component to mount in tests that uses the hook
   function FakeComponent({ enabled = true }) {
     const myRef = useRef();
-    useClickAway(myRef, handler, { enabled });
+    const hookOpts = enabled === true ? undefined : { enabled };
+    useClickAway(myRef, handler, hookOpts);
     return (
       <div ref={myRef}>
         <button>Hi</button>

--- a/src/hooks/test/use-focus-away-test.js
+++ b/src/hooks/test/use-focus-away-test.js
@@ -12,7 +12,8 @@ describe('useFocusAway', () => {
   // Create a fake component to mount in tests that uses the hook
   function FakeComponent({ enabled = true }) {
     const myRef = useRef();
-    useFocusAway(myRef, handler, { enabled });
+    const hookOpts = enabled === true ? undefined : { enabled };
+    useFocusAway(myRef, handler, hookOpts);
     return (
       <div ref={myRef}>
         <button>Hi</button>

--- a/src/hooks/test/use-focus-away-test.js
+++ b/src/hooks/test/use-focus-away-test.js
@@ -1,0 +1,68 @@
+import { mount } from 'enzyme';
+import { useRef } from 'preact/hooks';
+import { act } from 'preact/test-utils';
+
+import { useFocusAway } from '../use-focus-away';
+
+describe('useFocusAway', () => {
+  let handler;
+
+  const events = [new Event('focus')];
+
+  // Create a fake component to mount in tests that uses the hook
+  function FakeComponent({ enabled = true }) {
+    const myRef = useRef();
+    useFocusAway(myRef, handler, { enabled });
+    return (
+      <div ref={myRef}>
+        <button>Hi</button>
+      </div>
+    );
+  }
+
+  function createComponent(props) {
+    return mount(<FakeComponent {...props} />);
+  }
+
+  beforeEach(() => {
+    handler = sinon.stub();
+  });
+
+  events.forEach(event => {
+    it(`should invoke callback once for events outside of element (${event.type})`, () => {
+      const wrapper = createComponent();
+
+      act(() => {
+        document.body.dispatchEvent(event);
+      });
+      wrapper.update();
+
+      assert.calledOnce(handler);
+
+      // Update the component to change it and re-execute the hook
+      wrapper.setProps({ enabled: false });
+
+      act(() => {
+        document.body.dispatchEvent(new Event('focus'));
+      });
+
+      // Cleanup of hook should have removed eventListeners, so the callback
+      // is not called again
+      assert.calledOnce(handler);
+    });
+  });
+
+  events.forEach(event => {
+    it(`should not invoke callback on events inside of container (${event.type})`, () => {
+      const wrapper = createComponent();
+      const button = wrapper.find('button');
+
+      act(() => {
+        button.getDOMNode().dispatchEvent(event);
+      });
+      wrapper.update();
+
+      assert.equal(handler.callCount, 0);
+    });
+  });
+});

--- a/src/hooks/test/use-key-press-test.js
+++ b/src/hooks/test/use-key-press-test.js
@@ -1,0 +1,72 @@
+import { mount } from 'enzyme';
+import { useRef } from 'preact/hooks';
+import { act } from 'preact/test-utils';
+
+import { useKeyPress } from '../use-key-press';
+
+describe('useKeyPress', () => {
+  let handler;
+  const defaultKeys = ['d', 'u'];
+
+  const createEvent = (name, props) => {
+    const event = new Event(name);
+    Object.assign(event, props);
+    return event;
+  };
+
+  // Create a fake component to mount in tests that uses the hook
+  function FakeComponent({ keys = defaultKeys, enabled = true }) {
+    const myRef = useRef();
+    useKeyPress(keys, handler, { enabled });
+    return (
+      <div ref={myRef}>
+        <button>Hi</button>
+      </div>
+    );
+  }
+
+  function createComponent(props) {
+    return mount(<FakeComponent {...props} />);
+  }
+
+  beforeEach(() => {
+    handler = sinon.stub();
+  });
+
+  defaultKeys.forEach(key => {
+    it(`should invoke callback when registered key ${key} is pressed`, () => {
+      const event = createEvent('keydown', { key });
+      const wrapper = createComponent();
+
+      act(() => {
+        document.body.dispatchEvent(event);
+      });
+      wrapper.update();
+
+      assert.calledOnce(handler);
+
+      // Update the component to change it and re-execute the hook
+      wrapper.setProps({ enabled: false });
+
+      act(() => {
+        document.body.dispatchEvent(event);
+      });
+
+      // Cleanup of hook should have removed eventListeners, so the callback
+      // is not called again
+      assert.calledOnce(handler);
+    });
+  });
+
+  it('should not invoke callback if a non-registered key is pressed', () => {
+    const event = createEvent('keydown', { key: 'q' });
+    const wrapper = createComponent();
+
+    act(() => {
+      document.body.dispatchEvent(event);
+    });
+    wrapper.update();
+
+    assert.notCalled(handler);
+  });
+});

--- a/src/hooks/test/use-key-press-test.js
+++ b/src/hooks/test/use-key-press-test.js
@@ -17,7 +17,8 @@ describe('useKeyPress', () => {
   // Create a fake component to mount in tests that uses the hook
   function FakeComponent({ keys = defaultKeys, enabled = true }) {
     const myRef = useRef();
-    useKeyPress(keys, handler, { enabled });
+    const hookOpts = enabled === true ? undefined : { enabled };
+    useKeyPress(keys, handler, hookOpts);
     return (
       <div ref={myRef}>
         <button>Hi</button>

--- a/src/hooks/use-click-away.ts
+++ b/src/hooks/use-click-away.ts
@@ -1,0 +1,44 @@
+import type { RefObject } from 'preact';
+import { useEffect } from 'preact/hooks';
+
+import { ListenerCollection } from '../util/listener-collection';
+
+type UseClickAwayOptions = {
+  /** Enable listening for away-click events? Can be set to false to disable */
+  enabled?: boolean;
+};
+
+/**
+ * Listen on document.body for click events. If a click event's target is
+ * outside of the `container` element, invoke the `callback`. Do not listen if
+ * not `enabled`.
+ */
+export function useClickAway(
+  container: RefObject<HTMLElement | undefined>,
+  callback: (e: Event) => void,
+  { enabled = true }: UseClickAwayOptions = {}
+) {
+  useEffect(() => {
+    if (!enabled) {
+      return () => {};
+    }
+    const target = document.body;
+    const listeners = new ListenerCollection();
+
+    const handleAwayClick = (event: Event) => {
+      if (
+        container.current &&
+        !container.current.contains(event.target as Node)
+      ) {
+        callback(event);
+      }
+    };
+
+    listeners.add(target, 'mousedown', handleAwayClick);
+    listeners.add(target, 'click', handleAwayClick);
+
+    return () => {
+      listeners.removeAll();
+    };
+  }, [container, enabled, callback]);
+}

--- a/src/hooks/use-focus-away.ts
+++ b/src/hooks/use-focus-away.ts
@@ -1,0 +1,52 @@
+import type { RefObject } from 'preact';
+import { useEffect } from 'preact/hooks';
+
+import { ListenerCollection } from '../util/listener-collection';
+
+type UseFocusAwayOptions = {
+  /**
+   * Enable listening for focus events outside of `container`? Can be set to
+   * false to disable
+   */
+  enabled?: boolean;
+};
+
+/**
+ * Listen on document.body for focus events. If a focus event's target
+ * is outside of the `container` element, invoke the `callback`. Do not listen
+ * if not `enabled`.
+ */
+export function useFocusAway(
+  container: RefObject<HTMLElement | undefined>,
+  callback: (e: FocusEvent) => void,
+  { enabled = true }: UseFocusAwayOptions = {}
+) {
+  useEffect(() => {
+    if (!enabled) {
+      return () => {};
+    }
+    const target = document.body;
+    const listeners = new ListenerCollection();
+
+    listeners.add(
+      target,
+      'focus',
+      event => {
+        if (
+          container.current &&
+          !container.current.contains(event.target as Node)
+        ) {
+          callback(event);
+        }
+      },
+      {
+        // Focus events don't bubble; they need to be handled in the capture phase
+        capture: true,
+      }
+    );
+
+    return () => {
+      listeners.removeAll();
+    };
+  }, [container, enabled, callback]);
+}

--- a/src/hooks/use-key-press.ts
+++ b/src/hooks/use-key-press.ts
@@ -1,0 +1,38 @@
+import { useEffect } from 'preact/hooks';
+
+import { ListenerCollection } from '../util/listener-collection';
+
+type UseKeyPressOptions = {
+  /** Enable listening for key events? Can be set to false to disable */
+  enabled?: boolean;
+};
+
+/**
+ * Listen on HTMLElement `target` for key press events for the designated `keys`
+ * and invoke a callback. Do not listen if not `enabled`.
+ *
+ * @param keys - Array of keys (e.g. 'Escape', 'd') to listen for
+ */
+export function useKeyPress(
+  keys: string[],
+  callback: (e: KeyboardEvent) => void,
+  { enabled = true }: UseKeyPressOptions = {}
+) {
+  useEffect(() => {
+    if (!enabled) {
+      return () => {};
+    }
+    const target = document.body;
+    const listeners = new ListenerCollection();
+
+    listeners.add(target, 'keydown', event => {
+      if (keys.includes(event.key)) {
+        callback(event);
+      }
+    });
+
+    return () => {
+      listeners.removeAll();
+    };
+  }, [enabled, callback, keys]);
+}


### PR DESCRIPTION
Depends on #910 
Fixes #900
Part of #77

This PR decomposes the functionality of `useElementShouldClose` into three separate, more-generic hooks, and aligns with `useArrowKeyNavigation` in the use of `ListenerCollection` for managing event listeners. This will allow more nuanced control for `Dialog`s.

There's some opportunity to DRY this out some in the future (especially in tests), but I started with the simplest approach possible here.

Just like with `Dialog`, I imagine we might make these hooks part of the package's public API (and deprecate `useElementShouldClose`). But let's do that later and separately.