### PR TITLE
Add support to create transition components via plop

### DIFF
--- a/plop-templates/pattern-library-page.hbs
+++ b/plop-templates/pattern-library-page.hbs
@@ -19,11 +19,9 @@ export default function {{name}}Page() {
         </Library.Pattern>
 
         <Library.Pattern title="Props">
-          <Library.Example title="size">
+          <Library.Example title="exampleProp">
             <Library.Demo withSource>
-              <{{name}} size="sm">Small (sm)</{{name}}>
-              <{{name}} size="md">Medium (md) (default)</{{name}}>
-              <{{name}} size="lg">Large (lg)</{{name}}>
+              <p>TODO: Example of component with prop</p>
             </Library.Demo>
           </Library.Example>
         </Library.Pattern>

--- a/plop-templates/transition-component-test.hbs
+++ b/plop-templates/transition-component-test.hbs
@@ -9,7 +9,7 @@ describe('{{name}}', () => {
   const create{{name}} = (props = {}) => {
     const style = { width: 100, height: 200 };
     return mount(
-      <{{name}} visible={false} {...props}>
+      <{{name}} {...props}>
         <div style={style}>Test content</div>
       </{{name}}>,
       { attachTo: container }
@@ -29,12 +29,12 @@ describe('{{name}}', () => {
     'should pass a11y checks',
     checkAccessibility([
       {
-        name: 'visible',
-        content: () => create{{name}}({ visible: true }),
+        name: 'in',
+        content: () => create{{name}}({ direction: 'in' }),
       },
       {
-        name: 'hidden',
-        content: () => create{{name}}({ visible: false }),
+        name: 'out',
+        content: () => create{{name}}({ direction: 'out' }),
       },
     ])
   );

--- a/plop-templates/transition-component-test.hbs
+++ b/plop-templates/transition-component-test.hbs
@@ -1,0 +1,41 @@
+import { mount } from 'enzyme';
+
+import { checkAccessibility } from '../../../../test/util/accessibility';
+import {{name}} from '../{{name}}';
+
+describe('{{name}}', () => {
+  let container;
+
+  const create{{name}} = (props = {}) => {
+    const style = { width: 100, height: 200 };
+    return mount(
+      <{{name}} visible={false} {...props}>
+        <div style={style}>Test content</div>
+      </{{name}}>,
+      { attachTo: container }
+    );
+  };
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    container.remove();
+  });
+
+  it(
+    'should pass a11y checks',
+    checkAccessibility([
+      {
+        name: 'visible',
+        content: () => create{{name}}({ visible: true }),
+      },
+      {
+        name: 'hidden',
+        content: () => create{{name}}({ visible: false }),
+      },
+    ])
+  );
+});

--- a/plop-templates/transition-component.hbs
+++ b/plop-templates/transition-component.hbs
@@ -1,0 +1,36 @@
+import { useCallback } from 'preact/hooks';
+
+import type { TransitionComponent } from '../../types';
+
+/**
+ * TODO
+ */
+const {{name}}: TransitionComponent = ({
+  children,
+  visible,
+  onTransitionEnd,
+}) => {
+  const handleTransitionEnd = useCallback(() => {
+    if (visible) {
+      onTransitionEnd?.('in');
+    } else {
+      onTransitionEnd?.('out');
+    }
+  }, [visible, onTransitionEnd]);
+
+  return (
+    <div
+      data-component="{{name}}"
+      // nb. Preact uses "ontransitionend" rather than "onTransitionEnd".
+      // See https://bugs.chromium.org/p/chromium/issues/detail?id=961193
+      //
+      // @ts-ignore
+      // eslint-disable-next-line react/no-unknown-property
+      ontransitionend={handleTransitionEnd}
+    >
+      {children}
+    </div>
+  );
+};
+
+export default {{name}};

--- a/plop-templates/transition-component.hbs
+++ b/plop-templates/transition-component.hbs
@@ -7,16 +7,12 @@ import type { TransitionComponent } from '../../types';
  */
 const {{name}}: TransitionComponent = ({
   children,
-  visible,
+  direction = 'in',
   onTransitionEnd,
 }) => {
   const handleTransitionEnd = useCallback(() => {
-    if (visible) {
-      onTransitionEnd?.('in');
-    } else {
-      onTransitionEnd?.('out');
-    }
-  }, [visible, onTransitionEnd]);
+    onTransitionEnd?.(direction);
+  }, [direction, onTransitionEnd]);
 
   return (
     <div

--- a/plopfile.js
+++ b/plopfile.js
@@ -25,7 +25,7 @@ export default function (plop) {
         type: 'list',
         name: 'category',
         message: 'component category',
-        choices: ['presentational', 'composite', 'simple'],
+        choices: ['presentational', 'composite', 'simple', 'transition'],
         default: 'presentational',
       },
       {
@@ -52,7 +52,11 @@ export default function (plop) {
           path: 'src/components/{{group}}/index.ts',
           pattern: /\n\n*$/g,
           template: `\nexport { default as {{name}} } from './{{name}}';
-export type { {{name}}Props } from './{{name}}';\n`,
+${
+  data.category !== 'transition'
+    ? "export type { {{name}}Props } from './{{name}}';\n"
+    : ''
+}`,
         },
         {
           type: 'add',
@@ -64,7 +68,11 @@ export type { {{name}}Props } from './{{name}}';\n`,
           path: 'src/index.ts',
           pattern: /\n\n*$/g,
           template: `\nexport { {{name}} } from './components/{{group}}';
-export type { {{name}}Props } from './components/{{group}}';\n`,
+${
+  data.category !== 'transition'
+    ? "export type { {{name}}Props } from './components/{{group}}';\n"
+    : ''
+}`,
         },
       ];
 


### PR DESCRIPTION
In order to test this works, follow these steps:

* Run `yarn plop`, and introduce a component name (let's say `Fade`), then input `transition` as the group directory, and select `transition` as category.
  ![image](https://user-images.githubusercontent.com/2719332/234031750-d57211f0-9c95-4e8c-a05e-7eec2d875009.png)
* Make sure generated code is valid by running `make lint`.
* Make sure generated test passes: Assuming the component is called `Fade`, run `yarn test --grep Fade`.
