### PR TITLE
Add focus restoration to `Dialog`, `ModalDialog`

### DIFF
--- a/src/components/feedback/ModalDialog.tsx
+++ b/src/components/feedback/ModalDialog.tsx
@@ -27,6 +27,7 @@ const ModalDialogNext = function ModalDialog({
   closeOnClickAway = false,
   closeOnFocusAway = false,
   initialFocus = 'auto',
+  restoreFocus = true,
 
   ...htmlAndPanelAttributes
 }: ModalDialogProps) {
@@ -43,6 +44,7 @@ const ModalDialogNext = function ModalDialog({
         closeOnFocusAway={closeOnFocusAway}
         closeOnEscape={closeOnEscape}
         initialFocus={initialFocus}
+        restoreFocus={restoreFocus}
         classes={classnames(
           // Column-flex layout to constrain content to max-height
           'flex flex-col',

--- a/src/components/feedback/test/Dialog-test.js
+++ b/src/components/feedback/test/Dialog-test.js
@@ -112,6 +112,61 @@ describe('Dialog', () => {
     });
   });
 
+  describe('restoring focus', () => {
+    let container;
+
+    beforeEach(() => {
+      container = document.createElement('div');
+      const button = document.createElement('button');
+      button.id = 'focus-button';
+      document.body.appendChild(button);
+      document.body.appendChild(container);
+    });
+
+    afterEach(() => {
+      container.remove();
+    });
+
+    it('should not restore focus by default', () => {
+      const wrapper = mount(
+        <Dialog id="focus-dialog" title="My dialog" restoreFocus />,
+        {
+          attachTo: container,
+        }
+      );
+      const dialogElement = document.getElementById('focus-dialog');
+      // Focus moves to dialog by default when mounted
+      assert.equal(document.activeElement, dialogElement);
+
+      wrapper.unmount();
+
+      // Focus on unmount is not handled; it reverts to the body here.
+      assert.equal(document.activeElement, document.body);
+    });
+
+    it('should restore focus when unmounted when `restoreFocus` set', () => {
+      const button = document.getElementById('focus-button');
+
+      // Start with focus on a button
+      button.focus();
+      assert.equal(document.activeElement, button);
+
+      const wrapper = mount(
+        <Dialog id="focus-dialog" title="My dialog" restoreFocus />,
+        {
+          attachTo: container,
+        }
+      );
+      const dialogElement = document.getElementById('focus-dialog');
+      // Focus moves to dialog by default when mounted
+      assert.equal(document.activeElement, dialogElement);
+
+      // Unmount cleanup should restore focus to the button
+      wrapper.unmount();
+      assert.equal(document.activeElement, button);
+    });
+  });
+
   describe('closing the dialog', () => {
     let container;
     let onClose;

--- a/src/components/feedback/test/ModalDialog-test.js
+++ b/src/components/feedback/test/ModalDialog-test.js
@@ -36,4 +36,14 @@ describe('ModalDialog', () => {
       assert.isFalse(dialogProps.closeOnFocusAway);
     });
   });
+
+  describe('restoring focus', () => {
+    it('restores focus by default', () => {
+      const wrapper = mount(
+        <ModalDialog title="Test modal dialog">This is my dialog</ModalDialog>
+      );
+      const dialogProps = wrapper.find('Dialog').props();
+      assert.isTrue(dialogProps.restoreFocus);
+    });
+  });
 });

--- a/src/pattern-library/components/patterns/feedback/DialogPage.tsx
+++ b/src/pattern-library/components/patterns/feedback/DialogPage.tsx
@@ -32,6 +32,7 @@ function DialogButtons() {
 type Dialog_Props = DialogProps & {
   /** Pattern-wrapping prop. Not visible in source view */
   _nonCloseable?: boolean;
+  _alwaysShowButton?: boolean;
 };
 
 /**
@@ -40,6 +41,7 @@ type Dialog_Props = DialogProps & {
  */
 function Dialog_({
   buttons,
+  _alwaysShowButton = false,
   _nonCloseable,
   children,
   ...dialogProps
@@ -54,18 +56,27 @@ function Dialog_({
     <Button onClick={closeDialog}>Escape!</Button>
   );
 
-  if (!dialogOpen) {
-    return (
-      <Button onClick={() => setDialogOpen(!dialogOpen)} variant="primary">
-        Show dialog
-      </Button>
-    );
-  }
+  const openButton = (
+    <Button onClick={() => setDialogOpen(!dialogOpen)} variant="primary">
+      {dialogOpen ? 'Hide' : 'Show'} dialog
+    </Button>
+  );
 
   return (
-    <Dialog buttons={forwardedButtons} {...dialogProps} onClose={closeHandler}>
-      {children}
-    </Dialog>
+    <div className="flex w-full gap-x-2">
+      {(!dialogOpen || _alwaysShowButton) && <div>{openButton}</div>}
+      <div className="grow">
+        {dialogOpen && (
+          <Dialog
+            buttons={forwardedButtons}
+            {...dialogProps}
+            onClose={closeHandler}
+          >
+            {children}
+          </Dialog>
+        )}
+      </div>
+    </div>
   );
 }
 
@@ -99,15 +110,15 @@ export default function DialogPage() {
               <li>Support close-on-click-away (disabled by default).</li>
               <li>Support close-on-away-focus (disabled by default).</li>
               <li>Initial focus routing</li>
+              <li>
+                Support focus restoration after close (disabled by default)
+              </li>
             </ul>
           </Library.Example>
 
           <Library.Example title="TODO">
             <ul>
               <li>Support focus trapping (disabled by default)</li>
-              <li>
-                Support focus restoration after close (disabled by default)
-              </li>
               <li>All tests and vet automated accessibility tests</li>
             </ul>
           </Library.Example>
@@ -190,6 +201,35 @@ export default function DialogPage() {
               <Dialog_ closeOnEscape onClose={() => {}} title="Close on ESC">
                 <p>
                   This dialog will close if you press <kbd>Escape</kbd>.
+                </p>
+              </Dialog_>
+            </Library.Demo>
+          </Library.Example>
+
+          <Library.Example title="restoreFocus">
+            <p>
+              This boolean prop (default <code>false</code>) restores focus when
+              the Dialog is closed to the element that had focus before it was
+              opened.
+            </p>
+            <p>
+              Note: This example does not hide its button when the Dialog is
+              open, as the button needs to be present to restore focus to it.
+            </p>
+
+            <Library.Demo
+              title="Dialog with focus restoration on close"
+              withSource
+            >
+              <Dialog_
+                _alwaysShowButton
+                restoreFocus
+                onClose={() => {}}
+                title="Restore focus"
+              >
+                <p>
+                  This dialog will restore focus to the previously-focused
+                  element on close.
                 </p>
               </Dialog_>
             </Library.Demo>

--- a/src/pattern-library/components/patterns/feedback/ModalDialogPage.tsx
+++ b/src/pattern-library/components/patterns/feedback/ModalDialogPage.tsx
@@ -32,6 +32,7 @@ function ModalDialogButtons() {
 type ModalDialog_Props = ModalDialogProps & {
   /** Pattern-wrapping prop. Not visible in source view */
   _nonCloseable?: boolean;
+  _alwaysShowButton?: boolean;
 };
 
 /**
@@ -40,6 +41,7 @@ type ModalDialog_Props = ModalDialogProps & {
  */
 function ModalDialog_({
   buttons,
+  _alwaysShowButton = false,
   _nonCloseable,
   children,
   ...dialogProps
@@ -54,22 +56,25 @@ function ModalDialog_({
     <Button onClick={closeDialog}>Escape!</Button>
   );
 
-  if (!dialogOpen) {
-    return (
-      <Button onClick={() => setDialogOpen(!dialogOpen)} variant="primary">
-        Show modal dialog
-      </Button>
-    );
-  }
+  const openButton = (
+    <Button onClick={() => setDialogOpen(!dialogOpen)} variant="primary">
+      {dialogOpen ? 'Hide' : 'Show'} dialog
+    </Button>
+  );
 
   return (
-    <ModalDialog
-      buttons={forwardedButtons}
-      {...dialogProps}
-      onClose={closeHandler}
-    >
-      {children}
-    </ModalDialog>
+    <>
+      {(!dialogOpen || _alwaysShowButton) && openButton}
+      {dialogOpen && (
+        <ModalDialog
+          buttons={forwardedButtons}
+          {...dialogProps}
+          onClose={closeHandler}
+        >
+          {children}
+        </ModalDialog>
+      )}
+    </>
   );
 }
 
@@ -98,10 +103,11 @@ export default function ModalDialogPage() {
           <Library.Usage componentName="ModalDialog" />
           <p>
             By default, <code>ModalDialog</code>s close when the ESC key is
-            pressed.
+            pressed, and will restore focus when closed.
           </p>
           <Library.Demo title="Basic ModalDialog" withSource>
             <ModalDialog_
+              _alwaysShowButton
               buttons={<ModalDialogButtons />}
               icon={EditIcon}
               initialFocus={inputRef}


### PR DESCRIPTION
This PR adds restore-focus support when a `Dialog` is closed (unmounted in this case, as Dialogs do not manage state otherwise). This is disabled by default for (i.e. non-modal) `Dialog`s, but _enabled_ by default for `ModalDialog`. 

This is consistent with WAI-ARIA behavior guidelines for modal dialogs.

Depends on #929 
Part of #77