### PR TITLE
Make sure Dialogs do not render close button when onClose callback is not provided

### DIFF
--- a/src/components/feedback/Dialog.tsx
+++ b/src/components/feedback/Dialog.tsx
@@ -54,8 +54,6 @@ export type DialogProps = PresentationalProps &
   ComponentProps &
   Omit<PanelProps, 'fullWidthHeader'>;
 
-const noop = () => {};
-
 /**
  * Show a dialog
  */
@@ -74,7 +72,7 @@ const Dialog = function Dialog({
   // Forwarded to Panel
   buttons,
   icon,
-  onClose = noop,
+  onClose,
   paddingSize = 'md',
   scrollable = true,
   title,
@@ -87,6 +85,7 @@ const Dialog = function Dialog({
   );
   const [transitionComponentVisible, setTransitionComponentVisible] =
     useState(false);
+  const isClosableDialog = !!onClose;
 
   const closeHandler = useCallback(() => {
     if (TransitionComponent) {
@@ -94,7 +93,7 @@ const Dialog = function Dialog({
       // called by that component, once the "out" transition has finished
       setTransitionComponentVisible(false);
     } else {
-      onClose();
+      onClose?.();
     }
   }, [onClose, TransitionComponent]);
 
@@ -127,7 +126,7 @@ const Dialog = function Dialog({
     if (direction === 'in') {
       initializeDialog();
     } else {
-      onClose();
+      onClose?.();
     }
   };
 
@@ -216,7 +215,7 @@ const Dialog = function Dialog({
           buttons={buttons}
           fullWidthHeader={true}
           icon={icon}
-          onClose={closeHandler}
+          onClose={isClosableDialog ? closeHandler : undefined}
           paddingSize={paddingSize}
           title={title}
           scrollable={scrollable}

--- a/src/components/feedback/test/Dialog-test.js
+++ b/src/components/feedback/test/Dialog-test.js
@@ -282,6 +282,13 @@ describe('Dialog', () => {
         assert.called(onClose);
       });
     });
+
+    context('when no onClose callback is provided', () => {
+      it('does not render a close button', () => {
+        const wrapper = mount(<Dialog title="My dialog" />);
+        assert.isFalse(wrapper.find('CancelIcon').exists());
+      });
+    });
   });
 
   describe('aria-describedby', () => {


### PR DESCRIPTION
Closes https://github.com/hypothesis/frontend-shared/issues/1044

This PR changes the logic in `Dialog` to make sure an `onClose` callback is not passed down to the `Panel`, if the `Dialog` itself did not get one.