### PR TITLE
Expand reuse-annotation prototypes with a manage-annotation menu

### DIFF
--- a/src/pattern-library/components/Library.tsx
+++ b/src/pattern-library/components/Library.tsx
@@ -4,7 +4,13 @@ import type { ComponentChildren, JSX } from 'preact';
 import { useMemo, useState, useContext } from 'preact/hooks';
 import { Link as RouteLink } from 'wouter-preact';
 
-import { CodeIcon, Link as UILink, Scroll, ScrollContainer } from '../../';
+import {
+  CautionIcon,
+  CodeIcon,
+  Link as UILink,
+  Scroll,
+  ScrollContainer,
+} from '../../';
 import { jsxToHTML } from '../util/jsx-to-string';
 
 /**
@@ -394,7 +400,17 @@ function Link({ children, href }: LinkProps) {
   );
 }
 
+function Callout({ children }: { children: ComponentChildren }) {
+  return (
+    <div className="flex gap-x-2 p-3 rounded-md bg-slate-50 border shadow-inner">
+      <CautionIcon className="text-yellow-notice w-6 h-6" />
+      <div>{children}</div>
+    </div>
+  );
+}
+
 export default {
+  Callout,
   Changelog,
   ChangelogItem,
   Code,

--- a/src/pattern-library/components/patterns/prototype/MenuSection.tsx
+++ b/src/pattern-library/components/patterns/prototype/MenuSection.tsx
@@ -1,0 +1,44 @@
+import { toChildArray } from 'preact';
+import type { ComponentChildren, VNode } from 'preact';
+
+export type MenuSectionProps = {
+  /** Heading displayed at the top of the menu. */
+  heading?: string;
+
+  /** Menu items to display in this section. */
+  children: ComponentChildren;
+};
+
+/**
+ * Group a set of menu items together visually, with an optional header.
+ *
+ * @example
+ *   <Menu label="Things">
+ *     <MenuSection heading="Big things">
+ *       <MenuItem .../>
+ *       <MenuItem .../>
+ *     </MenuSection>
+ *     <MenuSection heading="Little things">
+ *       <MenuItem .../>
+ *       <MenuItem .../>
+ *     </MenuSection>
+ *   </Menu>
+ *
+ * @param {MenuSectionProps} props
+ */
+export default function MenuSection({ heading, children }: MenuSectionProps) {
+  return (
+    <>
+      {heading && (
+        <h2 className="text-color-text-light p-3 leading-none uppercase">
+          {heading}
+        </h2>
+      )}
+      <ul className="border-b">
+        {toChildArray(children).map(child => (
+          <li key={(child as VNode).key}>{child}</li>
+        ))}
+      </ul>
+    </>
+  );
+}

--- a/src/pattern-library/components/patterns/prototype/SharedAnnotationsPage.tsx
+++ b/src/pattern-library/components/patterns/prototype/SharedAnnotationsPage.tsx
@@ -8,6 +8,8 @@ import {
   CardContent,
   Checkbox,
   EditIcon,
+  EllipsisIcon,
+  GlobeIcon,
   GroupsFilledIcon,
   IconButton,
   ModalDialog,
@@ -21,22 +23,36 @@ import type { ModalDialogProps } from '../../../../components/feedback/ModalDial
 import Library from '../../Library';
 import { LoremIpsum } from '../samples';
 import FakeAnnotationPublishControl from './FakeAnnotationPublishControl';
+import FakeMenu from './Menu';
+import FakeMenuItem from './MenuItem';
+import FakeMenuSection from './MenuSection';
 
 type FakeAnnotationProps = {
   children?: ComponentChildren;
+  hasReplies?: boolean;
   isOwn?: boolean;
   isPinned?: boolean;
   isShared?: boolean;
+  withManageMenu?: boolean;
 };
 
 function FakeAnnotation({
   children,
+  hasReplies = false,
   isOwn = false,
   isPinned = false,
   isShared = false,
+  withManageMenu = false,
 }: FakeAnnotationProps) {
-  const actions = isOwn ? ['edit', 'delete', 'reply', 'pin'] : ['reply'];
+  const actions = ['reply'];
+  if (isOwn) {
+    actions.push('pin', 'edit');
+    if (!withManageMenu) {
+      actions.push('delete');
+    }
+  }
   const content = children ?? <LoremIpsum size="xs" />;
+  const groupName = isShared ? 'All course participants' : 'Section 1';
   return (
     <Card classes="relative">
       <div className="absolute right-full space-y-1 pt-1">
@@ -52,7 +68,60 @@ function FakeAnnotation({
         )}
       </div>
       <CardContent size="sm" classes="text-sm">
-        <div className="font-semibold text-sm">Pretend annotation</div>
+        <div>
+          <div className="flex gap-x-2">
+            <div className="font-semibold text-sm grow">Fred Pickle</div>
+            <div className="w-[16px] h-[16px]">
+              {withManageMenu && (
+                <FakeMenu
+                  align="right"
+                  contentClass="min-w-[200px]"
+                  defaultOpen
+                  menuIndicator={false}
+                  title="Manage annotation"
+                  label={<EllipsisIcon className="text-color-text-light" />}
+                >
+                  <FakeMenuSection>
+                    <FakeMenuItem label="Edit" />
+                    <FakeMenuItem label="Copy to..." />
+                    {!hasReplies && <FakeMenuItem label="Move to..." />}
+                    {hasReplies && (
+                      <FakeMenuItem
+                        isDisabled
+                        label={
+                          <div className="flex flex-col gap-y-1 py-1">
+                            <div>Move to...</div>
+                            <div className="text-xs italic">
+                              Annotations with replies cannot be moved
+                            </div>
+                          </div>
+                        }
+                      />
+                    )}
+                  </FakeMenuSection>
+                  <FakeMenuSection>
+                    <FakeMenuItem
+                      icon={TrashIcon}
+                      label={<span className="text-brand">Delete</span>}
+                    />
+                  </FakeMenuSection>
+                </FakeMenu>
+              )}
+            </div>
+          </div>
+          <div className="flex gap-x-2">
+            <div className="flex gap-x-1 items-center text-xs grow text-color-text-light">
+              <GlobeIcon className="w-2.5 h-2.5" />
+              <div>{groupName}</div>
+            </div>
+            <div className="flex gap-x-2 items-center">
+              <div className="text-color-text-light text-xs italic">
+                (edited Apr 23)
+              </div>
+              <div className="text-color-text-light text-sm">Apr 22</div>
+            </div>
+          </div>
+        </div>
         {content}
         <CardActions>
           <div className="flex text-[16px]">
@@ -62,15 +131,15 @@ function FakeAnnotation({
             {actions.includes('delete') && (
               <IconButton icon={TrashIcon} title="Delete" />
             )}
-            {actions.includes('reply') && (
-              <IconButton icon={ReplyIcon} title="Reply" />
-            )}
             {actions.includes('pin') && (
               <IconButton
                 icon={PinIcon}
                 title={isPinned ? 'Unpin' : 'Pin'}
                 pressed={isPinned}
               />
+            )}
+            {actions.includes('reply') && (
+              <IconButton icon={ReplyIcon} title="Reply" />
             )}
           </div>
         </CardActions>
@@ -140,27 +209,33 @@ export default function SharedAnnotationsPrototypePage() {
         </>
       }
     >
-      <Library.Section
-        title="Constituent Projects"
-        intro={
-          <>
-            <p>With this approach context, there are three implied projects:</p>
-
-            <ol start={1}>
-              <li>Course-shared content</li>
-              <li>Pinned content</li>
-              <li>Annotation re-use for copied course assignments</li>
-            </ol>
-
-            <p>
-              <i>Pinned content</i> is independent functionality and could be
-              deferred if desired. <i>Annotation re-use</i> depends on{' '}
-              <i>course-shared content</i>.
-            </p>
-          </>
-        }
-        level={3}
-      />
+      <Library.Section>
+        <Library.Callout>
+          <strong>Note:</strong> The UI sketches here are intended as
+          low-fidelity wireframes to demonstrate UX and flow intent. They are
+          not intended to represent polished design.
+        </Library.Callout>
+        <Library.Section title="User stories">
+          <p>
+            The low-fidelity UI sketches in this document attempt to address the{' '}
+            <a href="https://docs.google.com/document/d/1jrWGqRaCab-jhqrHjSEQXjOzMo8JGBPJz3BdYec_Zk0">
+              user stories in this document
+            </a>{' '}
+            (access limited to Hypothesis team).
+          </p>
+        </Library.Section>
+        <p>As broken down here, there are three implied projects:</p>
+        <ol start={1}>
+          <li>Course-shared content</li>
+          <li>Pinned content</li>
+          <li>Annotation re-use for copied course assignments</li>
+        </ol>
+        <p>
+          <i>Pinned content</i> is independent functionality and could be
+          deferred if desired. <i>Annotation re-use</i> depends on{' '}
+          <i>course-shared content</i>.
+        </p>
+      </Library.Section>
       <Library.Section
         title="1. Course-shared content"
         intro={
@@ -209,6 +284,31 @@ export default function SharedAnnotationsPrototypePage() {
                   noSharingMessage={'Annotations with replies cannot be moved'}
                 />
               </div>
+            </Library.Demo>
+          </Library.Section>
+
+          <Library.Section title="User interface: Improving experience in the future">
+            <p>
+              It might be possible to consolidate some annotation actions into a{' '}
+              {'"manage-annotation menu"'} at the top right of a top-level
+              annotation card. And we could to distinguish between moving and
+              copying.
+            </p>
+            <p>
+              This gives the user an option to copy a top-level annotation that
+              they authored. Annotations with replies could be copied but not
+              moved (replies would not get copied).
+            </p>
+            <Library.Demo title="Annotation card with context menu">
+              <FakeSidebar>
+                <FakeAnnotation isOwn withManageMenu />
+              </FakeSidebar>
+            </Library.Demo>
+
+            <Library.Demo title="Annotation (with replies) and context menu">
+              <FakeSidebar>
+                <FakeAnnotation hasReplies isOwn withManageMenu />
+              </FakeSidebar>
             </Library.Demo>
           </Library.Section>
         </Library.Section>


### PR DESCRIPTION
This PR expands on some prototype UI sketches for the reuse-annotations project, adding a "manage-annotation menu" concept sketch.

<img width="906" alt="image" src="https://user-images.githubusercontent.com/439947/234078770-d006b529-e667-4c00-82b5-549583675ed5.png">


It also adds a utility component to the Library components, `Callout`. I find that I often want to do something like this:

<img width="933" alt="image" src="https://user-images.githubusercontent.com/439947/234078859-f4a71ddd-c557-40fc-8589-4cb8a1dc8968.png">

and a commit here adds a convenience component to do that.