### PR TITLE
Transition common tests

### DIFF
--- a/plop-templates/transition-component-test.hbs
+++ b/plop-templates/transition-component-test.hbs
@@ -1,6 +1,6 @@
 import { mount } from 'enzyme';
 
-import { checkAccessibility } from '../../../../test/util/accessibility';
+import { testTransitionComponent } from '../../test/common-tests';
 import {{name}} from '../{{name}}';
 
 describe('{{name}}', () => {
@@ -25,17 +25,5 @@ describe('{{name}}', () => {
     container.remove();
   });
 
-  it(
-    'should pass a11y checks',
-    checkAccessibility([
-      {
-        name: 'in',
-        content: () => create{{name}}({ direction: 'in' }),
-      },
-      {
-        name: 'out',
-        content: () => create{{name}}({ direction: 'out' }),
-      },
-    ])
-  );
+  testTransitionComponent(Slider);
 });

--- a/src/components/test/common-tests.js
+++ b/src/components/test/common-tests.js
@@ -5,6 +5,7 @@ import { checkAccessibility } from '../../../test/util/accessibility';
 
 /**
  * @typedef {import('preact').FunctionComponent} FunctionComponent
+ * @typedef {import('../../types').TransitionComponent} TransitionComponent
  */
 
 const createComponent = (Component, props = {}) => {
@@ -235,5 +236,42 @@ export function testSimpleComponent(Component) {
       const wrapper = createComponent(Component);
       assert.isTrue(wrapper.find(Component).exists());
     });
+  });
+}
+
+/**
+ * Common tests for simple design components
+ *
+ * @param {TransitionComponent} Component
+ * @param {CommonTestOpts} opts
+ */
+export function testTransitionComponent(
+  Component,
+  { componentName, createContent = createComponent } = {}
+) {
+  const displayName = componentName ?? Component.displayName ?? Component.name;
+
+  describe(`Common transition component functionality for ${displayName}`, () => {
+    it('renders', () => {
+      const wrapper = createComponent(Component);
+      assert.isTrue(wrapper.find(Component).exists());
+    });
+
+    ['in', 'out'].forEach(direction => {
+      it('should handle unmounting while expanding or collapsing', () => {
+        const wrapper = createComponent(Component, { direction });
+        wrapper.setProps({ direction: direction === 'in' ? 'out' : 'in' });
+        wrapper.unmount();
+      });
+    });
+
+    it(
+      'should pass a11y checks',
+      checkAccessibility([
+        {
+          content: () => createContent(Component),
+        },
+      ])
+    );
   });
 }

--- a/src/components/test/common-tests.js
+++ b/src/components/test/common-tests.js
@@ -258,7 +258,7 @@ export function testTransitionComponent(
     });
 
     ['in', 'out'].forEach(direction => {
-      it('should handle unmounting while expanding or collapsing', () => {
+      it('should handle unmounting on either direction', () => {
         const wrapper = createComponent(Component, { direction });
         wrapper.setProps({ direction: direction === 'in' ? 'out' : 'in' });
         wrapper.unmount();

--- a/src/components/test/common-tests.js
+++ b/src/components/test/common-tests.js
@@ -258,10 +258,16 @@ export function testTransitionComponent(
     });
 
     ['in', 'out'].forEach(direction => {
-      it('should handle unmounting on either direction', () => {
-        const wrapper = createComponent(Component, { direction });
-        wrapper.setProps({ direction: direction === 'in' ? 'out' : 'in' });
-        wrapper.unmount();
+      it('should handle on transition end', () => {
+        const onTransitionEnd = sinon.stub();
+        const wrapper = createComponent(Component, {
+          direction,
+          onTransitionEnd,
+        });
+
+        wrapper.find('div').prop('ontransitionend')();
+
+        assert.calledWith(onTransitionEnd, direction);
       });
     });
 

--- a/src/components/transition/test/Slider-test.js
+++ b/src/components/transition/test/Slider-test.js
@@ -1,6 +1,6 @@
 import { mount } from 'enzyme';
 
-import { checkAccessibility } from '../../../../test/util/accessibility';
+import { testTransitionComponent } from '../../test/common-tests';
 import Slider from '../Slider';
 
 describe('Slider', () => {
@@ -23,6 +23,8 @@ describe('Slider', () => {
   afterEach(() => {
     container.remove();
   });
+
+  testTransitionComponent(Slider);
 
   it('should render collapsed if `direction` is `out` on mount', () => {
     const wrapper = createSlider({ direction: 'out' });
@@ -104,26 +106,4 @@ describe('Slider', () => {
     const containerStyle = wrapper.getDOMNode().style;
     assert.equal(containerStyle.display, 'none');
   });
-
-  ['in', 'out'].forEach(direction => {
-    it('should handle unmounting while expanding or collapsing', () => {
-      const wrapper = createSlider({ direction });
-      wrapper.setProps({ direction: direction === 'in' ? 'out' : 'in' });
-      wrapper.unmount();
-    });
-  });
-
-  it(
-    'should pass a11y checks',
-    checkAccessibility([
-      {
-        name: 'in',
-        content: () => createSlider({ direction: 'in' }),
-      },
-      {
-        name: 'out',
-        content: () => createSlider({ direction: 'out' }),
-      },
-    ])
-  );
 });


### PR DESCRIPTION
Create common logic via `testTransitionComponent` helper function, that can be used by all transition components tests.

I have moved there everything that made sense from `Slider-test` (our only real transition component so far). However, I have left most of the stuff out of this, because it was too specific for the `Slider`, which animates the content height, and has a transition which either fully displays its content, or fully hides it.

Other transition components might animate different aspects, or have an `in`/`out` state where the content is not fully displayed or hidden, but something in between.

Because of that I don't want to make any further assumptions, until we have more `TransitionComponent` examples.