### PR TITLE
Make close behavior for Dialogs more granular, configurable

### DIFF
--- a/src/pattern-library/components/patterns/feedback/DialogPage.tsx
+++ b/src/pattern-library/components/patterns/feedback/DialogPage.tsx
@@ -97,23 +97,23 @@ export default function DialogPage() {
                 Differentiation between modal and non-modal Dialogs via a{' '}
                 <code>modal</code> prop.
               </li>
-            </ul>
-          </Library.Example>
-
-          <Library.Example title="TODO">
-            <ul>
               <li>
                 Close on ESC keypress: Defaults to enabled for modal dialogs,
                 off for non-modal dialogs. Can be controlled with a prop.
               </li>
               <li>
-                Close on click-away: Defaults to enabled for modal dialogs, off
-                for non-modal dialogs. Can be controlled with a prop.
+                Close on click-away: Defaults to off for all dialogs. Can be
+                controlled with a prop.
               </li>
               <li>
                 Close on focus-away: Defaults to off for all dialogs. Can be
-                conrolled with a prop.
+                controlled with a prop.
               </li>
+            </ul>
+          </Library.Example>
+
+          <Library.Example title="TODO">
+            <ul>
               <li>
                 Focus trap: Defaults to enabled for modal dialogs, off for
                 non-modal dialogs. Can be controlled with a prop.
@@ -154,6 +154,11 @@ export default function DialogPage() {
               </InputGroup>
             </Dialog_>
           </Library.Demo>
+
+          <p>
+            Modal dialogs position themselves atop a full-screen overlay, and
+            will close by default when <kbd>Escape</kbd> is pressed.
+          </p>
 
           <Library.Demo title="Basic modal Dialog" withSource>
             <Dialog_
@@ -198,6 +203,75 @@ export default function DialogPage() {
                 dimensions based on the viewport
               </li>
             </ul>
+          </Library.Example>
+          <Library.Example title="closeOnClickAway">
+            <p>
+              This boolean prop (default <code>false</code>) controls whether
+              the Dialog should close when there are click events outside of it.
+            </p>
+            <Library.Demo
+              title="Dialog that closes on external clicks"
+              withSource
+            >
+              <Dialog_
+                closeOnClickAway
+                onClose={() => {}}
+                title="Dialog that closes when there are external clicks"
+              >
+                <p>This dialog will close if you click outside of it</p>
+              </Dialog_>
+            </Library.Demo>
+          </Library.Example>
+          <Library.Example title="closeOnFocusAway">
+            <p>
+              This boolean prop (default <code>false</code>) controls whether
+              the Dialog should close when there are focus events outside of it.
+            </p>
+            <Library.Demo
+              title="Dialog that closes on external focus events"
+              withSource
+            >
+              <Dialog_
+                closeOnFocusAway
+                onClose={() => {}}
+                title="Close on Away Focus"
+              >
+                <p>This dialog will close if you focus outside of it</p>
+              </Dialog_>
+            </Library.Demo>
+          </Library.Example>
+          <Library.Example title="closeOnEscape">
+            <p>
+              Close-on-<kbd>Escape</kbd> keypress behavior is enabled by default
+              when <code>modal</code> is set. The default behavior may be
+              overridden by setting this prop:
+            </p>
+            <ul>
+              <li>
+                Set to <code>true</code> to explicitly enable closing on{' '}
+                <code>Escape</code>, e.g. on non-modal Dialogs
+              </li>
+              <li>
+                Set to <code>false</code> to explicitly disable closing on{' '}
+                <code>Escape</code>, e.g. on modal Dialogs
+              </li>
+            </ul>
+
+            <Library.Demo
+              title="Disabling close-on-Escape for a modal dialog"
+              withSource
+            >
+              <Dialog_
+                closeOnEscape={false}
+                modal
+                onClose={() => {}}
+                title="ESC won't close me!"
+              >
+                <p>
+                  This dialog will not close if you press <kbd>Escape</kbd>.
+                </p>
+              </Dialog_>
+            </Library.Demo>
           </Library.Example>
         </Library.Pattern>
       </Library.Section>


### PR DESCRIPTION
This PR replaces the use of `useElementShouldClose` with newly-added, more granular hooks. Modal Dialogs still default to close on ESC, but no longer default to close on click-away or focus-away (this more closely echoes the native `dialog` element behavior). But all three behaviors can be controlled via props.

This is documented on the `Dialog` pattern-library page, so I'll leave it to the reviewer to determine whether the documentation is clear enough!

Part of #77
Depends on #911 