### PR TITLE
Use FunctionComponent as the base type for TransitionComponent

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -30,7 +30,7 @@ export type IconComponent = FunctionComponent<JSX.SVGAttributes<SVGSVGElement>>;
  * A component that describes an `in` and an `out` transition, typically to
  * animate the mounting and unmounting of a child component.
  */
-export type TransitionComponent = JSX.ElementType<{
+export type TransitionComponent = FunctionComponent<{
   visible: boolean;
   onTransitionEnd?: (direction: 'in' | 'out') => void;
 }>;


### PR DESCRIPTION
While working on something else, I have realized I probably didn't use the best possible base type for `TransitionComponent`.

I have changed it from `JSX.ElementType<...>` to `FunctionComponent<...>`, because that's what [the docs suggest](https://preactjs.com/guide/v10/typescript/), and what we use everywhere else.

This can be safely merged, because the change is backwards compatible:

```tsx
import type { FunctionComponent, JSX } from 'preact';
import { render } from 'preact';

// This code passes
const MyComp: JSX.ElementType = () => <>Hi!</>;
const MyOtherComp: FunctionComponent = MyComp;

render(document.body, <MyOtherComp />);
```