### PR TITLE
Add `secondary` variant to `CardTitle` and `CardHeader`

### DIFF
--- a/src/components/layout/CardHeader.tsx
+++ b/src/components/layout/CardHeader.tsx
@@ -20,6 +20,8 @@ type ComponentProps = {
    * Make the header take the full width of the Card, with a full-width border
    */
   fullWidth?: boolean;
+
+  variant?: 'primary' | 'secondary';
 };
 
 type HTMLAttributes = JSX.HTMLAttributes<HTMLElement>;
@@ -39,6 +41,7 @@ const CardHeader = function CardHeader({
   fullWidth = false,
   onClose,
   title,
+  variant = 'primary',
 
   ...htmlAttributes
 }: CardHeaderProps) {
@@ -48,12 +51,20 @@ const CardHeader = function CardHeader({
       {...htmlAttributes}
       className={classnames(
         'flex items-center gap-x-2 border-b py-2',
-        { 'mx-3': !fullWidth, 'px-3': fullWidth },
+        {
+          'bg-slate-0 border-slate-5': variant === 'secondary',
+          'mx-3': !fullWidth && variant === 'primary',
+          'px-3': fullWidth || variant === 'secondary',
+        },
         classes
       )}
       ref={downcastRef(elementRef)}
     >
-      {title && <CardTitle>{title}</CardTitle>}
+      {title && (
+        <CardTitle classes="grow" variant={variant}>
+          {title}
+        </CardTitle>
+      )}
       {children}
       {onClose && (
         <IconButton

--- a/src/components/layout/CardTitle.tsx
+++ b/src/components/layout/CardTitle.tsx
@@ -4,7 +4,15 @@ import type { JSX } from 'preact';
 import type { PresentationalProps } from '../../types';
 import { downcastRef } from '../../util/typing';
 
+type ComponentProps = {
+  /** Wrap the title with this HTML heading tag  */
+  tagName?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5';
+
+  variant?: 'primary' | 'secondary';
+};
+
 export type CardTitleProps = PresentationalProps &
+  ComponentProps &
   JSX.HTMLAttributes<HTMLElement>;
 
 /**
@@ -15,16 +23,28 @@ const CardTitle = function CardTitle({
   classes,
   elementRef,
 
+  tagName = 'h1',
+  variant = 'primary',
+
   ...htmlAttributes
 }: CardTitleProps) {
+  const WrapperElement = tagName;
   return (
     <div
       data-component="CardTitle"
       {...htmlAttributes}
-      className={classnames('grow text-lg text-brand font-semibold', classes)}
+      className={classnames(
+        {
+          'text-lg text-brand font-semibold': variant === 'primary',
+          'text-xl text-slate-7 font-normal': variant === 'secondary',
+        },
+        classes
+      )}
       ref={downcastRef(elementRef)}
     >
-      {children}
+      <WrapperElement data-testid="card-title-heading">
+        {children}
+      </WrapperElement>
     </div>
   );
 };

--- a/src/components/layout/test/CardHeader-test.js
+++ b/src/components/layout/test/CardHeader-test.js
@@ -12,7 +12,7 @@ describe('CardHeader', () => {
 
   it('renders a close button if `onClose` set', () => {
     const onClose = sinon.stub();
-    const wrapper = createComponent(CardHeader, { onClose });
+    const wrapper = createComponent(CardHeader, { title: 'My title', onClose });
 
     wrapper.find('button').simulate('click');
     assert.calledOnce(onClose);

--- a/src/components/layout/test/CardTitle-test.js
+++ b/src/components/layout/test/CardTitle-test.js
@@ -1,6 +1,30 @@
+import { mount } from 'enzyme';
+
 import { testPresentationalComponent } from '../../test/common-tests';
 import CardTitle from '../CardTitle';
 
+const createComponent = (Component, props = {}) => {
+  return mount(<Component {...props}>This is child content</Component>);
+};
+
 describe('CardTitle', () => {
   testPresentationalComponent(CardTitle);
+
+  describe('heading element tagName', () => {
+    it('should wrap title in an `h1` by default', () => {
+      const wrapper = createComponent(CardTitle);
+      const headingEl = wrapper
+        .find('[data-testid="card-title-heading"]')
+        .getDOMNode();
+      assert.equal(headingEl.tagName, 'H1');
+    });
+
+    it('should allow designation of other heading tags', () => {
+      const wrapper = createComponent(CardTitle, { tagName: 'h3' });
+      const headingEl = wrapper
+        .find('[data-testid="card-title-heading"]')
+        .getDOMNode();
+      assert.equal(headingEl.tagName, 'H3');
+    });
+  });
 });

--- a/src/pattern-library/components/patterns/layout/CardPage.tsx
+++ b/src/pattern-library/components/patterns/layout/CardPage.tsx
@@ -273,6 +273,39 @@ export default function CardPage() {
               </Card>
             </Library.Demo>
           </Library.Example>
+
+          <Library.Example title="variant">
+            <Library.Demo title="variant='secondary' (default)" withSource>
+              <Card>
+                <CardHeader
+                  variant="primary"
+                  title="Primary variant"
+                  onClose={() => {}}
+                />
+                <CardContent>
+                  <p>
+                    This {"Card's"} <code>CardHeader</code> is styled with the{' '}
+                    <code>primary</code> (default) variant.
+                  </p>
+                </CardContent>
+              </Card>
+            </Library.Demo>
+            <Library.Demo title="variant='secondary'" withSource>
+              <Card>
+                <CardHeader
+                  variant="secondary"
+                  onClose={() => {}}
+                  title="Secondary variant"
+                />
+                <CardContent>
+                  <p>
+                    This {"Card's"} <code>CardHeader</code> is styled with the{' '}
+                    <code>secondary</code> variant.
+                  </p>
+                </CardContent>
+              </Card>
+            </Library.Demo>
+          </Library.Example>
         </Library.Pattern>
       </Library.Section>
 
@@ -305,6 +338,62 @@ export default function CardPage() {
               </CardContent>
             </Card>
           </Library.Demo>
+        </Library.Pattern>
+        <Library.Pattern title="Props">
+          <Library.Example title="tagName">
+            <p>
+              {' '}
+              The <code>
+                tagName: {"'h1' | 'h2' | 'h3' | 'h4' | 'h5'"}
+              </code>{' '}
+              prop (default <code>{"'h1'"}</code>) determines which HTML heading
+              element will wrap the rendered content.
+            </p>
+            <Library.Demo title="tagName='h3'" withSource>
+              <Card>
+                <CardHeader>
+                  <EditIcon />
+                  <CardTitle tagName="h3">Card title</CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <p>
+                    Setting a different heading level (HTML tag) in a{' '}
+                    <code>CardTitle</code>.
+                  </p>
+                </CardContent>
+              </Card>
+            </Library.Demo>
+          </Library.Example>
+
+          <Library.Example title="variant">
+            <Library.Demo title="variant='primary'" withSource>
+              <Card>
+                <CardHeader>
+                  <CardTitle variant="primary">Card title</CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <p>
+                    This <code>CardTitle</code> uses the default{' '}
+                    <code>{"'primary'"}</code> variant.
+                  </p>
+                </CardContent>
+              </Card>
+            </Library.Demo>
+
+            <Library.Demo title="variant='secondary'" withSource>
+              <Card>
+                <CardHeader>
+                  <CardTitle variant="secondary">Card title</CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <p>
+                    This <code>CardTitle</code> uses the
+                    <code>{"'secondary'"}</code> variant.
+                  </p>
+                </CardContent>
+              </Card>
+            </Library.Demo>
+          </Library.Example>
         </Library.Pattern>
       </Library.Section>
 


### PR DESCRIPTION
This PR expresses a design pattern we are using in the `lms` application by updating `variants` for `CardTitle` and `CardHeader` to add a new `secondary` variant (default is `primary`, the way it "looked before.").

This captures the pattern we've started using in panels in the `lms` app. It will make markup more straightforward for LMS components, and make prototyping within panels of that style faster and more consistent.

Partial screen grab of updated `Card` pattern library page, in the `CardHeader` section:

<img width="884" alt="image" src="https://user-images.githubusercontent.com/439947/234669216-08188385-0094-481f-ba04-3268dd10aad5.png">
