### PR TITLE
Remove sticky header and update design to support the removal

### DIFF
--- a/src/pattern-library/components/Library.tsx
+++ b/src/pattern-library/components/Library.tsx
@@ -31,15 +31,11 @@ export type LibraryPageProps = {
  */
 function Page({ children, intro, title }: LibraryPageProps) {
   return (
-    <section className="max-w-6xl styled-text text-stone-600">
-      <div
-        className="sticky top-0 z-4 h-16 flex items-center bg-stone-100 border-b"
-        id="page-header"
-      >
-        <h1 className="px-2 text-3xl text-slate-700 font-light">{title}</h1>
-      </div>
-
-      <div className="px-2 mt-8">
+    <section className="styled-text text-stone-600">
+      <div className="px-8 py-4">
+        <h1 className="text-3xl text-slate-600 font-bold" id="page-header">
+          {title}
+        </h1>
         {intro && (
           <div className="my-8 pb-8 border-b space-y-4 font-light text-xl leading-relaxed">
             {intro}
@@ -64,7 +60,7 @@ function Heading({
   if (level <= 2) {
     return (
       <h2
-        className="text-3xl text-slate-600 font-bold mb-4"
+        className="text-2xl text-slate-600 font-medium mb-4"
         {...htmlAttributes}
       >
         {children}
@@ -73,7 +69,7 @@ function Heading({
   } else if (level === 3) {
     return (
       <h3
-        className="text-2xl text-slate-600 font-medium mb-4"
+        className="text-xl text-slate-600 font-medium mb-4"
         {...htmlAttributes}
       >
         {children}
@@ -246,7 +242,7 @@ function Demo({
       <div className="p-2 unstyled-text">
         {visibleTab === 'demo' && (
           <div
-            className="w-full p-8 rounded-md border border-stone-300 bg-slate-50 rounded-md"
+            className="w-full p-8 rounded-md border border-stone-300 bg-stone-50 rounded-md"
             style={style}
           >
             <div

--- a/src/pattern-library/components/PlaygroundApp.tsx
+++ b/src/pattern-library/components/PlaygroundApp.tsx
@@ -11,7 +11,7 @@ import {
 } from 'wouter-preact';
 
 import type { PlaygroundAppProps } from '../';
-import { Link, LogoIcon } from '../../';
+import { Link, LogoIcon, Scroll, ScrollContainer, ScrollContent } from '../../';
 import { componentGroups, getRoutes } from '../routes';
 import type { PlaygroundRoute } from '../routes';
 import Library from './Library';
@@ -102,8 +102,7 @@ export default function PlaygroundApp({
      * Support hash-based navigation and reset scroll when `wouter` path
      * changes.
      * - For locations without hash, reset scroll to top of page
-     * - For locations with hash, scroll to top of fragment-indicated element,
-     *   and ensure it's not obscured by the sticky `#page-header` element.
+     * - For locations with hash, scroll to top of fragment-indicated element
      */
     () => {
       const hash = window.location.hash.replace(/^#/, '');
@@ -111,18 +110,6 @@ export default function PlaygroundApp({
         const fragElement = document.getElementById(hash);
         if (fragElement) {
           fragElement.scrollIntoView();
-          const pageHeaderElement = document.getElementById('page-header');
-          // Height taken up by sticky header on page. Add 8 pixels to give
-          // some visual padding.
-          const headerOffset = pageHeaderElement
-            ? pageHeaderElement.getBoundingClientRect().height + 8
-            : 0;
-          const fragTop = fragElement.getBoundingClientRect().top;
-          if (fragTop <= headerOffset) {
-            // Adjustment to accommodate sticky header (only if fragment is at or
-            // near top of viewport)
-            window.scrollBy({ top: -1 * (headerOffset - fragTop) });
-          }
         }
       } else {
         window.scrollTo(0, 0);
@@ -164,77 +151,88 @@ export default function PlaygroundApp({
   >;
   return (
     <Router base={baseURL}>
-      <main className="max-w-[1250px] mx-auto">
-        <div className="md:grid md:grid-cols-[2fr_5fr]">
-          <div className="md:h-screen md:sticky md:top-0 overflow-scroll">
-            <div className="md:sticky md:top-0 h-16 px-6 flex items-center bg-slate-0 border-b">
-              <h1 className="text-lg">
-                <Link href={baseURL + '/'} classes="grow flex gap-x-2">
-                  <LogoIcon />
-                  Component Library
-                </Link>
-              </h1>
+      <div className="w-full bg-stone-200">
+        <main className="max-w-[1300px] mx-auto">
+          <div className="md:grid md:grid-cols-[2fr_5fr]">
+            <div className="md:h-screen md:sticky md:top-0 border-l border-stone-400 bg-stone-100">
+              <ScrollContainer borderless>
+                <div className="h-16 flex items-center">
+                  <h1 className="font-medium text-lg pl-6">
+                    <Link
+                      href={baseURL + '/'}
+                      classes="flex gap-x-3 text-stone-700"
+                    >
+                      <LogoIcon className="text-brand" />
+                      Component Library
+                    </Link>
+                  </h1>
+                </div>
+                <Scroll>
+                  <ScrollContent classes="bg-stone-400/10">
+                    <nav id="nav" className="pb-16 space-y-4 mr-4">
+                      <NavHeader>Foundations</NavHeader>
+                      <NavList>
+                        {getRoutes('foundations').map(route => (
+                          <NavLink key={route.title} route={route} />
+                        ))}
+                      </NavList>
+
+                      <NavHeader>Components</NavHeader>
+
+                      {groupKeys.map(group => {
+                        return (
+                          <NavSection
+                            key={group}
+                            title={componentGroups[group] as string}
+                          >
+                            <NavList>
+                              {getRoutes(group).map(route => (
+                                <NavLink key={route.title} route={route} />
+                              ))}
+                            </NavList>
+                          </NavSection>
+                        );
+                      })}
+
+                      {prototypeRoutes.length > 0 && (
+                        <>
+                          <NavHeader>Prototypes</NavHeader>
+                          <NavList>
+                            {prototypeRoutes.map(route => (
+                              <NavLink key={route.title} route={route} />
+                            ))}
+                          </NavList>
+                        </>
+                      )}
+
+                      {extraRoutes.length > 0 && (
+                        <>
+                          <NavHeader>{extraRoutesTitle}</NavHeader>
+                          <NavList>
+                            {customRoutes.map(route => (
+                              <NavLink key={route.title} route={route} />
+                            ))}
+                          </NavList>
+                        </>
+                      )}
+                    </nav>
+                  </ScrollContent>
+                </Scroll>
+              </ScrollContainer>
             </div>
-            <nav id="nav" className="pt-8 pb-16 space-y-4 mr-4">
-              <NavHeader>Foundations</NavHeader>
-              <NavList>
-                {getRoutes('foundations').map(route => (
-                  <NavLink key={route.title} route={route} />
-                ))}
-              </NavList>
-
-              <NavHeader>Components</NavHeader>
-
-              {groupKeys.map(group => {
-                return (
-                  <NavSection
-                    key={group}
-                    title={componentGroups[group] as string}
-                  >
-                    <NavList>
-                      {getRoutes(group).map(route => (
-                        <NavLink key={route.title} route={route} />
-                      ))}
-                    </NavList>
-                  </NavSection>
-                );
-              })}
-
-              {prototypeRoutes.length > 0 && (
-                <>
-                  <NavHeader>Prototypes</NavHeader>
-                  <NavList>
-                    {prototypeRoutes.map(route => (
-                      <NavLink key={route.title} route={route} />
-                    ))}
-                  </NavList>
-                </>
-              )}
-
-              {extraRoutes.length > 0 && (
-                <>
-                  <NavHeader>{extraRoutesTitle}</NavHeader>
-                  <NavList>
-                    {customRoutes.map(route => (
-                      <NavLink key={route.title} route={route} />
-                    ))}
-                  </NavList>
-                </>
-              )}
-            </nav>
+            <div className="bg-white pb-16 border-x border-stone-400">
+              <Switch>
+                {pageRoutes}
+                <Route>
+                  <Library.Page title=":( Sorry">
+                    <h1 className="text-2xl">Page not found</h1>
+                  </Library.Page>
+                </Route>
+              </Switch>
+            </div>
           </div>
-          <div className="bg-white pb-16">
-            <Switch>
-              {pageRoutes}
-              <Route>
-                <Library.Page title=":( Sorry">
-                  <h1 className="text-2xl">Page not found</h1>
-                </Library.Page>
-              </Route>
-            </Switch>
-          </div>
-        </div>
-      </main>
+        </main>
+      </div>
     </Router>
   );
 }


### PR DESCRIPTION
Remove the sticky header at the top of pattern-library pages. Update page region backgrounds and heading styilng to rebalance after the sticky header removal. Use `Scroll*` components in left nav for scroll shadow hinting.

Part of #1027 as the sticky header made it tricky to scroll intra-page fragment links correctly.

The diff is not as big as it looks: I added some wrapping elements/components in the `PlaygroundApp` page component. Suggest hiding whitespace in diff view.

Before:

<img width="1626" alt="image" src="https://github.com/hypothesis/frontend-shared/assets/439947/33932058-c8a6-42e8-b899-fbb44d3bbee9">


After:

<img width="1736" alt="image" src="https://github.com/hypothesis/frontend-shared/assets/439947/726ce2eb-f861-4249-ac8a-4f0867a644cc">
 