### PR TITLE
Add focus-trap and tab-key keyboard navigation to `ModalDialog`

### DIFF
--- a/src/components/feedback/ModalDialog.tsx
+++ b/src/components/feedback/ModalDialog.tsx
@@ -1,6 +1,7 @@
 import classnames from 'classnames';
 
 import { useSyncedRef } from '../../hooks/use-synced-ref';
+import { useTabKeyNavigation } from '../../hooks/use-tab-key-navigation';
 import { downcastRef } from '../../util/typing';
 import Overlay from '../layout/Overlay';
 import Dialog from './Dialog';
@@ -8,6 +9,12 @@ import type { DialogProps } from './Dialog';
 
 type ComponentProps = {
   size?: 'sm' | 'md' | 'lg' | 'custom';
+
+  /**
+   * Disable WAI-ARIA-specific modal-dialog focus trap and tab/shift-tab
+   * keyboard navigation
+   */
+  disableFocusTrap?: boolean;
 };
 
 export type ModalDialogProps = DialogProps & ComponentProps;
@@ -18,6 +25,7 @@ export type ModalDialogProps = DialogProps & ComponentProps;
 const ModalDialogNext = function ModalDialog({
   children,
   size = 'md',
+  disableFocusTrap = false,
 
   classes,
   elementRef,
@@ -32,6 +40,8 @@ const ModalDialogNext = function ModalDialog({
   ...htmlAndPanelAttributes
 }: ModalDialogProps) {
   const modalRef = useSyncedRef(elementRef);
+
+  useTabKeyNavigation(modalRef, { enabled: !disableFocusTrap });
 
   return (
     <Overlay data-composite-component="ModalDialog">

--- a/src/components/feedback/test/ModalDialog-test.js
+++ b/src/components/feedback/test/ModalDialog-test.js
@@ -13,6 +13,17 @@ const createComponent = (Component, props = {}) => {
 };
 
 describe('ModalDialog', () => {
+  let fakeUseTabKeyNavigation;
+
+  beforeEach(() => {
+    fakeUseTabKeyNavigation = sinon.stub();
+    $imports.$mock({
+      '../../hooks/use-tab-key-navigation': {
+        useTabKeyNavigation: fakeUseTabKeyNavigation,
+      },
+    });
+  });
+
   testCompositeComponent(ModalDialog, {
     createContent: createComponent,
     // ModalDialog's primary component element is its wrapped Dialog
@@ -44,6 +55,28 @@ describe('ModalDialog', () => {
       );
       const dialogProps = wrapper.find('Dialog').props();
       assert.isTrue(dialogProps.restoreFocus);
+    });
+  });
+
+  describe('trapping focus', () => {
+    it('traps focus by default', () => {
+      mount(
+        <ModalDialog title="Test modal dialog">This is my dialog</ModalDialog>
+      );
+      assert.deepEqual(fakeUseTabKeyNavigation.lastCall.args[1], {
+        enabled: true,
+      });
+    });
+
+    it('allows disabling of focus trap', () => {
+      mount(
+        <ModalDialog title="Test modal dialog" disableFocusTrap>
+          This is my dialog
+        </ModalDialog>
+      );
+      assert.deepEqual(fakeUseTabKeyNavigation.lastCall.args[1], {
+        enabled: false,
+      });
     });
   });
 });

--- a/src/hooks/test/use-arrow-key-navigation-test.js
+++ b/src/hooks/test/use-arrow-key-navigation-test.js
@@ -1,4 +1,4 @@
-import { options as preactOptions, render } from 'preact';
+import { render } from 'preact';
 import { useRef } from 'preact/hooks';
 import { act } from 'preact/test-utils';
 
@@ -33,16 +33,6 @@ describe('useArrowKeyNavigation', () => {
 
   afterEach(() => {
     container.remove();
-  });
-
-  // Workaround for an issue with `useEffect` throwing exceptions during
-  // `act` callbacks. Can be removed when https://github.com/preactjs/preact/pull/3530 is shipped.
-  let prevDebounceRendering;
-  beforeEach(() => {
-    prevDebounceRendering = preactOptions.debounceRendering;
-  });
-  afterEach(() => {
-    preactOptions.debounceRendering = prevDebounceRendering;
   });
 
   function renderToolbar(options = {}) {

--- a/src/hooks/test/use-tab-key-navigation-test.js
+++ b/src/hooks/test/use-tab-key-navigation-test.js
@@ -1,0 +1,245 @@
+import { render } from 'preact';
+import { useRef } from 'preact/hooks';
+import { act } from 'preact/test-utils';
+
+import { waitFor } from '../../test-util/wait';
+import { useTabKeyNavigation } from '../use-tab-key-navigation';
+
+function Toolbar({ navigationOptions = {} }) {
+  const containerRef = useRef();
+
+  useTabKeyNavigation(containerRef, navigationOptions);
+
+  return (
+    <div ref={containerRef} data-testid="toolbar">
+      <button data-testid="bold">Bold</button>
+      <button data-testid="italic">Italic</button>
+      <button data-testid="underline">Underline</button>
+      <a href="/help" target="_blank" data-testid="help">
+        Help
+      </a>
+    </div>
+  );
+}
+
+describe('useTabKeyNavigation', () => {
+  let container;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.append(container);
+    renderToolbar();
+  });
+
+  afterEach(() => {
+    container.remove();
+  });
+
+  function renderToolbar(options = {}) {
+    // We render the component with Preact directly rather than using Enzyme
+    // for these tests. Since the `tabIndex` state lives only in the DOM,
+    // and there are no child components involved, this is more convenient.
+    act(() => {
+      render(<Toolbar navigationOptions={options} />, container);
+    });
+    return findElementByTestId('toolbar');
+  }
+
+  function findElementByTestId(testId) {
+    return container.querySelector(`[data-testid=${testId}]`);
+  }
+
+  /**
+   * @param {string|Partial<KeyboardEvent>} key - Either a string name of a
+   *   key (e.g. 'ArrowLeft') or a partial `KeyboardEvent` object, e.g.
+   *   `{ key: 'Tab', shiftKey: true }`
+   */
+  function pressKey(key) {
+    const eventOptions = typeof key === 'string' ? { key } : key;
+
+    const event = new KeyboardEvent('keydown', {
+      bubbles: true,
+      cancelable: true,
+      ...eventOptions,
+    });
+    act(() => {
+      findElementByTestId('toolbar').dispatchEvent(event);
+    });
+    return event;
+  }
+
+  function currentItem() {
+    return document.activeElement.innerText;
+  }
+
+  it('should move focus and tab stop between elements when tab keys are pressed', () => {
+    const forwardKey = 'Tab';
+    const backKey = { key: 'Tab', shiftKey: true };
+
+    renderToolbar();
+
+    const steps = [
+      // Test navigating forwards.
+      [forwardKey, 'Italic'],
+      [forwardKey, 'Underline'],
+      [forwardKey, 'Help'],
+
+      // Test that navigation wraps to start.
+      [forwardKey, 'Bold'],
+
+      // Test that navigation wraps to end.
+      [backKey, 'Help'],
+
+      // Test navigating backwards.
+      [backKey, 'Underline'],
+      [backKey, 'Italic'],
+      [backKey, 'Bold'],
+    ];
+
+    for (let [key, expectedItem] of steps) {
+      pressKey(key);
+
+      const currentElement = document.activeElement;
+      assert.equal(currentElement.innerText, expectedItem);
+
+      const toolbarButtons = container.querySelectorAll('a,button');
+      for (let element of toolbarButtons) {
+        if (element === currentElement) {
+          assert.equal(element.tabIndex, 0);
+        } else {
+          assert.equal(element.tabIndex, -1);
+        }
+      }
+    }
+  });
+
+  [
+    {
+      key: 'Tab',
+      shouldHandle: true,
+    },
+    {
+      key: { key: 'Tab', shiftKey: true },
+      shouldHandle: true,
+    },
+    {
+      key: 'Space',
+      shouldHandle: false,
+    },
+  ].forEach(({ key, shouldHandle }) => {
+    it('should stop keyboard event propagation if event is handled', () => {
+      renderToolbar();
+
+      const handleKeyDown = sinon.stub();
+      container.addEventListener('keydown', handleKeyDown);
+
+      const event = pressKey(key);
+      assert.equal(
+        event.defaultPrevented,
+        shouldHandle,
+        `${key} defaultPrevented`
+      );
+      assert.equal(handleKeyDown.called, !shouldHandle, `${key} propagated`);
+      handleKeyDown.resetHistory();
+    });
+  });
+
+  it('should skip hidden elements', () => {
+    renderToolbar();
+    findElementByTestId('bold').focus();
+    findElementByTestId('italic').style.display = 'none';
+
+    pressKey('Tab');
+
+    assert.equal(currentItem(), 'Underline');
+  });
+
+  it('should skip disabled elements', () => {
+    renderToolbar();
+    findElementByTestId('bold').focus();
+    findElementByTestId('italic').disabled = true;
+
+    pressKey('Tab');
+
+    assert.equal(currentItem(), 'Underline');
+  });
+
+  it('should not respond to keys if hook is not enabled', () => {
+    renderToolbar({
+      enabled: false,
+    });
+    ['Tab', { key: 'Tab', shiftKey: true }].forEach(key => {
+      findElementByTestId('bold').focus();
+      pressKey(key);
+      assert.equal(currentItem(), 'Bold');
+    });
+  });
+
+  it('shows an error if container ref is not initialized', () => {
+    function BrokenToolbar() {
+      const ref = useRef();
+      useTabKeyNavigation(ref);
+      return <div />;
+    }
+
+    // Suppress "Add @babel/plugin-transform-react-jsx-source to get a more
+    // detailed component stack" warning from the `render` call below.
+    sinon.stub(console, 'warn');
+
+    let error;
+    try {
+      act(() => render(<BrokenToolbar />, container));
+    } catch (e) {
+      error = e;
+    } finally {
+      console.warn.restore();
+    }
+
+    assert.instanceOf(error, Error);
+    assert.equal(error.message, 'Container ref not set');
+  });
+
+  it('should respect a custom element selector', () => {
+    renderToolbar({
+      selector: '[data-testid=bold],[data-testid=italic]',
+    });
+    findElementByTestId('bold').focus();
+
+    pressKey('Tab');
+    assert.equal(currentItem(), 'Italic');
+    pressKey('Tab');
+    assert.equal(currentItem(), 'Bold');
+    pressKey({ key: 'Tab', shiftKey: true });
+    assert.equal(currentItem(), 'Italic');
+  });
+
+  it('should re-initialize tabindex attributes if current element is removed', async () => {
+    const toolbar = renderToolbar();
+    const boldButton = toolbar.querySelector('[data-testid=bold]');
+    const italicButton = toolbar.querySelector('[data-testid=italic]');
+
+    boldButton.focus();
+    assert.equal(boldButton.tabIndex, 0);
+    assert.equal(italicButton.tabIndex, -1);
+
+    boldButton.remove();
+
+    // nb. tabIndex update is async because it uses MutationObserver
+    await waitFor(() => italicButton.tabIndex === 0);
+  });
+
+  it('should re-initialize tabindex attributes if current element is disabled', async () => {
+    renderToolbar();
+    const boldButton = findElementByTestId('bold');
+    const italicButton = findElementByTestId('italic');
+
+    boldButton.focus();
+    assert.equal(boldButton.tabIndex, 0);
+    assert.equal(italicButton.tabIndex, -1);
+
+    boldButton.disabled = true;
+
+    // nb. tabIndex update is async because it uses MutationObserver
+    await waitFor(() => italicButton.tabIndex === 0);
+  });
+});

--- a/src/hooks/use-tab-key-navigation.ts
+++ b/src/hooks/use-tab-key-navigation.ts
@@ -1,0 +1,185 @@
+import type { RefObject } from 'preact';
+import { useEffect } from 'preact/hooks';
+
+import { ListenerCollection } from '../util/listener-collection';
+
+function isElementDisabled(element: HTMLElement & { disabled?: boolean }) {
+  return typeof element.disabled === 'boolean' && element.disabled;
+}
+
+function isElementVisible(element: HTMLElement) {
+  return element.offsetParent !== null;
+}
+
+export type UseTabKeyNavigationOptions = {
+  /**
+   * Whether to focus the first element in the set of matching elements when
+   * the component is mounted
+   */
+  autofocus?: boolean;
+
+  /**
+   * Don't respond to any keyboard events if not enabled. This allows selective
+   * enabling by components using this hook, as hook use itself cannot be
+   * conditional.
+   */
+  enabled?: boolean;
+
+  /**
+   * CSS selector which specifies the elements that navigation moves between
+   */
+  selector?: string;
+};
+
+/**
+ * Trap focus within a modal dialog and support roving tabindex with 'Tab' and
+ * 'Shift-Tab' keys to navigate through interactive descendants. See [1] for
+ * reference for how keyboard navigation should work within modal dialogs.
+ *
+ * NB: This hook should be removed/disused once we migrate to using native
+ * <dialog> elements. The hook duplicates some logic in `useArrowKeyNavigation`.
+ *
+ * @example
+ *   function MyModalDialog() {
+ *     const container = useRef();
+ *
+ *     // Enable tab key navigation between interactive elements in the
+ *     // modal-dialog container.
+ *     useTabKeyNavigation(container);
+ *
+ *     return (
+ *       <div ref={container} role="dialog" aria-modal>
+ *         <button>Bold</bold>
+ *         <button>Italic</bold>
+ *         <a href="https://example.com/help">Help</a>
+ *       </div>
+ *     )
+ *   }
+ *
+ * [1] https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/#keyboardinteraction
+ *
+ */
+
+export function useTabKeyNavigation(
+  containerRef: RefObject<HTMLElement | undefined>,
+  {
+    enabled = true,
+    autofocus = false,
+    selector = 'a,button,input,select,textarea',
+  }: UseTabKeyNavigationOptions = {}
+) {
+  useEffect(() => {
+    if (!enabled) {
+      return () => {};
+    }
+    if (!containerRef.current) {
+      throw new Error('Container ref not set');
+    }
+    const container = containerRef.current;
+
+    const getNavigableElements = () => {
+      const elements: HTMLElement[] = Array.from(
+        container.querySelectorAll(selector)
+      );
+      return elements.filter(
+        el => isElementVisible(el) && !isElementDisabled(el)
+      );
+    };
+
+    /**
+     * Update the `tabindex` attribute of navigable elements.
+     *
+     * Exactly one element will have `tabindex=0` and all others will have
+     * `tabindex=1`.
+
+     * @param currentIndex - Index of element in `elements` to make current.
+     *   Defaults to the current element if there is one, or the first element
+     *   otherwise.
+     * @param setFocus - Whether to focus the current element
+     */
+    const updateTabIndexes = (
+      elements = getNavigableElements(),
+      currentIndex = -1,
+      setFocus = false
+    ) => {
+      if (currentIndex < 0) {
+        currentIndex = elements.findIndex(el => el.tabIndex === 0);
+        if (currentIndex < 0) {
+          currentIndex = 0;
+        }
+      }
+
+      for (const [index, element] of elements.entries()) {
+        element.tabIndex = index === currentIndex ? 0 : -1;
+        if (index === currentIndex && setFocus) {
+          element.focus();
+        }
+      }
+    };
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      const elements = getNavigableElements();
+      let currentIndex = elements.findIndex(item => item.tabIndex === 0);
+
+      let handled = false;
+      if (event.key === 'Tab' && event.shiftKey) {
+        if (currentIndex === 0) {
+          currentIndex = elements.length - 1;
+        } else {
+          --currentIndex;
+        }
+        handled = true;
+      } else if (event.key === 'Tab') {
+        if (currentIndex === elements.length - 1) {
+          currentIndex = 0;
+        } else {
+          ++currentIndex;
+        }
+        handled = true;
+      }
+
+      if (!handled) {
+        return;
+      }
+
+      updateTabIndexes(elements, currentIndex, true);
+
+      event.preventDefault();
+      event.stopPropagation();
+    };
+
+    updateTabIndexes(getNavigableElements(), 0, autofocus);
+
+    const listeners = new ListenerCollection();
+
+    // Set an element as current when it gains focus. In Safari this event
+    // may not be received if the element immediately loses focus after it
+    // is triggered.
+    listeners.add(container, 'focusin', event => {
+      const elements = getNavigableElements();
+      const targetIndex = elements.indexOf(event.target as HTMLElement);
+      if (targetIndex >= 0) {
+        updateTabIndexes(elements, targetIndex);
+      }
+    });
+
+    listeners.add(container, 'keydown', onKeyDown);
+
+    // Update the tab indexes of elements as they are added, removed, enabled
+    // or disabled.
+    const mo = new MutationObserver(() => {
+      updateTabIndexes();
+    });
+    mo.observe(container, {
+      subtree: true,
+      attributes: true,
+      attributeFilter: ['disabled'],
+      childList: true,
+    });
+
+    return () => {
+      listeners.removeAll();
+      mo.disconnect();
+    };
+  }, [autofocus, containerRef, enabled, selector]);
+}

--- a/src/pattern-library/components/patterns/feedback/DialogPage.tsx
+++ b/src/pattern-library/components/patterns/feedback/DialogPage.tsx
@@ -100,28 +100,6 @@ export default function DialogPage() {
             </strong>{' '}
             and is not yet part of this {"package's"} public API.
           </p>
-
-          <Library.Example title="Done">
-            <ul>
-              <li>
-                Creation of <code>Dialog</code> component.
-              </li>
-              <li>Support close-on-ESC (disabled by default).</li>
-              <li>Support close-on-click-away (disabled by default).</li>
-              <li>Support close-on-away-focus (disabled by default).</li>
-              <li>Initial focus routing</li>
-              <li>
-                Support focus restoration after close (disabled by default)
-              </li>
-            </ul>
-          </Library.Example>
-
-          <Library.Example title="TODO">
-            <ul>
-              <li>Support focus trapping (disabled by default)</li>
-              <li>All tests and vet automated accessibility tests</li>
-            </ul>
-          </Library.Example>
         </Library.Pattern>
         <Library.Pattern title="Usage">
           <Library.Usage componentName="Dialog" />

--- a/src/pattern-library/components/patterns/feedback/ModalDialogPage.tsx
+++ b/src/pattern-library/components/patterns/feedback/ModalDialogPage.tsx
@@ -9,6 +9,7 @@ import {
   IconButton,
   Input,
   InputGroup,
+  Link,
 } from '../../../../next';
 import Library from '../../Library';
 
@@ -102,9 +103,13 @@ export default function ModalDialogPage() {
         <Library.Pattern title="Usage">
           <Library.Usage componentName="ModalDialog" />
           <p>
-            By default, <code>ModalDialog</code>s close when the ESC key is
-            pressed, and will restore focus when closed.
+            By default, <code>ModalDialog</code> components:
           </p>
+          <ul>
+            <li>Close on ESC keypress</li>
+            <li>Trap focus and allow navigation with Tab/Shift-Tab keys</li>
+            <li>Restore focus to previously-focused element when closed</li>
+          </ul>
           <Library.Demo title="Basic ModalDialog" withSource>
             <ModalDialog_
               _alwaysShowButton
@@ -122,7 +127,67 @@ export default function ModalDialogPage() {
             </ModalDialog_>
           </Library.Demo>
         </Library.Pattern>
-        <Library.Pattern title="Props">TODO</Library.Pattern>
+        <Library.Pattern title="Props">
+          <Library.Example title="disableFocusTrap">
+            <p>
+              This boolean prop (default <code>true</code>) enables modal-dialog
+              focus trap and keyboard navigation as specified by{' '}
+              <Link
+                href="https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/#keyboardinteraction"
+                underline="always"
+              >
+                WAI-ARIA authoring guidelines
+              </Link>
+              .
+            </p>
+            <p>
+              <em>Note</em>: Disabling this prop is not recommended and could
+              raise issues of accessibility.
+            </p>
+            <Library.Demo title="Disabling focus trapping">
+              <ModalDialog_
+                _alwaysShowButton
+                buttons={<ModalDialogButtons />}
+                icon={EditIcon}
+                initialFocus={inputRef}
+                onClose={() => {}}
+                title="Modal Dialog with disabled `trapFocus`"
+                disableFocusTrap
+              >
+                <p>This is a ModalDialog that does not trap focus.</p>
+                <InputGroup>
+                  <Input name="my-input" elementRef={inputRef} />
+                  <IconButton icon={ArrowRightIcon} variant="dark" title="go" />
+                </InputGroup>
+              </ModalDialog_>
+            </Library.Demo>
+          </Library.Example>
+
+          <Library.Example title="Props forwarded to Dialog">
+            <p>
+              The following optional props (<code>ModalDialog</code> defaults in
+              parentheses) are forwarded to <code>Dialog</code>. See{' '}
+              <code>Dialog</code> documentation for details.
+            </p>
+            <ul>
+              <li>
+                <code>closeOnEscape</code> (<code>true</code>)
+              </li>
+              <li>
+                <code>closeOnClickAway</code> (<code>false</code>)
+              </li>
+              <li>
+                <code>closeOnFocusAway</code> (<code>false</code>)
+              </li>
+              <li>
+                <code>initialFocus</code> (<code>{"'auto'"}</code>)
+              </li>
+              <li>
+                <code>restoreFocus</code> (<code>true</code>)
+              </li>
+            </ul>
+          </Library.Example>
+        </Library.Pattern>
       </Library.Section>
     </Library.Page>
   );


### PR DESCRIPTION
This PR adds a new hook, `useTabKeyNavigation`, modeled after `useArrowKeyNavigation`, and enables it by default for `ModalDialog`.

This establishes trap-focus behavior and tab/shift-tab keyboard navigation for `ModalDialog`s, which we need for accessibility.

Note that `useTabKeyNavigation` duplicates behavior from `useArrowKeyNavigation`, per voice discussion earlier today. The life expectancy of `useTabKeyNavigation` is short-ish, so this time-saving measure is perhaps justifiable. 

This PR also contains a commit that removes a no-longer-needed testing workaround for `useArrowKeyNavigation`'s tests.