### PR TITLE
Create workflows to deploy pattern library, manually or after release

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,44 @@
+name: Deploy
+concurrency:
+  group: deploy
+  cancel-in-progress: true
+
+on:
+  workflow_dispatch:
+  workflow_call:
+
+jobs:
+  docker_hub:
+    name: Docker Hub
+    uses: hypothesis/workflows/.github/workflows/dockerhub.yml@main
+    with:
+      Application: ${{ github.event.repository.name }}
+    secrets: inherit
+
+  staging:
+    name: Staging
+    needs: [docker_hub]
+    uses: hypothesis/workflows/.github/workflows/deploy.yml@main
+    with:
+      operation: deploy
+      github_environment_name: Staging
+      github_environment_url: https://patterns.staging.hypothes.is
+      aws_region: us-west-1
+      elasticbeanstalk_application: frontend-shared
+      elasticbeanstalk_environment: staging
+      docker_tag: ${{ needs.Docker_Hub.outputs.docker_tag }}
+    secrets: inherit
+
+  production:
+    name: Production
+    needs: [docker_hub, staging]
+    uses: hypothesis/workflows/.github/workflows/deploy.yml@main
+    with:
+      operation: deploy
+      github_environment_name: Production
+      github_environment_url: https://patterns.hypothes.is
+      aws_region: us-west-1
+      elasticbeanstalk_application: frontend-shared
+      elasticbeanstalk_environment: prod
+      docker_tag: ${{ needs.Docker_Hub.outputs.docker_tag }}
+    secrets: inherit

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -22,3 +22,7 @@ jobs:
       run: npm publish --access public
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+  deploy-website:
+    name: Deploy website
+    uses: ./.github/workflows/deploy.yml
+    secrets: inherit


### PR DESCRIPTION
> This PR is part of https://github.com/hypothesis/frontend-shared/issues/973

This PR introduces the base for what will be the workflow to deploy the pattern library on its own.

It ~does some assumptions, and~ would not work yet, because the infrastructure is not ready yet.

In any case, the workflow will build the docker image and then deploy it on Elastic Beanstalk.

It can be triggered automatically, every time a new release is created, but also manually in case it's needed.