### PR TITLE
Include and serve images folder inside docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN rm -r /usr/share/nginx/html && rm /etc/nginx/conf.d/default.conf
 # Copy pattern library static assets, and put them in nginx document root folder
 COPY --from=builder /frontend-shared/build /usr/share/nginx/html
 COPY ./templates/pattern-library.mustache /usr/share/nginx/html/index.html
+COPY ./images /usr/share/nginx/html/images
 COPY conf/nginx.conf /etc/nginx/conf.d/default.conf
 
 EXPOSE 5001


### PR DESCRIPTION
This changes the patterns Dockerfile so that it copies the `images` folder inside nginx's document root.

This will allow to serve any file in that folder as a static file.

For example the `images/icons/annotate.svg` file will be available as `https://patterns.hypothes.is/images/icons/annotate.svg`.

### Testing steps

1. Check out this branch
2. Build the docker image: `docker build . -t hypothesis_frontend_shared`
3. Run the image you just build: `docker run --rm -p 5002:5001 hypothesis_frontend_shared` (with `--rm` the container will be deleted once stopped)
4. Visit http://localhost:5002 and verify the overall navigation works
5. Visit http://localhost:5002/images/icons/annotate.svg and verify the icon is properly served (any other icon should work as well).