### PR TITLE
Make `ModalDialog` available in package API

### DIFF
--- a/src/components/feedback/Modal.tsx
+++ b/src/components/feedback/Modal.tsx
@@ -36,6 +36,7 @@ const noop = () => {};
 
 /**
  * Show a modal
+ * @deprecated - Use `ModalDialog` instead
  */
 const ModalNext = function Modal({
   children,

--- a/src/next.ts
+++ b/src/next.ts
@@ -22,7 +22,13 @@ export {
   TableRow,
   Thumbnail,
 } from './components/data';
-export { Dialog, Modal, Spinner, SpinnerOverlay } from './components/feedback';
+export {
+  Dialog,
+  Modal,
+  ModalDialog,
+  Spinner,
+  SpinnerOverlay,
+} from './components/feedback';
 export {
   Button,
   ButtonBase,
@@ -78,6 +84,7 @@ export type {
 export type {
   DialogProps,
   ModalProps,
+  ModalDialogProps,
   SpinnerProps,
   SpinnerOverlayProps,
 } from './components/feedback';

--- a/src/pattern-library/components/patterns/feedback/DialogPage.tsx
+++ b/src/pattern-library/components/patterns/feedback/DialogPage.tsx
@@ -407,10 +407,6 @@ export default function DialogPage() {
               deprecated <code>Modal</code> component.
             </strong>
           </p>
-          <p>
-            <code>ModalDialog</code> is still under development and is not yet
-            part of the package API.
-          </p>
           <Library.Example title="Migrating to this component from Modal">
             <Library.Changelog>
               <Library.ChangelogItem status="changed">
@@ -496,11 +492,6 @@ export default function DialogPage() {
               when there are multiple or complex embedded widgts, like data
               tables (ARIA <code>{'`role="grid"`'}</code>) or tabs (ARIA{' '}
               <code>{'`role="tablist"`'}</code>).
-            </p>
-            <p>
-              <strong>
-                Keyboard navigation for embedded widgets is under development.
-              </strong>
             </p>
             <Library.Demo title="Modal with embedded ARIA widgets" withSource>
               <ModalDialog_

--- a/src/pattern-library/components/patterns/feedback/ModalPage.tsx
+++ b/src/pattern-library/components/patterns/feedback/ModalPage.tsx
@@ -103,6 +103,19 @@ export default function ModalPage() {
           </p>
         }
       >
+        <Library.Pattern title="Status">
+          <Library.Changelog>
+            <Library.ChangelogItem status="deprecated">
+              This implementation of
+              <s>
+                <code>Modal</code>
+              </s>{' '}
+              is deprecated. Use
+              <code>ModalDialog</code> or <code>Dialog</code> instead, which
+              provide a similar API and enhanced accessibility.
+            </Library.ChangelogItem>
+          </Library.Changelog>
+        </Library.Pattern>
         <Library.Pattern title="Usage">
           <Library.Usage componentName="Modal" />
           <Library.Demo title="Basic modal" withSource>


### PR DESCRIPTION
Depends on #959 

This PR (finally) exports `ModalDialog` from the package. It also deprecates `Modal`.

Fixes #77