### PR TITLE
Make sure all dev dependencies are defined in devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "express": "^4.17.1",
     "fancy-log": "^2.0.0",
     "gulp": "^4.0.0",
+    "highlight.js": "^11.7.0",
     "karma": "^6.3.4",
     "karma-chai": "^0.1.0",
     "karma-chrome-launcher": "^3.1.0",
@@ -58,6 +59,7 @@
     "svgo": "^3.0.0",
     "tailwindcss": "3.3.1",
     "typescript": "^5.0.2",
+    "wouter-preact": "^2.10.0-alpha.1",
     "yalc": "^1.0.0-pre.50"
   },
   "peerDependencies": {
@@ -89,9 +91,5 @@
   ],
   "type": "module",
   "main": "./lib/index.js",
-  "browserslist": "chrome 70, firefox 70, safari 11.1",
-  "dependencies": {
-    "highlight.js": "^11.6.0",
-    "wouter-preact": "^2.10.0-alpha.1"
-  }
+  "browserslist": "chrome 70, firefox 70, safari 11.1"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4315,7 +4315,7 @@ header-case@^2.0.4:
     capital-case "^1.0.4"
     tslib "^2.0.3"
 
-highlight.js@^11.6.0:
+highlight.js@^11.7.0:
   version "11.7.0"
   resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-11.7.0.tgz#3ff0165bc843f8c9bce1fd89e2fda9143d24b11e"
   integrity sha512-1rRqesRFhMO/PRF+G86evnyJkCgaZFOI+Z6kdj15TA18funfoqJXvgPCLSf0SWq3SRfg1j3HlDs8o4s3EGq1oQ==


### PR DESCRIPTION
This PR moves `wouter-preact` and `highlight.js` as `devDependencies`, since they are used only for the pattern library, and this way we will save a bit of bandwidth when installing dependencies in `client`, `lms` and `browser-extension`.