### PR TITLE
Deprecate `useElementShouldClose`, export granular event hooks

### DIFF
--- a/src/hooks/use-element-should-close.js
+++ b/src/hooks/use-element-should-close.js
@@ -37,6 +37,8 @@ function listen(element, events, listener, { useCapture = false } = {}) {
  * that should close it - such as clicks outside the element or Esc key presses.
  * When such an interaction happens, the `handleClose` callback is invoked.
  *
+ * @deprecated Use `useKeyPress`, `useClickAway` and/or `useFocusAway` instead
+ *
  * @param {Ref<HTMLElement | undefined>} closeableEl - Outer DOM element for the popup
  * @param {boolean} isOpen - Whether the popup is currently visible/open
  * @param {() => void} handleClose - Callback invoked to close the popup

--- a/src/next.ts
+++ b/src/next.ts
@@ -1,6 +1,8 @@
 // Hooks
 export { useArrowKeyNavigation } from './hooks/use-arrow-key-navigation';
-export { useElementShouldClose } from './hooks/use-element-should-close';
+export { useClickAway } from './hooks/use-click-away';
+export { useFocusAway } from './hooks/use-focus-away';
+export { useKeyPress } from './hooks/use-key-press';
 export { useSyncedRef } from './hooks/use-synced-ref';
 
 // Components
@@ -106,3 +108,6 @@ export type {
   TabProps,
   TabListProps,
 } from './components/navigation/';
+
+// Deprecated
+export { useElementShouldClose } from './hooks/use-element-should-close';


### PR DESCRIPTION
Deprecate `useElementShouldClose` in favor of updated, granular event hooks, and make new hooks available in package API.

Follow up to fixing #900

(Side note: the `@deprecated` keyword as applied to component functions in the past has triggered my editor to recognize those components (when imported or used) as deprecated, but that isn't the case for this hook function. I hope I ... deprecated it correctly?)