### PR TITLE
Add `ModalDialog` example to demonstrate keyboard navigation

### DIFF
--- a/src/pattern-library/components/patterns/feedback/DialogPage.tsx
+++ b/src/pattern-library/components/patterns/feedback/DialogPage.tsx
@@ -15,9 +15,12 @@ import {
   InputGroup,
   Link,
   Scroll,
+  Tab,
+  TabList,
 } from '../../../../next';
 import Library from '../../Library';
 import { LoremIpsum, nabokovNovels } from '../samples';
+import type { NabokovNovel } from '../samples';
 
 const nabokovRows = nabokovNovels();
 const nabokovColumns = [
@@ -145,6 +148,10 @@ function ModalDialog_({
 
 export default function DialogPage() {
   const inputRef = useRef(null);
+
+  // For the complex-modal example
+  const [selectedRow, setSelectedRow] = useState<NabokovNovel | null>(null);
+  const [selectedTab, setSelectedTab] = useState<'tab1' | 'tab2'>('tab1');
   return (
     <Library.Page
       title="Dialogs"
@@ -451,6 +458,72 @@ export default function DialogPage() {
               </ModalDialog_>
             </Library.Demo>
           </Library.Example>
+          <Library.Example title="Handling complex modals">
+            <p>
+              Modal dialogs should provide appropriate keyboard navigation even
+              when there are multiple or complex embedded widgts, like data
+              tables (ARIA <code>{'`role="grid"`'}</code>) or tabs (ARIA{' '}
+              <code>{'`role="tablist"`'}</code>).
+            </p>
+            <p>
+              <strong>
+                Keyboard navigation for embedded widgets is under development.
+              </strong>
+            </p>
+            <Library.Demo title="Modal with embedded ARIA widgets" withSource>
+              <ModalDialog_
+                buttons={<DialogButtons />}
+                classes="h-[25rem]"
+                onClose={() => {}}
+                title="Modal with tabs and data table"
+                scrollable={false}
+              >
+                <TabList classes="gap-x-4">
+                  <Tab
+                    textContent="Tab 1"
+                    selected={selectedTab === 'tab1'}
+                    onClick={() => setSelectedTab('tab1')}
+                  >
+                    Tab 1
+                  </Tab>
+                  <Tab
+                    textContent="Tab 2"
+                    selected={selectedTab === 'tab2'}
+                    onClick={() => setSelectedTab('tab2')}
+                  >
+                    Tab 2
+                  </Tab>
+                </TabList>
+                <p>
+                  Content for both tabs, with{' '}
+                  <Link href="#" underline="always">
+                    a link
+                  </Link>
+                  .
+                </p>
+                {selectedTab === 'tab1' && (
+                  <Scroll>
+                    <DataTable
+                      rows={nabokovRows}
+                      columns={nabokovColumns}
+                      title="Nabokov novels"
+                      selectedRow={selectedRow}
+                      onSelectRow={row => setSelectedRow(row)}
+                    />
+                  </Scroll>
+                )}
+                {selectedTab === 'tab2' && (
+                  <>
+                    <p>This is content on another, second, tab.</p>
+                    <div className="flex gap-x-4">
+                      <Button>Click me</Button>
+                      <Button>No, me!</Button>
+                    </div>
+                  </>
+                )}
+              </ModalDialog_>
+            </Library.Demo>
+          </Library.Example>
           <Library.Example title="Managing modal height">
             <p>
               By default, the height of a modal is dependent on the content
@@ -645,31 +718,9 @@ export default function DialogPage() {
               or to disable scrolling entirely.
             </p>
             <p>
-              This example demonstrates setting the boolean{' '}
-              <code>scrollable</code> prop to <code>false</code> and using a{' '}
-              <code>Scroll</code> component within Modal content to scroll only
-              a portion of the content.
+              The <i>Handling Complex Modals</i> example above disables
+              scrolling with the <code>scrollable</code> prop.
             </p>
-            <Library.Demo title="Manually controlling scrolling" withSource>
-              <ModalDialog_
-                buttons={<DialogButtons />}
-                classes="h-[25rem]"
-                onClose={() => {}}
-                title="Modal with scrollable disabled"
-                scrollable={false}
-              >
-                <p>
-                  Fake {'>'} breadcrumbs {'>'} example
-                </p>
-                <Scroll>
-                  <DataTable
-                    rows={nabokovRows}
-                    columns={nabokovColumns}
-                    title="Nabokov novels"
-                  />
-                </Scroll>
-              </ModalDialog_>
-            </Library.Demo>
           </Library.Example>
 
           <Library.Example title="width">


### PR DESCRIPTION
This PR adds a pattern-library example to the Dialogs pattern-library page (http://localhost:4001/feedback-dialog) to demonstrate keyboard navigation within a `ModalDialog` that contains complex content, in this case multiple ARIA widgets (a `tablist` and a `grid`).

While the tag-key navigation handling is working well for most modals, it breaks down when a modal dialog contains widgets which themselves have keyboard-navigation handling.

I'm adding this example as documentation of what the existing keyboard-navigation problems are. I have some fixes in mind that I've been prototyping. This extant example will then help us to verify when keyboard behavior is fixed. Sort of like committing a failing test.

Here is the current tab-navigation behavior in this example:

![modal-keyboard-nav](https://user-images.githubusercontent.com/439947/231867381-b6e3fcb4-a8c3-4852-a522-d592362d42bb.gif)

What's happening here:

* Tab-key navigation _mostly_ works with the `tablist` tabs, but this is a sort of "accidental mostly works" because the tabs themselves are buttons, which get picked up by the modal's tab-key navigation hook automatically. What _should_ happen is that the tab sequence should select the `tablist` container (not the individual buttons) and then the tablist's own arrow-key navigation should take over within the tablist. This is a sort of subtle difference, but, implemented correctly, will correctly navigate to the last tab focused when returning to the tablist.
* Data-table navigation is completely not working. It should be possible to tab to the table, and then navigate the rows in the table with arrow keys. Alas, this is not as simple as adding `DataTable` elements (`[role="grid"]`) to the `useTabKeyNavigation` hook's selector, i.e. we can't just add them to the tab sequence. It's more fiddly than that. The good news is that I think I do have a workable solution. Similar to with the `tablist`, the behavior should be: the modal's tab sequence includes the `DataTable` container, and then the user can navigate rows with arrow keys. Tabbing out of the table, then tabbing back and using arrow keys again should navigate based on the last row selected (not starting from the top row).

i.e. in both widget cases, "tabbing back" to the widgets after tabbing out of them should retain state about the last widget sub-item that was active, not reset the navigation sequence in the widget. THIS IS REALLY HARD TO EXPLAIN, especially this late in the day :). It may be easier to demonstrate when I push a proposed fix.

