### PR TITLE
Enhance Dialog so that it allows providing a TransitionComponent

### DIFF
--- a/src/components/feedback/test/Dialog-test.js
+++ b/src/components/feedback/test/Dialog-test.js
@@ -18,8 +18,8 @@ const createComponent = (Component, props = {}) => {
  * @type {import('../../../next.js').TransitionComponent}
  */
 const ComponentWithTransition = ({ children, visible, onTransitionEnd }) => {
-  // Fake a 200ms transition time
-  setTimeout(() => onTransitionEnd?.(visible ? 'in' : 'out'), 200);
+  // Fake a 50ms transition time
+  setTimeout(() => onTransitionEnd?.(visible ? 'in' : 'out'), 50);
   return <div>{children}</div>;
 };
 
@@ -137,7 +137,7 @@ describe('Dialog', () => {
           wrapper.find('[role="dialog"]').getDOMNode()
         );
         // Once the transition has ended, the Dialog should be focused
-        await delay(300); // Transition finishes after 200ms
+        await delay(60); // Transition finishes after 6ms
         assert.equal(
           document.activeElement,
           wrapper.find('[role="dialog"]').getDOMNode()
@@ -278,7 +278,7 @@ describe('Dialog', () => {
         // The onClose callback is not immediately invoked
         assert.notCalled(onClose);
         // Once the transition has ended, the callback should have been called
-        await delay(300); // Transition finishes after 200ms
+        await delay(60); // Transition finishes after 50ms
         assert.called(onClose);
       });
     });

--- a/src/next.ts
+++ b/src/next.ts
@@ -56,6 +56,7 @@ export type {
   CompositeProps,
   IconComponent,
   PresentationalProps,
+  TransitionComponent,
 } from './types';
 
 export type {

--- a/src/pattern-library/components/patterns/FadeComponent.tsx
+++ b/src/pattern-library/components/patterns/FadeComponent.tsx
@@ -1,0 +1,31 @@
+import classnames from 'classnames';
+import { useCallback } from 'preact/hooks';
+
+import type { TransitionComponent } from '../../../types';
+
+const FadeComponent: TransitionComponent = ({
+  children,
+  visible,
+  onTransitionEnd,
+}) => {
+  const handleTransitionEnd = useCallback(
+    () => onTransitionEnd?.(visible ? 'in' : 'out'),
+    [visible, onTransitionEnd]
+  );
+
+  return (
+    <div
+      className={classnames('transition-opacity duration-500', {
+        'opacity-100': visible,
+        'opacity-0': !visible,
+      })}
+      // @ts-expect-error react uses "ontransitionend" rather than "onTransitionEnd".
+      // eslint-disable-next-line react/no-unknown-property
+      ontransitionend={handleTransitionEnd}
+    >
+      {children}
+    </div>
+  );
+};
+
+export default FadeComponent;

--- a/src/pattern-library/components/patterns/FadeComponent.tsx
+++ b/src/pattern-library/components/patterns/FadeComponent.tsx
@@ -3,6 +3,10 @@ import { useCallback } from 'preact/hooks';
 
 import type { TransitionComponent } from '../../../types';
 
+/**
+ * This component is used just to demonstrate the `TransitionComponent`
+ * functionality on components supporting it, like `Dialog`.
+ */
 const FadeComponent: TransitionComponent = ({
   children,
   visible,
@@ -19,7 +23,7 @@ const FadeComponent: TransitionComponent = ({
         'opacity-100': visible,
         'opacity-0': !visible,
       })}
-      // @ts-expect-error react uses "ontransitionend" rather than "onTransitionEnd".
+      // @ts-expect-error preact uses "ontransitionend" rather than "onTransitionEnd".
       // eslint-disable-next-line react/no-unknown-property
       ontransitionend={handleTransitionEnd}
     >

--- a/src/pattern-library/components/patterns/feedback/DialogPage.tsx
+++ b/src/pattern-library/components/patterns/feedback/DialogPage.tsx
@@ -17,6 +17,7 @@ import {
   Scroll,
 } from '../../../../next';
 import Library from '../../Library';
+import FadeComponent from '../FadeComponent';
 import { LoremIpsum, nabokovNovels } from '../samples';
 
 const nabokovRows = nabokovNovels();
@@ -318,6 +319,37 @@ export default function DialogPage() {
                   pattern should be avoided, but is supported for a few legacy
                   use cases. You can close this modal by clicking the{' '}
                   {'"Escape!"'} button.
+                </p>
+              </Dialog_>
+            </Library.Demo>
+          </Library.Example>
+
+          <Library.Example title="transitionComponent">
+            <p>
+              It allows to provide a component which supports transitions, but
+              keeping the internal behavior (initial focus, closing, etc)
+              transparent to consumers.
+            </p>
+            <p>
+              The only requirement is that provided component needs to conform
+              to the next props:
+            </p>
+            <Library.Code
+              content={`type TransitionComponentProps = {
+  visible: boolean;
+  onTransitionEnd?: (direction: 'in' | 'out') => void;
+}`}
+            />
+            <Library.Demo
+              title="Dialog with TransitionComponent example"
+              withSource
+            >
+              <Dialog_
+                title="Dialog with TransitionComponent example"
+                transitionComponent={FadeComponent}
+              >
+                <p>
+                  This dialog has a fade in/out transition when opened/closed.
                 </p>
               </Dialog_>
             </Library.Demo>

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,3 +25,12 @@ export type BaseProps = PresentationalProps & { unstyled?: boolean };
  * valid `<svg>` element attribute as props.
  */
 export type IconComponent = FunctionComponent<JSX.SVGAttributes<SVGSVGElement>>;
+
+/**
+ * A component type used by other components that can optionally support a
+ * transition animation
+ */
+export type TransitionComponent = JSX.ElementType<{
+  visible: boolean;
+  onTransitionEnd?: (direction: 'in' | 'out') => void;
+}>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,8 +27,8 @@ export type BaseProps = PresentationalProps & { unstyled?: boolean };
 export type IconComponent = FunctionComponent<JSX.SVGAttributes<SVGSVGElement>>;
 
 /**
- * A component type used by other components that can optionally support a
- * transition animation
+ * A component that describes an `in` and an `out` transition, typically to
+ * animate the mounting and unmounting of a child component.
  */
 export type TransitionComponent = JSX.ElementType<{
   visible: boolean;


### PR DESCRIPTION
This PR extends the `Dialog` component, so that a `transitionComponent` can be provided, and the `Dialog` transparently handle all its focusing capabilities.

The `transitionComponent` can be any component that has these properties:

```ts
type TransitionComponentProps = {
  visible: boolean;
  onTransitionEnd?: () => void;
};
```

Some UI libraries also handle the transition start callback, but since we don't yet have a real use-case for it, I have decided to leave it out for now, reducing the code and tests to maintain.

This PR also includes some basic documentation and an example on how to use this property, which is now part of the pattern library. Visit http://localhost:4001/feedback-dialog and search for `transitionComponent`.

> **Note**
> This PR is easier to review hidding whitespaces.