### PR TITLE
Add grow class to CardTitle when used from Panel

### DIFF
--- a/src/components/layout/Panel.tsx
+++ b/src/components/layout/Panel.tsx
@@ -1,3 +1,4 @@
+import classnames from 'classnames';
 import type { ComponentChildren, JSX } from 'preact';
 
 import type { IconComponent, CompositeProps } from '../../types';
@@ -94,7 +95,7 @@ const Panel = function Panel({
     >
       <CardHeader onClose={onClose} fullWidth={scrollable || fullWidthHeader}>
         {Icon && <Icon className="w-em h-em" />}
-        <CardTitle>{title}</CardTitle>
+        <CardTitle classes={classnames({ grow: !!onClose })}>{title}</CardTitle>
       </CardHeader>
       {scrollable ? <Scroll>{panelContent}</Scroll> : <>{panelContent}</>}
       {buttons && (


### PR DESCRIPTION
Another PR removed the `grow` class from `CardTitle`, to make the `CardHeader` pass it explicitly instead.

However, I have just noticed it makes the close button be rendered next to the title in `Panel`s, because those render a `CardTitle` on their own, instead of relying on the logic inside `CardHeader`:

![image](https://user-images.githubusercontent.com/2719332/235084644-e6fc4c76-3fc3-4f4c-92a2-ada3d8d279b0.png)

Dynamically adding `grow` class when `onClose` has been provided to `Panel`, fixes this:

![image](https://user-images.githubusercontent.com/2719332/235084544-21535cbe-0c1c-4d28-b901-556509e621f5.png)

### Testing

- While in `main` branch, go to http://localhost:4001/layout-panel and search for `onClose`. You will notice the panel renders the close button incorrectly:
  ![image](https://user-images.githubusercontent.com/2719332/235101325-ce723488-a7d6-4d90-834f-37f005f35f3c.png)
- Check out this branch, and then go again to http://localhost:4001/layout-panel. The close button should render properly now:
  ![image](https://user-images.githubusercontent.com/2719332/235101507-69d7f8a0-32f2-4cbd-af06-90d651e6ffa1.png)

