### PR TITLE
Ensure proper layout of `CardHeader`

### DIFF
--- a/src/components/layout/CardHeader.tsx
+++ b/src/components/layout/CardHeader.tsx
@@ -60,12 +60,9 @@ const CardHeader = function CardHeader({
       )}
       ref={downcastRef(elementRef)}
     >
-      {title && (
-        <CardTitle classes="grow" variant={variant}>
-          {title}
-        </CardTitle>
-      )}
+      {title && <CardTitle variant={variant}>{title}</CardTitle>}
       {children}
+      <div className="grow" />
       {onClose && (
         <IconButton
           onClick={onClose}

--- a/src/pattern-library/components/patterns/layout/CardPage.tsx
+++ b/src/pattern-library/components/patterns/layout/CardPage.tsx
@@ -212,13 +212,47 @@ export default function CardPage() {
             componentName="Card, CardContent, CardHeader"
             size="sm"
           />
+
+          <Library.Example title="Using CardHeader">
+            <Library.Demo withSource title="Using CardHeader">
+              <Card>
+                <CardHeader title="Card title" />
+                <CardContent>
+                  <div>
+                    A <code>Card</code> with <code>CardHeader</code>.
+                  </div>
+                </CardContent>
+              </Card>
+            </Library.Demo>
+          </Library.Example>
         </Library.Pattern>
 
         <Library.Pattern title="Props">
           <Library.Example title="title">
-            <Library.Demo title="Setting a title" withSource>
+            <p>
+              When this optional <code>string</code> prop is provided,{' '}
+              <code>CardHeader</code> will render a <code>CardTitle</code> with
+              this <code>title</code>.
+            </p>
+            <Library.Demo withSource title="With a `title`">
               <Card>
-                <CardHeader title="Card title" />
+                <CardHeader title="Card title" onClose={() => {}} />
+                <CardContent>
+                  <div>
+                    A <code>Card</code> with <code>CardHeader</code>.
+                  </div>
+                </CardContent>
+              </Card>
+            </Library.Demo>
+
+            <Library.Demo
+              withSource
+              title="Composed with `CardTitle` (no `title`)"
+            >
+              <Card>
+                <CardHeader onClose={() => {}}>
+                  <CardTitle>Title here</CardTitle>
+                </CardHeader>
                 <CardContent>
                   <div>
                     A <code>Card</code> with <code>CardHeader</code>.


### PR DESCRIPTION
This PR is an alternative fix to https://github.com/hypothesis/frontend-shared/pull/1005 that adds some updated examples to the pattern library to make this kind of thing easier to spot in future.

It fixes an alignment problem in `CardHeader`s that could cause the close button not to align right properly.

Fix regression in certain compositions of `CardHeader` by using a spacing div that will ensure that the close button is always aligned right.