### PR TITLE
Consolidate `*Dialog` props and documentation; export `Dialog`

### DIFF
--- a/src/components/feedback/ModalDialog.tsx
+++ b/src/components/feedback/ModalDialog.tsx
@@ -7,8 +7,13 @@ import Overlay from '../layout/Overlay';
 import Dialog from './Dialog';
 import type { DialogProps } from './Dialog';
 
+type ModalWidth = 'sm' | 'md' | 'lg' | 'custom';
+
 type ComponentProps = {
-  width?: 'sm' | 'md' | 'lg' | 'custom';
+  /**
+   * @deprecated  - use `size` instead
+   */
+  width?: ModalWidth;
 
   /**
    * Do not close the modal when the Escape key is pressed
@@ -26,6 +31,11 @@ type ComponentProps = {
    * the dialog is closed.
    */
   disableRestoreFocus?: boolean;
+
+  /**
+   * Relative size (width) of modal dialog
+   */
+  size?: ModalWidth;
 };
 
 export type ModalDialogProps = Omit<
@@ -39,10 +49,11 @@ export type ModalDialogProps = Omit<
  */
 const ModalDialogNext = function ModalDialog({
   children,
-  width = 'md',
   disableCloseOnEscape = false,
   disableFocusTrap = false,
   disableRestoreFocus = false,
+  size,
+  width,
 
   classes,
   elementRef,
@@ -54,6 +65,8 @@ const ModalDialogNext = function ModalDialog({
 
   ...htmlAndPanelAttributes
 }: ModalDialogProps) {
+  // Prefer `size` prop but support deprecated `width` if present
+  const modalSize = size ?? width ?? 'md';
   const modalRef = useSyncedRef(elementRef);
 
   useTabKeyNavigation(modalRef, { enabled: !disableFocusTrap });
@@ -83,14 +96,17 @@ const ModalDialogNext = function ModalDialog({
           'tall:fixed tall:max-h-[80vh] tall:top-[10vh]',
           {
             // Max-width rules will ensure actual width never exceeds 90vw
-            'w-[30rem]': width === 'sm',
-            'w-[36rem]': width === 'md', // default
-            'w-[42rem]': width === 'lg',
+            'w-[30rem]': modalSize === 'sm',
+            'w-[36rem]': modalSize === 'md', // default
+            'w-[42rem]': modalSize === 'lg',
             // No width classes are added if width is 'custom'
           },
           classes
         )}
         elementRef={downcastRef(modalRef)}
+        // Testing affordance. TODO: Remove once deprecated `width` prop
+        // no longer supported.
+        data-modal-size={modalSize}
       >
         {children}
       </Dialog>

--- a/src/components/feedback/ModalDialog.tsx
+++ b/src/components/feedback/ModalDialog.tsx
@@ -8,7 +8,7 @@ import Dialog from './Dialog';
 import type { DialogProps } from './Dialog';
 
 type ComponentProps = {
-  size?: 'sm' | 'md' | 'lg' | 'custom';
+  width?: 'sm' | 'md' | 'lg' | 'custom';
 
   /**
    * Disable WAI-ARIA-specific modal-dialog focus trap and tab/shift-tab
@@ -24,7 +24,7 @@ export type ModalDialogProps = DialogProps & ComponentProps;
  */
 const ModalDialogNext = function ModalDialog({
   children,
-  size = 'md',
+  width = 'md',
   disableFocusTrap = false,
 
   classes,
@@ -68,10 +68,10 @@ const ModalDialogNext = function ModalDialog({
           'tall:fixed tall:max-h-[80vh] tall:top-[10vh]',
           {
             // Max-width rules will ensure actual width never exceeds 90vw
-            'w-[30rem]': size === 'sm',
-            'w-[36rem]': size === 'md', // default
-            'w-[42rem]': size === 'lg',
-            // No width classes are added if size is 'custom'
+            'w-[30rem]': width === 'sm',
+            'w-[36rem]': width === 'md', // default
+            'w-[42rem]': width === 'lg',
+            // No width classes are added if width is 'custom'
           },
           classes
         )}

--- a/src/components/feedback/ModalDialog.tsx
+++ b/src/components/feedback/ModalDialog.tsx
@@ -11,13 +11,28 @@ type ComponentProps = {
   width?: 'sm' | 'md' | 'lg' | 'custom';
 
   /**
+   * Do not close the modal when the Escape key is pressed
+   */
+  disableCloseOnEscape?: boolean;
+
+  /**
    * Disable WAI-ARIA-specific modal-dialog focus trap and tab/shift-tab
    * keyboard navigation
    */
   disableFocusTrap?: boolean;
+
+  /**
+   * Disable the restoration of focus to the previously-focused element when
+   * the dialog is closed.
+   */
+  disableRestoreFocus?: boolean;
 };
 
-export type ModalDialogProps = DialogProps & ComponentProps;
+export type ModalDialogProps = Omit<
+  DialogProps,
+  'restoreFocus' | 'closeOnEscape'
+> &
+  ComponentProps;
 
 /**
  * Show a modal dialog
@@ -25,17 +40,17 @@ export type ModalDialogProps = DialogProps & ComponentProps;
 const ModalDialogNext = function ModalDialog({
   children,
   width = 'md',
+  disableCloseOnEscape = false,
   disableFocusTrap = false,
+  disableRestoreFocus = false,
 
   classes,
   elementRef,
 
   // Forwarded to Dialog
-  closeOnEscape = true,
   closeOnClickAway = false,
   closeOnFocusAway = false,
   initialFocus = 'auto',
-  restoreFocus = true,
 
   ...htmlAndPanelAttributes
 }: ModalDialogProps) {
@@ -52,9 +67,9 @@ const ModalDialogNext = function ModalDialog({
         // Dialog props
         closeOnClickAway={closeOnClickAway}
         closeOnFocusAway={closeOnFocusAway}
-        closeOnEscape={closeOnEscape}
+        closeOnEscape={!disableCloseOnEscape}
         initialFocus={initialFocus}
-        restoreFocus={restoreFocus}
+        restoreFocus={!disableRestoreFocus}
         classes={classnames(
           // Column-flex layout to constrain content to max-height
           'flex flex-col',

--- a/src/components/feedback/test/ModalDialog-test.js
+++ b/src/components/feedback/test/ModalDialog-test.js
@@ -99,4 +99,47 @@ describe('ModalDialog', () => {
       });
     });
   });
+
+  describe('modal size', () => {
+    function sizedModal(props) {
+      return mount(
+        <ModalDialog title="Test modal dialog" {...props}>
+          This is my dialog
+        </ModalDialog>
+      );
+    }
+
+    function modalSize(wrapper) {
+      return wrapper
+        .find('Dialog')
+        .getDOMNode()
+        .getAttribute('data-modal-size');
+    }
+
+    it('sets a default size if neither `size` nor `width` provided', () => {
+      const wrapper = mount(
+        <ModalDialog title="Test modal dialog">This is my dialog</ModalDialog>
+      );
+
+      assert.equal(modalSize(wrapper), 'md');
+    });
+
+    it('sets size from size prop', () => {
+      const wrapper = sizedModal({ size: 'lg' });
+
+      assert.equal(modalSize(wrapper), 'lg');
+    });
+
+    it('accepts deprecated `width` prop to set size', () => {
+      const wrapper = sizedModal({ width: 'lg' });
+
+      assert.equal(modalSize(wrapper), 'lg');
+    });
+
+    it('prefers `size` over `width` to set size', () => {
+      const wrapper = sizedModal({ size: 'lg', width: 'sm' });
+
+      assert.equal(modalSize(wrapper), 'lg');
+    });
+  });
 });

--- a/src/components/feedback/test/ModalDialog-test.js
+++ b/src/components/feedback/test/ModalDialog-test.js
@@ -46,6 +46,16 @@ describe('ModalDialog', () => {
       assert.isFalse(dialogProps.closeOnClickAway);
       assert.isFalse(dialogProps.closeOnFocusAway);
     });
+
+    it('allows disabling of close-on-escape', () => {
+      const wrapper = mount(
+        <ModalDialog title="Test modal dialog" disableCloseOnEscape>
+          This is my dialog
+        </ModalDialog>
+      );
+      const dialogProps = wrapper.find('Dialog').props();
+      assert.isFalse(dialogProps.closeOnEscape);
+    });
   });
 
   describe('restoring focus', () => {
@@ -55,6 +65,16 @@ describe('ModalDialog', () => {
       );
       const dialogProps = wrapper.find('Dialog').props();
       assert.isTrue(dialogProps.restoreFocus);
+    });
+
+    it('allows disabling of focus restoration', () => {
+      const wrapper = mount(
+        <ModalDialog title="Test modal dialog" disableRestoreFocus>
+          This is my dialog
+        </ModalDialog>
+      );
+      const dialogProps = wrapper.find('Dialog').props();
+      assert.isFalse(dialogProps.restoreFocus);
     });
   });
 

--- a/src/next.ts
+++ b/src/next.ts
@@ -22,7 +22,7 @@ export {
   TableRow,
   Thumbnail,
 } from './components/data';
-export { Modal, Spinner, SpinnerOverlay } from './components/feedback';
+export { Dialog, Modal, Spinner, SpinnerOverlay } from './components/feedback';
 export {
   Button,
   ButtonBase,
@@ -75,6 +75,7 @@ export type {
 } from './components/data';
 
 export type {
+  DialogProps,
   ModalProps,
   SpinnerProps,
   SpinnerOverlayProps,

--- a/src/pattern-library/components/Library.tsx
+++ b/src/pattern-library/components/Library.tsx
@@ -259,14 +259,15 @@ function StatusChip({ status }: LibraryStatusChipProps) {
     <span
       className={classnames('rounded-md py-1', {
         'px-2 bg-red-error text-color-text-inverted': status === 'breaking',
-        'px-2 bg-yellow-notice': status === 'deprecated',
-        'font-semibold': status === 'added' || status === 'changed',
+        'px-2 bg-yellow-notice':
+          status === 'deprecated' || status === 'changed',
+        'font-semibold': status === 'added',
       })}
     >
       {status === 'breaking' && <span>Breaking</span>}
       {status === 'deprecated' && <span>Deprecated</span>}
       {status === 'added' && <span>Added:</span>}
-      {status === 'changed' && <span>Changed:</span>}
+      {status === 'changed' && <span>Changed</span>}
     </span>
   );
 }

--- a/src/pattern-library/components/patterns/feedback/DialogPage.tsx
+++ b/src/pattern-library/components/patterns/feedback/DialogPage.tsx
@@ -399,6 +399,9 @@ export default function DialogPage() {
                 pressed, but you can disable this behavior by setting the{' '}
                 <code>disableCloseOnEscape</code> prop.
               </Library.ChangelogItem>
+              <Library.ChangelogItem status="deprecated">
+                <code>width</code> prop → use <code>size</code> instead
+              </Library.ChangelogItem>
             </Library.Changelog>
           </Library.Example>
         </Library.Pattern>
@@ -578,35 +581,39 @@ export default function DialogPage() {
             </p>
           </Library.Example>
 
-          <Library.Example title="width">
-            <Library.Demo title="width='sm'" withSource>
+          <Library.Example title="size">
+            <p>
+              The <code>size</code> prop establishes the width of the modal
+              dialog.
+            </p>
+            <Library.Demo title="size='sm'" withSource>
               <ModalDialog_
                 buttons={<DialogButtons />}
                 onClose={() => {}}
                 title="Small modal"
-                width="sm"
+                size="sm"
               >
                 <LoremIpsum size="sm" />
               </ModalDialog_>
             </Library.Demo>
 
-            <Library.Demo title="width='md' (default)" withSource>
+            <Library.Demo title="size='md' (default)" withSource>
               <ModalDialog_
                 buttons={<DialogButtons />}
                 onClose={() => {}}
                 title="Medium-width modal"
-                width="md"
+                size="md"
               >
                 <LoremIpsum size="md" />
               </ModalDialog_>
             </Library.Demo>
 
-            <Library.Demo title="width='lg'" withSource>
+            <Library.Demo title="size='lg'" withSource>
               <ModalDialog_
                 buttons={<DialogButtons />}
                 onClose={() => {}}
                 title="Wide modal"
-                width="lg"
+                size="lg"
               >
                 <LoremIpsum size="md" />
               </ModalDialog_>
@@ -614,17 +621,17 @@ export default function DialogPage() {
 
             <p>
               To style your <code>ModalDialog</code> with a custom width, set{' '}
-              <code>width</code> to <code>{"'custom'"}</code> and provide sizing
+              <code>size</code> to <code>{"'custom'"}</code> and provide sizing
               CSS class(es) via the <code>classes</code> prop.
             </p>
 
-            <Library.Demo title="width='custom'" withSource>
+            <Library.Demo title="size='custom'" withSource>
               <ModalDialog_
                 buttons={<DialogButtons />}
                 classes="w-[40em]"
                 onClose={() => {}}
                 title="Custom-width modal"
-                width="custom"
+                size="custom"
               >
                 <LoremIpsum size="md" />
               </ModalDialog_>
@@ -663,6 +670,16 @@ export default function DialogPage() {
                 </Scroll>
               </ModalDialog_>
             </Library.Demo>
+          </Library.Example>
+
+          <Library.Example title="width">
+            <p>
+              The{' '}
+              <s>
+                <code>width</code>
+              </s>{' '}
+              prop is deprecated: use <code>size</code> instead.
+            </p>
           </Library.Example>
 
           <Library.Example title="Forwarded Props: Dialog">

--- a/src/pattern-library/components/patterns/feedback/DialogPage.tsx
+++ b/src/pattern-library/components/patterns/feedback/DialogPage.tsx
@@ -168,9 +168,8 @@ export default function DialogPage() {
         <Library.Pattern title="Status">
           <p>
             <strong>
-              <code>Dialog</code> is under development
-            </strong>{' '}
-            and is not yet part of this {"package's"} public API.
+              <code>Dialog</code> is a new component.
+            </strong>
           </p>
         </Library.Pattern>
         <Library.Pattern title="Usage">
@@ -365,19 +364,47 @@ export default function DialogPage() {
         <Library.Pattern title="Status">
           <p>
             <strong>
-              <code>ModalDialog</code> is under development
-            </strong>{' '}
-            and is not yet part of this {"package's"} public API.
+              <code>ModalDialog</code> is intended to replace the existing,
+              deprecated <code>Modal</code> component.
+            </strong>
           </p>
+          <p>
+            <code>ModalDialog</code> is still under development and is not yet
+            part of the package API.
+          </p>
+          <Library.Example title="Migrating to this component from Modal">
+            <Library.Changelog>
+              <Library.ChangelogItem status="changed">
+                ModalDialogs trap focus and provide tab/shift-tab navigation
+                through navigable elements. Disable this behavior by setting the{' '}
+                <code>disableFocusTrap</code> prop.
+              </Library.ChangelogItem>
+              <Library.ChangelogItem status="changed">
+                ModalDialogs restore focus to the previously-focused element
+                when closed. Disable this behavior by setting the{' '}
+                <code>disableRestoreFocus</code> prop.
+              </Library.ChangelogItem>
+              <Library.ChangelogItem status="changed">
+                ModalDialogs do not close when the user clicks outside of them.
+                Re-enable this behavior if needed by setting the{' '}
+                <code>closeOnClickAway</code> prop.
+              </Library.ChangelogItem>
+              <Library.ChangelogItem status="changed">
+                ModalDialogs do not close if there are focus events outside of
+                their container. Re-enable this behavior if needed by setting
+                the <code>closeOnFocusAwayProp</code>.
+              </Library.ChangelogItem>
+              <Library.ChangelogItem status="changed">
+                ModalDialogs (still) close when the <kbd>Escape</kbd> key is
+                pressed, but you can disable this behavior by setting the{' '}
+                <code>disableCloseOnEscape</code> prop.
+              </Library.ChangelogItem>
+            </Library.Changelog>
+          </Library.Example>
         </Library.Pattern>
         <Library.Pattern title="Usage">
           <Library.Usage componentName="ModalDialog" />
-          <p>
-            By default, <code>ModalDialog</code>s will close on escape keypress
-            (<code>closeOnEscape</code>) and restore focus on close (
-            <code>restoreFocus</code>). It also traps focus unless overridden
-            with <code>disableFocusTrap</code>.
-          </p>
+
           <Library.Demo title="Basic ModalDialog" withSource>
             <ModalDialog_
               _alwaysShowButton
@@ -388,6 +415,16 @@ export default function DialogPage() {
               title="Basic dialog"
             >
               <p>This is a basic ModalDialog.</p>
+              <ul className="list-disc m-8">
+                <li>
+                  It will close if you press the <kbd>Escape</kbd> key.
+                </li>
+                <li>
+                  It will trap focus and allow navigation with tab and
+                  shift-tab.
+                </li>
+                <li>It will restore focus after it is closed.</li>
+              </ul>
               <InputGroup>
                 <Input name="my-input" elementRef={inputRef} />
                 <IconButton icon={ArrowRightIcon} variant="dark" title="go" />
@@ -424,15 +461,17 @@ export default function DialogPage() {
             </p>
             <ul>
               <li>
-                <strong>Set a height on the Modal</strong> itself. The Modal
-                will always render at this height. If contained content height
-                exceeds this height, it will scroll.
+                <strong>Set a height on the ModalDialog</strong> itself. The
+                Modal will always render at this height. If contained content
+                height exceeds this height, it will scroll.
               </li>
               <li>
-                <strong>Set a minimum height on the {"Modal's"} content</strong>
-                . The Modal will always render at least this height, but will
-                grow in height if needed to accommodate longer content (up to
-                the bounds of the viewport).
+                <strong>
+                  Set a minimum height on the {"ModalDialog's"} content
+                </strong>
+                . The ModalDialog will always render at least this height, but
+                will grow in height if needed to accommodate longer content (up
+                to the bounds of the viewport).
               </li>
             </ul>
             <Library.Demo title="ModalDialog with a fixed height" withSource>
@@ -443,7 +482,7 @@ export default function DialogPage() {
                 onClose={() => {}}
               >
                 <p>
-                  This Modal has a height of <code>25rem</code>.
+                  This ModalDialog has a height of <code>25rem</code>.
                 </p>
               </ModalDialog_>
             </Library.Demo>
@@ -459,7 +498,7 @@ export default function DialogPage() {
                 onClose={() => {}}
               >
                 <p>
-                  This Modal has a height of <code>25rem</code> and long
+                  This ModalDialog has a height of <code>25rem</code> and long
                   content.
                 </p>
                 <LoremIpsum size="lg" />
@@ -477,8 +516,8 @@ export default function DialogPage() {
               >
                 <div className="min-h-[15rem]">
                   <p>
-                    This {"Modal's"} content has a preferred height of 15rem set
-                    by a CSS class.
+                    This {"ModalDialog's"} content has a preferred height of
+                    15rem set by a CSS class.
                   </p>
                 </div>
               </ModalDialog_>
@@ -508,10 +547,16 @@ export default function DialogPage() {
           </Library.Example>
         </Library.Pattern>
         <Library.Pattern title="Props">
+          <Library.Example title="disableCloseOnEscape">
+            <p>
+              Set this boolean prop (default <code>false</code>) to disable
+              closing the modal when the <kbd>Escape</kbd> key is pressed.
+            </p>
+          </Library.Example>
           <Library.Example title="disableFocusTrap">
             <p>
-              This boolean prop (default <code>true</code>) enables modal-dialog
-              focus trap and keyboard navigation as specified by{' '}
+              This boolean prop (default <code>false</code>) enables
+              modal-dialog focus trap and keyboard navigation as specified by{' '}
               <Link
                 href="https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/#keyboardinteraction"
                 underline="always"
@@ -524,23 +569,13 @@ export default function DialogPage() {
               <em>Note</em>: Disabling this prop is not recommended and could
               raise issues of accessibility.
             </p>
-            <Library.Demo title="Disabling focus trapping">
-              <ModalDialog_
-                _alwaysShowButton
-                buttons={<DialogButtons />}
-                icon={EditIcon}
-                initialFocus={inputRef}
-                onClose={() => {}}
-                title="Modal Dialog with disabled `trapFocus`"
-                disableFocusTrap
-              >
-                <p>This is a ModalDialog that does not trap focus.</p>
-                <InputGroup>
-                  <Input name="my-input" elementRef={inputRef} />
-                  <IconButton icon={ArrowRightIcon} variant="dark" title="go" />
-                </InputGroup>
-              </ModalDialog_>
-            </Library.Demo>
+          </Library.Example>
+
+          <Library.Example title="disableRestoreFocus">
+            <p>
+              Set this boolean prop (default <code>false</code>) to disable the
+              restoration of focus after the <code>ModalDialog</code> is closed.
+            </p>
           </Library.Example>
 
           <Library.Example title="width">
@@ -632,9 +667,23 @@ export default function DialogPage() {
 
           <Library.Example title="Forwarded Props: Dialog">
             <p>
-              <code>ModalDialog</code> accepts and forwards all{' '}
-              <code>Dialog</code> props, including forwarded <code>Panel</code>{' '}
-              props.
+              <code>ModalDialog</code> forwards the following props (defaults in
+              parentheses) to <code>Dialog</code>:
+            </p>
+            <ul>
+              <li>
+                <code>closeOnClickAway</code> (<code>false</code>)
+              </li>
+              <li>
+                <code>closeOnFocusAway</code> (<code>false</code>)
+              </li>
+              <li>
+                <code>initialFocus</code> (<code>{"'auto'"}</code>)
+              </li>
+            </ul>
+            <p>
+              <code>Panel</code> props forwarded by <code>Dialog</code> are also
+              accepted.
             </p>
           </Library.Example>
         </Library.Pattern>

--- a/src/pattern-library/components/patterns/feedback/DialogPage.tsx
+++ b/src/pattern-library/components/patterns/feedback/DialogPage.tsx
@@ -1,14 +1,14 @@
 import { useState, useRef } from 'preact/hooks';
 
-import { Dialog } from '../../../../components/feedback';
 import { ModalDialog } from '../../../../components/feedback';
-import type { DialogProps } from '../../../../components/feedback/Dialog';
 import type { ModalDialogProps } from '../../../../components/feedback/ModalDialog';
+import type { DialogProps } from '../../../../next';
 import {
   ArrowRightIcon,
   Button,
   CautionIcon,
   DataTable,
+  Dialog,
   EditIcon,
   IconButton,
   Input,

--- a/src/pattern-library/components/patterns/feedback/DialogPage.tsx
+++ b/src/pattern-library/components/patterns/feedback/DialogPage.tsx
@@ -543,39 +543,35 @@ export default function DialogPage() {
             </Library.Demo>
           </Library.Example>
 
-          <Library.Example title="size">
-            <p>
-              The <code>size</code> prop affects the width of a{' '}
-              <code>ModalDialog</code>.
-            </p>
-            <Library.Demo title="size='sm'" withSource>
+          <Library.Example title="width">
+            <Library.Demo title="width='sm'" withSource>
               <ModalDialog_
                 buttons={<DialogButtons />}
                 onClose={() => {}}
                 title="Small modal"
-                size="sm"
+                width="sm"
               >
                 <LoremIpsum size="sm" />
               </ModalDialog_>
             </Library.Demo>
 
-            <Library.Demo title="size='md' (default)" withSource>
+            <Library.Demo title="width='md' (default)" withSource>
               <ModalDialog_
                 buttons={<DialogButtons />}
                 onClose={() => {}}
                 title="Medium-width modal"
-                size="md"
+                width="md"
               >
                 <LoremIpsum size="md" />
               </ModalDialog_>
             </Library.Demo>
 
-            <Library.Demo title="size='lg'" withSource>
+            <Library.Demo title="width='lg'" withSource>
               <ModalDialog_
                 buttons={<DialogButtons />}
                 onClose={() => {}}
                 title="Wide modal"
-                size="lg"
+                width="lg"
               >
                 <LoremIpsum size="md" />
               </ModalDialog_>
@@ -583,17 +579,17 @@ export default function DialogPage() {
 
             <p>
               To style your <code>ModalDialog</code> with a custom width, set{' '}
-              <code>size</code> to <code>{"'custom'"}</code> and provide sizing
+              <code>width</code> to <code>{"'custom'"}</code> and provide sizing
               CSS class(es) via the <code>classes</code> prop.
             </p>
 
-            <Library.Demo title="size='custom'" withSource>
+            <Library.Demo title="width='custom'" withSource>
               <ModalDialog_
                 buttons={<DialogButtons />}
                 classes="w-[40em]"
                 onClose={() => {}}
                 title="Custom-width modal"
-                size="custom"
+                width="custom"
               >
                 <LoremIpsum size="md" />
               </ModalDialog_>


### PR DESCRIPTION
This PR consolidates props naming, organization and documentation for `Dialog` and `ModalDialog`, and adds `Dialog` to the package API[^1]. It:

* Adjusts the naming of a few props to better match conventions and make migration from `Modal` easier
* Completes pattern-library documentation for both components and adds migration notes
* Exports `Dialog` from the package (next) entrypoint (not `ModalDialog`, yet, because of some deficiencies in the `useTabKeyNavigation` hook when combined with embedded interactive widgets like `DataTable` and `TabList`.

Regarding the changing of a few prop names:

* `size` -> (back to) `width`: I got a little zealous early on in the implementation of the new `ModalDialog` and wanted to start moving towards the standard theme-/customization-related prop names I presented to the team several weeks ago. However, it's distracting right now and will make migration from `Modal` more tedious. Change this prop name back to `width` so that it is unchanged from `Modal`.
* The following boolean props were renamed on `ModalDialog` because their defaults differ from `Dialog`, and our conventions suggest that booleans should default false and be named for their effect when set (`true`):
    * `closeOnEscape` => `disableCloseOnEscape`
    * `restoreFocus` => `disableRestoreFocus`


[^1]: Holding for now on adding `ModalDialog` to API until some nuances with trapped-focus and embedded interactive widgets (e.g. `DataTable`, `TabList`) can be perfected.