### PR TITLE
Split `ModalDialog` from `Dialog`

### DIFF
--- a/src/components/feedback/ModalDialog.tsx
+++ b/src/components/feedback/ModalDialog.tsx
@@ -1,0 +1,74 @@
+import classnames from 'classnames';
+
+import { useSyncedRef } from '../../hooks/use-synced-ref';
+import { downcastRef } from '../../util/typing';
+import Overlay from '../layout/Overlay';
+import Dialog from './Dialog';
+import type { DialogProps } from './Dialog';
+
+type ComponentProps = {
+  size?: 'sm' | 'md' | 'lg' | 'custom';
+};
+
+export type ModalDialogProps = DialogProps & ComponentProps;
+
+/**
+ * Show a modal dialog
+ */
+const ModalDialogNext = function ModalDialog({
+  children,
+  size = 'md',
+
+  classes,
+  elementRef,
+
+  // Forwarded to Dialog
+  closeOnEscape = true,
+  closeOnClickAway = false,
+  closeOnFocusAway = false,
+  initialFocus = 'auto',
+
+  ...htmlAndPanelAttributes
+}: ModalDialogProps) {
+  const modalRef = useSyncedRef(elementRef);
+
+  return (
+    <Overlay data-composite-component="ModalDialog">
+      <Dialog
+        // Attribute defaults; can be overridden
+        aria-modal
+        {...htmlAndPanelAttributes}
+        // Dialog props
+        closeOnClickAway={closeOnClickAway}
+        closeOnFocusAway={closeOnFocusAway}
+        closeOnEscape={closeOnEscape}
+        initialFocus={initialFocus}
+        classes={classnames(
+          // Column-flex layout to constrain content to max-height
+          'flex flex-col',
+          'max-w-[90vw] max-h-[90vh]',
+          // Overlay sets up a flex layout centered on both axes. For taller
+          // viewports, remove this modal container from the flex flow with
+          // fixed positioning and position it 10vh from the top of the
+          // viewport. This feels more balanced on taller screens. Ensure an
+          // equal 10vh gap at the bottom of the screen by adjusting max-height
+          // to `80vh`.
+          'tall:fixed tall:max-h-[80vh] tall:top-[10vh]',
+          {
+            // Max-width rules will ensure actual width never exceeds 90vw
+            'w-[30rem]': size === 'sm',
+            'w-[36rem]': size === 'md', // default
+            'w-[42rem]': size === 'lg',
+            // No width classes are added if size is 'custom'
+          },
+          classes
+        )}
+        elementRef={downcastRef(modalRef)}
+      >
+        {children}
+      </Dialog>
+    </Overlay>
+  );
+};
+
+export default ModalDialogNext;

--- a/src/components/feedback/index.ts
+++ b/src/components/feedback/index.ts
@@ -1,9 +1,11 @@
 export { default as Dialog } from './Dialog';
 export { default as Modal } from './Modal';
+export { default as ModalDialog } from './ModalDialog';
 export { default as Spinner } from './Spinner';
 export { default as SpinnerOverlay } from './SpinnerOverlay';
 
 export type { DialogProps } from './Dialog';
 export type { ModalProps } from './Modal';
+export type { ModalDialogProps } from './ModalDialog';
 export type { SpinnerProps } from './Spinner';
 export type { SpinnerOverlayProps } from './SpinnerOverlay';

--- a/src/components/feedback/test/Dialog-test.js
+++ b/src/components/feedback/test/Dialog-test.js
@@ -126,45 +126,8 @@ describe('Dialog', () => {
       container.remove();
     });
 
-    context('modal dialog', () => {
-      it('enables close on `ESC`, but not on external click or focus', () => {
-        mount(
-          <Dialog title="Test dialog" modal onClose={onClose}>
-            Modal dialog
-          </Dialog>,
-          {
-            attachTo: container,
-          }
-        );
-
-        assert.deepEqual(fakeUseKeyPress.lastCall.args[0], ['Escape']);
-        assert.deepEqual(fakeUseKeyPress.lastCall.args[2], { enabled: true });
-        assert.deepEqual(fakeUseFocusAway.lastCall.args[2], { enabled: false });
-        assert.deepEqual(fakeUseClickAway.lastCall.args[2], { enabled: false });
-      });
-
-      it('does not enable close on `ESC` if overridden by `closeOnEscape`', () => {
-        mount(
-          <Dialog
-            closeOnEscape={false}
-            title="Test dialog"
-            modal
-            onClose={onClose}
-          >
-            Modal dialog
-          </Dialog>,
-          {
-            attachTo: container,
-          }
-        );
-
-        assert.deepEqual(fakeUseKeyPress.lastCall.args[0], ['Escape']);
-        assert.deepEqual(fakeUseKeyPress.lastCall.args[2], { enabled: false });
-      });
-    });
-
-    context('non-modal dialog', () => {
-      it('does not enable close on ESC, external clicks or external focus events', () => {
+    describe('closing the dialog', () => {
+      it('does not lose on ESC, external clicks or external focus events by default', () => {
         mount(
           <Dialog title="Test dialog" onClose={onClose}>
             This is my dialog
@@ -230,40 +193,6 @@ describe('Dialog', () => {
       );
       const content = wrapper.find('[role="dialog"]').getDOMNode();
       assert.isNull(content.getAttribute('aria-describedby'));
-    });
-  });
-
-  describe('modal Dialogs', () => {
-    let nonModalWrapper;
-    let modalWrapper;
-
-    beforeEach(() => {
-      nonModalWrapper = mount(
-        <Dialog title="My dialog">
-          <p>Dialog content</p>
-        </Dialog>
-      );
-
-      modalWrapper = mount(
-        <Dialog title="My dialog" modal>
-          <p>Modal Dialog content</p>
-        </Dialog>
-      );
-    });
-
-    it('should render a backdrop for modal dialogs', () => {
-      assert.isFalse(nonModalWrapper.find('Overlay').exists());
-      assert.isTrue(modalWrapper.find('Overlay').exists());
-    });
-
-    it('should set aria-modal for modal dialogs', () => {
-      const nonModalContainer = nonModalWrapper
-        .find('[role="dialog"]')
-        .getDOMNode();
-      const modalContainer = modalWrapper.find('[role="dialog"]').getDOMNode();
-
-      assert.equal(nonModalContainer.getAttribute('aria-modal'), 'false');
-      assert.equal(modalContainer.getAttribute('aria-modal'), 'true');
     });
   });
 });

--- a/src/components/feedback/test/ModalDialog-test.js
+++ b/src/components/feedback/test/ModalDialog-test.js
@@ -1,0 +1,39 @@
+import { mount } from 'enzyme';
+
+import { testCompositeComponent } from '../../test/common-tests';
+import ModalDialog from '../ModalDialog';
+import { $imports } from '../ModalDialog';
+
+const createComponent = (Component, props = {}) => {
+  return mount(
+    <Component title="Test title" onClose={() => {}} {...props}>
+      This is child content
+    </Component>
+  );
+};
+
+describe('ModalDialog', () => {
+  testCompositeComponent(ModalDialog, {
+    createContent: createComponent,
+    // ModalDialog's primary component element is its wrapped Dialog
+    elementSelector: 'Dialog',
+    // But the composite component is identified on the wrapping Overlay
+    wrapperSelector: 'Overlay',
+  });
+
+  afterEach(() => {
+    $imports.$restore();
+  });
+
+  describe('closing the modal dialog', () => {
+    it('closes on ESC by default, but not on away-focus or away-click', () => {
+      const wrapper = mount(
+        <ModalDialog title="Test modal dialog">This is my dialog</ModalDialog>
+      );
+      const dialogProps = wrapper.find('Dialog').props();
+      assert.isTrue(dialogProps.closeOnEscape);
+      assert.isFalse(dialogProps.closeOnClickAway);
+      assert.isFalse(dialogProps.closeOnFocusAway);
+    });
+  });
+});

--- a/src/components/test/common-tests.js
+++ b/src/components/test/common-tests.js
@@ -18,6 +18,13 @@ function primaryElement(wrapper, elementSelector) {
   return wrapper.childAt(0).getDOMNode();
 }
 
+function wrapperElement(wrapper, wrapperSelector) {
+  if (wrapperSelector) {
+    return wrapper.find(wrapperSelector).getDOMNode();
+  }
+  return wrapper.childAt(0).getDOMNode();
+}
+
 /**
  * Set of tests common to all presentational components
  *
@@ -31,13 +38,28 @@ function primaryElement(wrapper, elementSelector) {
  * @prop {string} [elementSelector] - Selector to find the element to which any
  *   passed HTML attributes are applied, when it is not the outermost element
  *   rendered by the component.
+ */
+
+/**
+ * For composite components, add a `wrapperSelector` option, a selector for the
+ * element to which a `data-composite-component` attribute is applied, when it
+ * is not the outermost element rendered by the component.
  *
+ * @typedef {CommonTestOpts & { wrapperSelector?: string }} CompositeTestOpts
+ */
+
+/**
  * @param {FunctionComponent} Component
- * @param {CommonTestOpts} opts
+ * @param {CompositeTestOpts} opts
  */
 export function testCompositeComponent(
   Component,
-  { componentName, createContent = createComponent, elementSelector } = {}
+  {
+    componentName,
+    createContent = createComponent,
+    elementSelector,
+    wrapperSelector,
+  } = {}
 ) {
   const displayName = componentName ?? Component.displayName ?? Component.name;
 
@@ -50,24 +72,18 @@ export function testCompositeComponent(
     });
 
     it('applies HTML attributes to primary element', () => {
-      let primaryEl;
-
       const wrapper = createContent(Component, {
         'data-testid': 'foo-container',
       });
-
-      if (elementSelector) {
-        primaryEl = wrapper.find(elementSelector).getDOMNode();
-      } else {
-        primaryEl = wrapper.childAt(0).getDOMNode();
-      }
+      const primaryEl = primaryElement(wrapper, elementSelector);
 
       assert.isTrue(primaryEl.hasAttribute('data-testid'));
       assert.equal(primaryEl.getAttribute('data-testid'), 'foo-container');
     });
 
     it('applies a `data-composite-component` attribute for debugging', () => {
-      const wrapperOuterEl = createContent(Component).childAt(0).getDOMNode();
+      const wrapper = createContent(Component);
+      const wrapperOuterEl = wrapperElement(wrapper, wrapperSelector);
 
       assert.isTrue(wrapperOuterEl.hasAttribute('data-composite-component'));
       assert.equal(

--- a/src/pattern-library/components/patterns/feedback/DialogPage.tsx
+++ b/src/pattern-library/components/patterns/feedback/DialogPage.tsx
@@ -77,8 +77,7 @@ export default function DialogPage() {
       intro={
         <p>
           <code>Dialog</code> is intended as a more full-featured replacement
-          for the <code>Modal</code> component, supporting both modal and
-          non-modal dialogs.
+          for the <code>Modal</code> component, for non-modal dialogs.
         </p>
       }
     >
@@ -94,43 +93,22 @@ export default function DialogPage() {
           <Library.Example title="Done">
             <ul>
               <li>
-                Differentiation between modal and non-modal Dialogs via a{' '}
-                <code>modal</code> prop.
+                Creation of <code>Dialog</code> component.
               </li>
-              <li>
-                Close on ESC keypress: Defaults to enabled for modal dialogs,
-                off for non-modal dialogs. Can be controlled with a prop.
-              </li>
-              <li>
-                Close on click-away: Defaults to off for all dialogs. Can be
-                controlled with a prop.
-              </li>
-              <li>
-                Close on focus-away: Defaults to off for all dialogs. Can be
-                controlled with a prop.
-              </li>
+              <li>Support close-on-ESC (disabled by default).</li>
+              <li>Support close-on-click-away (disabled by default).</li>
+              <li>Support close-on-away-focus (disabled by default).</li>
+              <li>Initial focus routing</li>
             </ul>
           </Library.Example>
 
           <Library.Example title="TODO">
             <ul>
+              <li>Support focus trapping (disabled by default)</li>
               <li>
-                Focus trap: Defaults to enabled for modal dialogs, off for
-                non-modal dialogs. Can be controlled with a prop.
+                Support focus restoration after close (disabled by default)
               </li>
-              <li>
-                Initial focus: Should search for <code>autofocus</code> elements
-                when in {'"auto"'} mode. {"'manual'"} value should be renamed to{' '}
-                {"'custom'"} per conventions.
-              </li>
-              <li>Focus restoration after close.</li>
-              <li>
-                Control over using <code>Panel</code> or not.
-              </li>
-              <li>
-                <code>size</code> and <code>unstyled</code> support
-              </li>
-              <li>Vet automated accessibility tests.</li>
+              <li>All tests and vet automated accessibility tests</li>
             </ul>
           </Library.Example>
         </Library.Pattern>
@@ -154,31 +132,6 @@ export default function DialogPage() {
               </InputGroup>
             </Dialog_>
           </Library.Demo>
-
-          <p>
-            Modal dialogs position themselves atop a full-screen overlay, and
-            will close by default when <kbd>Escape</kbd> is pressed.
-          </p>
-
-          <Library.Demo title="Basic modal Dialog" withSource>
-            <Dialog_
-              buttons={<DialogButtons />}
-              icon={EditIcon}
-              initialFocus={inputRef}
-              onClose={() => {}}
-              title="Basic dialog"
-              modal
-            >
-              <p>
-                This is a basic modal Dialog that routes focus initially to a
-                text input.
-              </p>
-              <InputGroup>
-                <Input name="my-input" elementRef={inputRef} />
-                <IconButton icon={ArrowRightIcon} variant="dark" title="go" />
-              </InputGroup>
-            </Dialog_>
-          </Library.Demo>
         </Library.Pattern>
 
         <Library.Pattern title="Props">
@@ -187,23 +140,7 @@ export default function DialogPage() {
             additional to or differ from props accepted by the Modal component.
             All component props will be documented before Dialog is released.
           </p>
-          <Library.Example title="modal">
-            <p>
-              Setting the <code>modal</code> <code>boolean</code> prop (default{' '}
-              <code>false</code>) indicates that the Dialog should have modal
-              behavior.
-            </p>
-            <p>
-              <code>modal</code> Dialogs:
-            </p>
-            <ul>
-              <li>Have a full-screen backdrop</li>
-              <li>
-                Position themselves on the screen and constrain the Dialog
-                dimensions based on the viewport
-              </li>
-            </ul>
-          </Library.Example>
+
           <Library.Example title="closeOnClickAway">
             <p>
               This boolean prop (default <code>false</code>) controls whether
@@ -242,33 +179,17 @@ export default function DialogPage() {
           </Library.Example>
           <Library.Example title="closeOnEscape">
             <p>
-              Close-on-<kbd>Escape</kbd> keypress behavior is enabled by default
-              when <code>modal</code> is set. The default behavior may be
-              overridden by setting this prop:
+              Enable close-on-ESC behavior by setting this boolean prop (default{' '}
+              <code>false</code>).
             </p>
-            <ul>
-              <li>
-                Set to <code>true</code> to explicitly enable closing on{' '}
-                <code>Escape</code>, e.g. on non-modal Dialogs
-              </li>
-              <li>
-                Set to <code>false</code> to explicitly disable closing on{' '}
-                <code>Escape</code>, e.g. on modal Dialogs
-              </li>
-            </ul>
 
             <Library.Demo
-              title="Disabling close-on-Escape for a modal dialog"
+              title="Dialog with close-on-Escape behavior"
               withSource
             >
-              <Dialog_
-                closeOnEscape={false}
-                modal
-                onClose={() => {}}
-                title="ESC won't close me!"
-              >
+              <Dialog_ closeOnEscape onClose={() => {}} title="Close on ESC">
                 <p>
-                  This dialog will not close if you press <kbd>Escape</kbd>.
+                  This dialog will close if you press <kbd>Escape</kbd>.
                 </p>
               </Dialog_>
             </Library.Demo>

--- a/src/pattern-library/components/patterns/feedback/ModalDialogPage.tsx
+++ b/src/pattern-library/components/patterns/feedback/ModalDialogPage.tsx
@@ -1,0 +1,123 @@
+import { useState, useRef } from 'preact/hooks';
+
+import { ModalDialog } from '../../../../components/feedback';
+import type { ModalDialogProps } from '../../../../components/feedback/ModalDialog';
+import {
+  ArrowRightIcon,
+  Button,
+  EditIcon,
+  IconButton,
+  Input,
+  InputGroup,
+} from '../../../../next';
+import Library from '../../Library';
+
+function ModalDialogButtons() {
+  return (
+    <>
+      <Button key="maybe" onClick={() => alert('You chose maybe')}>
+        Maybe
+      </Button>
+      <Button
+        key="yep"
+        onClick={() => alert('You chose yep')}
+        variant="primary"
+      >
+        Do it!
+      </Button>
+    </>
+  );
+}
+
+type ModalDialog_Props = ModalDialogProps & {
+  /** Pattern-wrapping prop. Not visible in source view */
+  _nonCloseable?: boolean;
+};
+
+/**
+ * Wrap the ModalDialog component with some state management to make reuse in
+ * multiple examples plausible and convenient.
+ */
+function ModalDialog_({
+  buttons,
+  _nonCloseable,
+  children,
+  ...dialogProps
+}: ModalDialog_Props) {
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const closeDialog = () => setDialogOpen(false);
+
+  const closeHandler = _nonCloseable ? undefined : closeDialog;
+  const forwardedButtons = buttons ? (
+    buttons
+  ) : (
+    <Button onClick={closeDialog}>Escape!</Button>
+  );
+
+  if (!dialogOpen) {
+    return (
+      <Button onClick={() => setDialogOpen(!dialogOpen)} variant="primary">
+        Show modal dialog
+      </Button>
+    );
+  }
+
+  return (
+    <ModalDialog
+      buttons={forwardedButtons}
+      {...dialogProps}
+      onClose={closeHandler}
+    >
+      {children}
+    </ModalDialog>
+  );
+}
+
+export default function ModalDialogPage() {
+  const inputRef = useRef(null);
+  return (
+    <Library.Page
+      title="ModalDialog"
+      intro={
+        <p>
+          <code>ModalDialog</code> is intended as a more full-featured
+          replacement for the <code>Modal</code> component, for modal dialogs.
+        </p>
+      }
+    >
+      <Library.Section title="ModalDialog">
+        <Library.Pattern title="Status">
+          <p>
+            <strong>
+              <code>ModalDialog</code> is under development
+            </strong>{' '}
+            and is not yet part of this {"package's"} public API.
+          </p>
+        </Library.Pattern>
+        <Library.Pattern title="Usage">
+          <Library.Usage componentName="ModalDialog" />
+          <p>
+            By default, <code>ModalDialog</code>s close when the ESC key is
+            pressed.
+          </p>
+          <Library.Demo title="Basic ModalDialog" withSource>
+            <ModalDialog_
+              buttons={<ModalDialogButtons />}
+              icon={EditIcon}
+              initialFocus={inputRef}
+              onClose={() => {}}
+              title="Basic dialog"
+            >
+              <p>This is a basic ModalDialog.</p>
+              <InputGroup>
+                <Input name="my-input" elementRef={inputRef} />
+                <IconButton icon={ArrowRightIcon} variant="dark" title="go" />
+              </InputGroup>
+            </ModalDialog_>
+          </Library.Demo>
+        </Library.Pattern>
+        <Library.Pattern title="Props">TODO</Library.Pattern>
+      </Library.Section>
+    </Library.Page>
+  );
+}

--- a/src/pattern-library/routes.ts
+++ b/src/pattern-library/routes.ts
@@ -25,6 +25,7 @@ import ScrollBoxPage from './components/patterns/data/ScrollBoxPage';
 import TablePage from './components/patterns/data/TablePage';
 import ThumbnailPage from './components/patterns/data/ThumbnailPage';
 import DialogPage from './components/patterns/feedback/DialogPage';
+import ModalDialogPage from './components/patterns/feedback/ModalDialogPage';
 import ModalPage from './components/patterns/feedback/ModalPage';
 import SpinnerPage from './components/patterns/feedback/SpinnerPage';
 import ButtonsPage from './components/patterns/input/ButtonPage';
@@ -146,6 +147,12 @@ const routes: PlaygroundRoute[] = [
     group: 'feedback',
     component: DialogPage,
     route: '/feedback-dialog',
+  },
+  {
+    title: 'ModalDialog',
+    group: 'feedback',
+    component: ModalDialogPage,
+    route: '/feedback-modal-dialog',
   },
   {
     title: 'Modal',


### PR DESCRIPTION
This PR splits out `ModalDialog` from `Dialog`. `ModalDialog` wraps `Dialog`, and provides modal-dialog-specific defaults and styling. It doesn't add any new functionality, but moves things around between components. Pattern-library pages added and updated.

This PR also makes an addition to the options accepted by common composite component tests.

Next steps will involve focus management: restoring after close and trapping.

## Addition of `wrapperSelector` option for composite component common tests

By default, all common tests assume that the outermost element rendered by a component is its primary element, unless a different element is identified with the (pre-existing) `elementSelector` test option. Before these changes, this element is assumed to be:

* where any HTML attributes passed as props are merged to
* where any passed CSS classes are added to
* where the `data-component` attribute is applied
* where the `data-composite-component` attribute is applied (for composite components only)

The test changes here make it possible for composite component tests to differentiate between a primary element (the first three items above) versus a _wrapper_ element (the last item, where `data-composite-component` is set). 

Perhaps easier to look at by example. In the case of `ModalDialog`, the structure is like so:

```jsx
<Overlay data-composite-component="ModalDialog">
  <Dialog ... data-component="Dialog" />
<Overlay>
```

In this case, the _primary_ element is the Dialog, but the `data-composite-component` attribute is applied to a different, _wrapper_ element. I’ve allowed for this in common composite tests by adding a new, optional `wrapperSelector` option to complement the `elementSelector` option. 

By default, tests will continue to treat to the outermost element as both _primary_ and _wrapper_ elements unless one or both of these selector options are set. 

Part of #77