### PR TITLE
Document how to deploy the pattern library

### DIFF
--- a/docs/developing.md
+++ b/docs/developing.md
@@ -10,6 +10,10 @@ $ make dev
 
 You can view the pattern library at http://localhost:4001/
 
+The pattern library is hosted at https://patterns.hypothes.is/. It gets deployed automatically when a new package version is published.
+
+It can be manually deployed using the [deploy workflow](https://github.com/hypothesis/frontend-shared/actions/workflows/deploy.yml)
+
 ## Testing locally with other projects
 
 This section explains how to test other applications (e.g. [`client`](https://github.com/hypothesis/client), `lms`) with

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -3,7 +3,9 @@
 ## Summary
 
 1. **Update the package version** in `package.json` and merge that change into the `main` branch[^1]. We use [Semantic Versioning](https://semver.org/#semantic-versioning-200).
-2. **Create a tag** pointing at the version-change commit and generate a **new GitHub release** (details follow). Publishing a GitHub release will kick off a GitHub Action that will **publish the `@hypothesis/frontend-shared` package to `npm`.**
+2. **Create a tag** pointing at the version-change commit and generate a **new GitHub release** (details follow). Publishing a GitHub release will kick off a GitHub Action that will do the following:
+   - Publish the `@hypothesis/frontend-shared` package to `npm`
+   - Deploy the pattern library to https://patterns.hypothes.is
 
 ## Creating a GitHub release
 


### PR DESCRIPTION
> This PR is part of https://github.com/hypothesis/frontend-shared/issues/973, and depends on https://github.com/hypothesis/frontend-shared/pull/999

Document how the automatic pattern library deployment works, and how to run it manually if needed.