### PR TITLE
Remove redundant headings on single-component documentation pages

### DIFF
--- a/src/pattern-library/components/patterns/data/AspectRatioPage.tsx
+++ b/src/pattern-library/components/patterns/data/AspectRatioPage.tsx
@@ -12,7 +12,7 @@ export default function AspectRatioPage() {
         </p>
       }
     >
-      <Library.Section title="AspectRatio">
+      <Library.Section>
         <Library.Pattern>
           <Library.Usage componentName="AspectRatio" />
           <Library.Example>

--- a/src/pattern-library/components/patterns/data/DataTablePage.tsx
+++ b/src/pattern-library/components/patterns/data/DataTablePage.tsx
@@ -30,7 +30,7 @@ export default function DataTablePage() {
         </p>
       }
     >
-      <Library.Section title="DataTable">
+      <Library.Section>
         <Library.Pattern>
           <Library.Usage componentName="DataTable" />
 

--- a/src/pattern-library/components/patterns/data/ThumbnailPage.tsx
+++ b/src/pattern-library/components/patterns/data/ThumbnailPage.tsx
@@ -17,7 +17,7 @@ export default function ThumbnailPage() {
         </p>
       }
     >
-      <Library.Section title="Thumbnail">
+      <Library.Section>
         <Library.Pattern>
           <Library.Usage componentName="Thumbnail" />
 

--- a/src/pattern-library/components/patterns/feedback/ModalPage.tsx
+++ b/src/pattern-library/components/patterns/feedback/ModalPage.tsx
@@ -93,7 +93,6 @@ export default function ModalPage() {
       }
     >
       <Library.Section
-        title="Modal"
         intro={
           <p>
             This is an interim implementation of a modal dialog that conforms to

--- a/src/pattern-library/components/patterns/input/InputGroupPage.tsx
+++ b/src/pattern-library/components/patterns/input/InputGroupPage.tsx
@@ -13,7 +13,6 @@ export default function InputGroupPage() {
   return (
     <Library.Page title="InputGroup">
       <Library.Section
-        title="InputGroup"
         intro={
           <p>
             <code>InputGroup</code> is a presentational component that provides

--- a/src/pattern-library/components/patterns/input/InputPage.tsx
+++ b/src/pattern-library/components/patterns/input/InputPage.tsx
@@ -12,7 +12,6 @@ export default function InputPage() {
       }
     >
       <Library.Section
-        title="Input"
         intro={
           <p>
             <code>Input</code> is a presentational component for styling textual{' '}

--- a/src/pattern-library/components/patterns/input/SelectPage.tsx
+++ b/src/pattern-library/components/patterns/input/SelectPage.tsx
@@ -33,7 +33,6 @@ export default function SelectPage() {
       }
     >
       <Library.Section
-        title="Select"
         intro={
           <p>
             <code>Select</code> styles <code>{'<select>'}</code> elements. Note

--- a/src/pattern-library/components/patterns/layout/PanelPage.tsx
+++ b/src/pattern-library/components/patterns/layout/PanelPage.tsx
@@ -15,7 +15,6 @@ export default function PanelPage() {
       }
     >
       <Library.Section
-        title="Panel"
         intro={
           <p>
             <code>Panel</code> is a composite component for standardized panel

--- a/src/pattern-library/components/patterns/navigation/LinkButtonPage.tsx
+++ b/src/pattern-library/components/patterns/navigation/LinkButtonPage.tsx
@@ -13,7 +13,6 @@ export default function LinkButtonPage() {
       }
     >
       <Library.Section
-        title="LinkButton"
         intro={
           <p>
             <code>LinkButton</code> is a presentational component.

--- a/src/pattern-library/components/patterns/navigation/PointerButtonPage.tsx
+++ b/src/pattern-library/components/patterns/navigation/PointerButtonPage.tsx
@@ -23,7 +23,6 @@ export default function PointerButtonPage() {
       }
     >
       <Library.Section
-        title="PointerButton"
         intro={
           <p>
             <code>PointerButton</code> is a presentational component.

--- a/src/pattern-library/components/patterns/transition/SliderPage.tsx
+++ b/src/pattern-library/components/patterns/transition/SliderPage.tsx
@@ -61,7 +61,6 @@ export default function SliderPage() {
       }
     >
       <Library.Section
-        title="Slider"
         intro={
           <p>
             <code>Slider</code> implements the <code>TransitionComponent</code>{' '}


### PR DESCRIPTION
For pattern-library pages that only document a single component, where the component is indicated by the page title, remove extra top-level heading titles. This has two benefits:

* Less vertical space used
* No heading redundancy visually
* Will provide better auto-generated fragment identifiers, which are composed from multiple headings

The associated sections are still extant, for document-structure purposes.

Part of #1027