### PR TITLE
Add Dockerfile and required config to build and serve pattern library independently

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+./.git*
+./build
+./docs
+./lib
+./node_modules
+./test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM node:19.8.1-alpine as builder
+
+COPY . /frontend-shared
+RUN cd /frontend-shared && \
+    yarn install --frozen-lockfile && \
+    yarn build-pattern-lib
+
+
+FROM nginx:1.24.0-alpine
+
+RUN rm -r /usr/share/nginx/html && rm /etc/nginx/conf.d/default.conf
+# Copy pattern library static assets, and put them in nginx document root folder
+COPY --from=builder /frontend-shared/build /usr/share/nginx/html
+COPY ./templates/pattern-library.mustache /usr/share/nginx/html/index.html
+COPY conf/nginx.conf /etc/nginx/conf.d/default.conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,3 +13,5 @@ RUN rm -r /usr/share/nginx/html && rm /etc/nginx/conf.d/default.conf
 COPY --from=builder /frontend-shared/build /usr/share/nginx/html
 COPY ./templates/pattern-library.mustache /usr/share/nginx/html/index.html
 COPY conf/nginx.conf /etc/nginx/conf.d/default.conf
+
+EXPOSE 5001

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -1,0 +1,23 @@
+server {
+    listen 80 default_server;
+    charset utf-8;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # Handle /_status endpoint with a 200 response once the container is up
+    location = /_status {
+        add_header Content-Type text/plain;
+        return 200 'Success!';
+    }
+
+    # When requesting static paths with an extension, try them, and return a 404 if not found
+    location ~* .+\..+ {
+        try_files $uri $uri/ =404;
+    }
+
+    # When requesting a path without extension, try it, and return the index if not found
+    # This allows for client-side route handling
+    location / {
+        try_files $uri $uri/ /index.html$is_args$args;
+    }
+}

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -1,5 +1,5 @@
 server {
-    listen 80 default_server;
+    listen 5001 default_server;
     charset utf-8;
     root /usr/share/nginx/html;
     index index.html;

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
   "scripts": {
     "build-lib": "babel src/ --out-dir lib/ --extensions '.js,.ts,.tsx' --source-maps --ignore '**/test' --ignore '**/karma.config.js'",
     "build": "yarn build-lib && tsc --build src/tsconfig.json",
+    "build-pattern-lib": "yarn gulp bundle-css && yarn rollup -c rollup.config.js",
     "typecheck": "tsc --build src/tsconfig.json",
     "lint": "eslint .",
     "checkformatting": "prettier --check '**/*.{js,scss,ts,tsx,md}'",


### PR DESCRIPTION
> This PR is part of https://github.com/hypothesis/frontend-shared/issues/973

This PR adds the required configuration to build a docker image which statically builds the pattern library, and then serves it with nginx on port 5001.

Deployment configs and such will follow this PR:
- Deployment workflow: https://github.com/hypothesis/frontend-shared/pull/999

### Testing steps

1. Check out this branch.
2. Run `docker build . -t hypothesis_frontend_shared`. This will build the docker image and tag it as `hypothesis_frontend_shared`.
3. Run a docker container based on the image just built: `docker run --rm -p 5001:5001 hypothesis_frontend_shared`
    * *`--rm` makes sure the container is discarded once stopped*
    * *The container will expose nginx on port `5001` of the host machine. In the unlikely case you are using this port, try with a different number*
4. Navigate to http://localhost:5001 (or the port you used) and check the pattern library looks ok.
    * Check also that once you have navigated somewhere other than `/`, you can refresh the page and the same section is loaded.
    * Check that `/_status` returns a 200 response. 
5. Verify "not found" URLs:
    * Dynamic "not-found" routes are handled client side, and nginx falls back to `index.html`. Navigate to something like http://localhost:5001/foo, and verify that you see this:
      ![image](https://user-images.githubusercontent.com/2719332/234899067-cb04c14a-7df7-4b3e-afd0-67ab4f61971c.png)
    * Invalid static assets (any URL containing a dot is considered a file with an extension). Navigate to something like http://localhost:5001/foo.css, and verify that you see an regular nginx 404 error:  
      ![image](https://user-images.githubusercontent.com/2719332/234899434-4946aeee-92b3-415c-8e8c-c8f1623234e1.png)

