### PR TITLE
Update the structure of component documentation for data, feedback components

### DIFF
--- a/src/pattern-library/components/patterns/data/AspectRatioPage.tsx
+++ b/src/pattern-library/components/patterns/data/AspectRatioPage.tsx
@@ -25,7 +25,7 @@ export default function AspectRatioPage() {
             </Library.Demo>
           </Library.Example>
         </Library.Pattern>
-        <Library.Section title="Using AspectRatio">
+        <Library.Section title="Working with AspectRatio">
           <Library.Example title="Placeholder content">
             <p>
               Placeholder content can be put in a container that is the first

--- a/src/pattern-library/components/patterns/data/DataTablePage.tsx
+++ b/src/pattern-library/components/patterns/data/DataTablePage.tsx
@@ -259,7 +259,7 @@ export default function DataTablePage() {
                 are declared in <code>columns</code> will be rendered.
               </Library.InfoItem>
               <Library.InfoItem label="type">
-                <code>{`Array<Record<string,any>>`}</code>
+                <code>{`Array<Record<string,any>`}</code>
               </Library.InfoItem>
               <Library.InfoItem label="required">
                 <code>true</code>

--- a/src/pattern-library/components/patterns/data/DataTablePage.tsx
+++ b/src/pattern-library/components/patterns/data/DataTablePage.tsx
@@ -34,35 +34,26 @@ export default function DataTablePage() {
         <Library.Pattern>
           <Library.Usage componentName="DataTable" />
 
-          <Library.Example title="Basic DataTable">
-            <p>
-              This example shows a non-interactive <code>DataTable</code> with{' '}
-              <code>columns</code> and <code>rows</code> data.
-            </p>
-            <Library.Demo
-              title="DataTable showing some of Vladimir Nabokov's novels"
-              withSource
-            >
-              <div className="w-full h-[250px]">
-                <Scroll>
-                  <DataTable
-                    title="A subset of Nabokov's novels with publish date and original language"
-                    rows={nabokovRows}
-                    columns={nabokovColumns}
-                  />
-                </Scroll>
-              </div>
-            </Library.Demo>
-          </Library.Example>
+          <Library.Demo title="Basic DataTable" withSource>
+            <div className="w-full h-[250px]">
+              <Scroll>
+                <DataTable
+                  title="A subset of Nabokov's novels with publish date and original language"
+                  rows={nabokovRows}
+                  columns={nabokovColumns}
+                />
+              </Scroll>
+            </div>
+          </Library.Demo>
         </Library.Pattern>
 
         <Library.Pattern title="Working with tables">
           <Library.Example title="Rows, columns and items">
             <p>
-              <code>DataTable</code> operates on <code>rows</code> and{' '}
-              <code>columns</code>, which are described in detail in their
-              respective Props sections. An <code>item</code> is a single field
-              within a row (an individual table cell).
+              <code>DataTable</code> operates on <code>rows</code> and
+              <code>columns</code>. Rows are generic key-value objects and
+              columns determine which fields in each row are rendered in the
+              table.
             </p>
             <p>
               All of the <code>DataTable</code> examples on this page use the
@@ -125,6 +116,60 @@ export default function DataTablePage() {
   ];`}
               />
             </div>
+            <Library.Code
+              title="example of columns"
+              content={`const columns = [
+  { field: 'title', label: 'Title', classes: 'w-[80%]' },
+  { field: 'year', label: 'Year' },
+];`}
+            />
+          </Library.Example>
+          <Library.Example title="Interactive DataTables">
+            <p>
+              The presence of a <code>onSelectRow</code> and/or a{' '}
+              <code>onConfirmRow</code> callback prop will cause a{' '}
+              <code>DataTable</code> to be interactive.
+            </p>
+            <p>
+              Rows in interactive <code>DataTable</code>s can be{' '}
+              <strong>selected</strong> by a single click or keyboard navigation
+              focus, then subsequently — if <code>onConfirmRow</code> is
+              provided — <strong>confirmed</strong> with a double-click or by
+              pressing {"'Enter'"}.
+            </p>
+            <p>
+              <code>DataTable</code> does not maintain internal state and
+              expects a parent component to provide the current{' '}
+              <code>selectedRow</code>.
+            </p>
+
+            <Library.Demo
+              title="Interactive DataTable with callbacks for row selection, confirmation"
+              withSource
+            >
+              <div className="space-y-2 w-full">
+                <div>
+                  Selected row:{' '}
+                  {selectedRow2 ? <i>{selectedRow2.title}</i> : 'None'}
+                </div>
+                <div>
+                  Confirmed row:{' '}
+                  {confirmedRow ? <i>{confirmedRow.title}</i> : 'None'}
+                </div>
+                <div className="w-full h-[250px]">
+                  <Scroll>
+                    <DataTable
+                      title="Some of Nabokov's novels"
+                      rows={nabokovRows}
+                      columns={nabokovColumns}
+                      selectedRow={selectedRow2}
+                      onSelectRow={row => setSelectedRow2(row)}
+                      onConfirmRow={row => setConfirmedRow(row)}
+                    />
+                  </Scroll>
+                </div>
+              </div>
+            </Library.Demo>
           </Library.Example>
           <Library.Example title="Tables in constrained spaces">
             <p>
@@ -156,59 +201,35 @@ export default function DataTablePage() {
           </Library.Example>
         </Library.Pattern>
 
-        <Library.Pattern title="Props">
-          <Library.Example title="rows">
-            <p>
-              <code>rows</code> is an Array of objects mapping field names to
-              values.
-            </p>
-            <p>
-              Only fields that are present in the <code>columns</code> data will
-              be rendered. In this example, the <code>translatedTitle</code>{' '}
-              field is not referenced in <code>columns</code>, so it is not
-              rendered. In other words, row objects may contain entries that are
-              not used by <code>DataTable</code>.
-            </p>
-            <Library.Code
-              title="columns data used for this example"
-              content={`const columns = [
-  { field: 'title', label: 'Title' },
-  { field: 'year', label: 'Year' },
-  { field: 'language', label: 'Language' },
-];`}
-            />
-            <Library.Demo withSource>
-              <div className="w-full h-[250px]">
-                <Scroll>
-                  <DataTable
-                    title="A subset of Nabokov's novels with publish date and original language"
-                    rows={nabokovRows}
-                    columns={nabokovColumns}
-                  />
-                </Scroll>
-              </div>
-            </Library.Demo>
-          </Library.Example>
-
+        <Library.Pattern title="Component API">
+          <p>
+            <code>rows</code>, <code>columns</code> and <code>title</code> are
+            required.
+          </p>
           <Library.Example title="columns">
-            <p>
-              Columns define the headers that are rendered, as well as which row
-              fields are rendered.
-            </p>
-            <p>
-              <code>field</code> and <code>label</code> are required. Optional{' '}
-              <code>classes</code> will extend CSS classes applied to associated{' '}
-              <code>th</code> elements and is mainly intended for setting the
-              width of columns.
-            </p>
-            <Library.Code
-              title="columns data used for this example"
-              content={`const columns = [
-  { field: 'title', label: 'Title', classes: 'w-[80%]' },
-  { field: 'year', label: 'Year' },
-];`}
-            />
-            <Library.Demo withSource>
+            <Library.Info>
+              <Library.InfoItem label="description">
+                An array of objects defining headers to render, as well as which
+                fields in <code>rows</code> are rendered. Optional{' '}
+                <code>classes</code> extend CSS classes applied to associated{' '}
+                <code>th</code> elements.
+              </Library.InfoItem>
+              <Library.InfoItem label="type">
+                <Library.Code
+                  size="sm"
+                  content={`Array<{
+  field: string;
+  label: string;
+  classes?: string;
+}>
+`}
+                />
+              </Library.InfoItem>
+              <Library.InfoItem label="required">
+                <code>true</code>
+              </Library.InfoItem>
+            </Library.Info>
+            <Library.Demo title="Setting columns for a DataTable" withSource>
               <div className="w-full h-[250px]">
                 <Scroll>
                   <DataTable
@@ -222,42 +243,126 @@ export default function DataTablePage() {
                 </Scroll>
               </div>
             </Library.Demo>
+            <Library.Code
+              title="columns data used for this example"
+              content={`const columns = [
+  { field: 'title', label: 'Title', classes: 'w-[80%]' },
+  { field: 'year', label: 'Year' },
+];`}
+            />
           </Library.Example>
 
-          <Library.Example title="renderItem">
+          <Library.Example title="rows">
+            <Library.Info>
+              <Library.InfoItem label="description">
+                Array of objects mapping field names to values. Only fields that
+                are declared in <code>columns</code> will be rendered.
+              </Library.InfoItem>
+              <Library.InfoItem label="type">
+                <code>{`Array<Record<string,any>>`}</code>
+              </Library.InfoItem>
+              <Library.InfoItem label="required">
+                <code>true</code>
+              </Library.InfoItem>
+            </Library.Info>
+
+            <Library.Demo
+              title="Only fields declared in columns are rendered"
+              withSource
+            >
+              <div className="w-full h-[250px]">
+                <Scroll>
+                  <DataTable
+                    title="A subset of Nabokov's novels with publish date and original language"
+                    rows={nabokovRows}
+                    columns={nabokovColumns}
+                  />
+                </Scroll>
+              </div>
+            </Library.Demo>
+
             <p>
-              <code>renderItem</code> is a callback for formatting the contents
-              of an individual table cell. It is given the current{' '}
-              <code>row</code> and the <code>field</code> to format.
+              In this example, the <code>translatedTitle</code> field is not
+              referenced in <code>columns</code>, so it is not rendered.
             </p>
             <Library.Code
               title="columns data used for this example"
               content={`const columns = [
   { field: 'title', label: 'Title' },
-  { field: 'translatedTitle', label: 'Translated As' },
   { field: 'year', label: 'Year' },
+  { field: 'language', label: 'Language' },
 ];`}
             />
-            <Library.Code
-              title="`renderItem` callback used for this example"
-              size="sm"
-              content={`const renderItem = (row, field) => {
-  switch (field) {
-    case 'title':
-      return <i>{row.title}</i>;
-    case 'translatedTitle':
-      return row.translatedTitle ? (
-        <i>{row.translatedTitle}</i>
-      ) : (
-        'N/A'
-      );
-    default:
-      return row[field];
-  }
-}`}
-            />
+          </Library.Example>
 
+          <Library.Example title="emptyMessage">
+            <Library.Info>
+              <Library.InfoItem label="description">
+                Message to show if there are no <code>rows</code>. Superseded by{' '}
+                <code>loading</code> state.
+              </Library.InfoItem>
+              <Library.InfoItem label="type">
+                <code>{`preact.ComponentChildren`}</code>
+              </Library.InfoItem>
+            </Library.Info>
             <Library.Demo withSource>
+              <div className="w-full h-[250px]">
+                <Scroll>
+                  <DataTable
+                    title="Some of Nabokov's novels"
+                    rows={[]}
+                    columns={nabokovColumns}
+                    emptyMessage={<strong>No books found</strong>}
+                  />
+                </Scroll>
+              </div>
+            </Library.Demo>
+          </Library.Example>
+
+          <Library.Example title="loading">
+            <Library.Info>
+              <Library.InfoItem label="description">
+                Show a loading spinner. Column headings are still displayed.
+              </Library.InfoItem>
+              <Library.InfoItem label="type">
+                <code>{`boolean`}</code>
+              </Library.InfoItem>
+              <Library.InfoItem label="default">
+                <code>false</code>
+              </Library.InfoItem>
+            </Library.Info>
+            <Library.Demo withSource>
+              <div className="w-full h-[250px]">
+                <Scroll>
+                  <DataTable
+                    title="Some of Nabokov's novels"
+                    rows={nabokovRows}
+                    columns={nabokovColumns}
+                    loading={true}
+                  />
+                </Scroll>
+              </div>
+            </Library.Demo>
+          </Library.Example>
+
+          <Library.Example title="renderItem">
+            <Library.Info>
+              <Library.InfoItem label="description">
+                Callback for formatting the contents of an individual table
+                cell.
+              </Library.InfoItem>
+              <Library.InfoItem label="type">
+                <code>{`(r: Row, field: keyof Row) => preact.ComponentChildren`}</code>
+              </Library.InfoItem>
+              <Library.InfoItem label="default">
+                <code>{`(r: Row, field: keyof Row) => r[field] as ComponentChildren`}</code>
+              </Library.InfoItem>
+            </Library.Info>
+
+            <Library.Demo
+              title="Using renderItem to format table cell contents"
+              withSource
+            >
               <div className="w-full h-[250px]">
                 <Scroll>
                   <DataTable
@@ -286,97 +391,40 @@ export default function DataTablePage() {
                 </Scroll>
               </div>
             </Library.Demo>
-          </Library.Example>
-
-          <Library.Example title="loading">
-            <p>
-              Set this boolean prop to show a loading spinner, while still
-              displaying column headings.
-            </p>
-            <Library.Demo withSource>
-              <div className="w-full h-[250px]">
-                <Scroll>
-                  <DataTable
-                    title="Some of Nabokov's novels"
-                    rows={nabokovRows}
-                    columns={nabokovColumns}
-                    loading={true}
-                  />
-                </Scroll>
-              </div>
-            </Library.Demo>
-          </Library.Example>
-
-          <Library.Example title="emptyMessage">
-            <p>
-              An optional <code>emptyMessage</code> can be shown when the{' '}
-              <code>rows</code> Array is empty and <code>loading</code> is not
-              set.
-            </p>
-            <Library.Demo withSource>
-              <div className="w-full h-[250px]">
-                <Scroll>
-                  <DataTable
-                    title="Some of Nabokov's novels"
-                    rows={[]}
-                    columns={nabokovColumns}
-                    emptyMessage={<strong>No books found</strong>}
-                  />
-                </Scroll>
-              </div>
-            </Library.Demo>
-          </Library.Example>
-        </Library.Pattern>
-
-        <Library.Pattern title="Props for interactive DataTables">
-          <p>
-            Several of the props available on <code>DataTable</code> support
-            interactivity. Rows of data in interactive tables can be either{' '}
-            <em>selected</em> or <em>confirmed</em>.
-          </p>
-          <p>
-            A row can first be <strong>selected</strong> by a single click or
-            keyboard navigation focus, then subsequently — if the use case calls
-            for it — <strong>confirmed</strong> with a double-click or by
-            pressing {"'Enter'"}. Confirmation can be a handy convenience
-            affordance for, e.g., submitting a form, but selection alone may
-            satisfy most use cases in which a user is prompted to choose an
-            entry from a set of data rows.
-          </p>
-          <p>
-            <code>DataTable</code> does not maintain internal state and expects
-            a parent component to provide the current <code>selectedRow</code>.
-            Provided <code>onSelectRow</code> and <code>onConfirmRow</code>{' '}
-            callbacks are invoked when relevant mouse, keyboard and focus events
-            occur.
-          </p>
-
-          <Library.Example title="selectedRow">
-            <p>
-              Identify which row in the <code>rows</code> Array is currently
-              selected.
-            </p>
-            <Library.Demo withSource>
-              <div className="w-full h-[250px]">
-                <Scroll>
-                  <DataTable
-                    title="Some of Nabokov's novels"
-                    rows={nabokovRows}
-                    columns={nabokovColumns}
-                    selectedRow={nabokovRows[2]}
-                  />
-                </Scroll>
-              </div>
-            </Library.Demo>
+            <Library.Code
+              title="renderItem callback used for this example"
+              size="sm"
+              content={`const renderItem = (row, field) => {
+  switch (field) {
+    case 'title':
+      return <i>{row.title}</i>;
+    case 'translatedTitle':
+      return row.translatedTitle ? (
+        <i>{row.translatedTitle}</i>
+      ) : (
+        'N/A'
+      );
+    default:
+      return row[field];
+  }
+}`}
+            />
           </Library.Example>
 
           <Library.Example title="onSelectRow">
-            <p>
-              When a table row is keyboard-focused or clicked on, the{' '}
-              <code>onSelectRow</code> callback is invoked with the selected{' '}
-              <code>row</code>.
-            </p>
-            <Library.Demo withSource>
+            <Library.Info>
+              <Library.InfoItem label="description">
+                Callback invoked when a row is selected (focused or
+                single-clicked).
+              </Library.InfoItem>
+              <Library.InfoItem label="type">
+                <code>{`(r: Row) => void`}</code>
+              </Library.InfoItem>
+            </Library.Info>
+            <Library.Demo
+              title="DataTable with onSelectRow callback"
+              withSource
+            >
               <div className="space-y-2 w-full">
                 <div>
                   Selected row:{' '}
@@ -398,35 +446,53 @@ export default function DataTablePage() {
           </Library.Example>
 
           <Library.Example title="onConfirmRow">
-            <p>
-              When a table row is double-clicked, or <code>Enter</code> is
-              pressed with the row in focus, the <code>onConfirmRow</code>{' '}
-              callback is invoked with the confirmed <code>row</code>.
-            </p>
-            <Library.Demo withSource>
-              <div className="space-y-2 w-full">
-                <div>
-                  Selected row:{' '}
-                  {selectedRow2 ? <i>{selectedRow2.title}</i> : 'None'}
-                </div>
-                <div>
-                  Confirmed row:{' '}
-                  {confirmedRow ? <i>{confirmedRow.title}</i> : 'None'}
-                </div>
-                <div className="w-full h-[250px]">
-                  <Scroll>
-                    <DataTable
-                      title="Some of Nabokov's novels"
-                      rows={nabokovRows}
-                      columns={nabokovColumns}
-                      selectedRow={selectedRow2}
-                      onSelectRow={row => setSelectedRow2(row)}
-                      onConfirmRow={row => setConfirmedRow(row)}
-                    />
-                  </Scroll>
-                </div>
+            <Library.Info>
+              <Library.InfoItem label="description">
+                Callback invoked when a row is confirmed (double-clicked, or{' '}
+                <kbd>enter</kbd> pressed)
+              </Library.InfoItem>
+              <Library.InfoItem label="type">
+                <code>{`(r: Row) => void`}</code>
+              </Library.InfoItem>
+            </Library.Info>
+          </Library.Example>
+
+          <Library.Example title="selectedRow">
+            <Library.Info>
+              <Library.InfoItem label="description">
+                Set which Row in <code>rows</code> is currently selected.
+              </Library.InfoItem>
+              <Library.InfoItem label="type">
+                <code>{`Row`}</code>
+              </Library.InfoItem>
+            </Library.Info>
+
+            <Library.Demo title="DataTable with selectedRow" withSource>
+              <div className="w-full h-[250px]">
+                <Scroll>
+                  <DataTable
+                    title="Some of Nabokov's novels"
+                    rows={nabokovRows}
+                    columns={nabokovColumns}
+                    selectedRow={nabokovRows[2]}
+                  />
+                </Scroll>
               </div>
             </Library.Demo>
+          </Library.Example>
+
+          <Library.Example title="title">
+            <Library.Info>
+              <Library.InfoItem label="description">
+                A title used for accessibility purposes.
+              </Library.InfoItem>
+              <Library.InfoItem label="type">
+                <code>string</code>
+              </Library.InfoItem>
+              <Library.InfoItem label="required">
+                <code>true</code>
+              </Library.InfoItem>
+            </Library.Info>
           </Library.Example>
         </Library.Pattern>
       </Library.Section>

--- a/src/pattern-library/components/patterns/data/IconsPage.tsx
+++ b/src/pattern-library/components/patterns/data/IconsPage.tsx
@@ -7,20 +7,25 @@ export default function IconsPage() {
     <Library.Page
       title="Icons"
       intro={
-        <p>Icons are simple, standalone components that wrap SVG source.</p>
+        <p>
+          Icons are simple, standalone components that wrap SVG source markup.
+        </p>
       }
     >
-      <Library.Section title="Icon components">
+      <Library.Section>
         <Library.Pattern>
           <Library.Usage componentName="CancelIcon" />
           <Library.Example>
-            <Library.Demo title="Usage example with CancelIcon" withSource>
+            <Library.Demo
+              title="Basic Icon component usage: CancelIcon"
+              withSource
+            >
               <Icons.CancelIcon />
             </Library.Demo>
           </Library.Example>
         </Library.Pattern>
 
-        <Library.Pattern title="Available icon components">
+        <Library.Pattern title="Icon components">
           <div className="my-4 grid grid-cols-4 gap-6">
             {(Object.keys(Icons) as Array<keyof typeof Icons>).map(iconName => {
               const IconComponent = Icons[iconName];
@@ -37,59 +42,31 @@ export default function IconsPage() {
           </div>
         </Library.Pattern>
 
-        <Library.Pattern title="Props">
-          <p>
-            Icon components accept any{' '}
-            <code>
-              <Link href="https://developer.mozilla.org/en-US/docs/Web/API/SVGSVGElement">
-                SVGSVGElement
-              </Link>
-            </code>{' '}
-            attributes as props. Use <code>className</code> (not{' '}
-            <code>classes</code>) to style icons.
-          </p>
-          <Library.Example>
-            <Library.Demo title="Styled icon component" withSource>
-              <Icons.CautionIcon className="text-yellow-notice w-16 h-16" />
-            </Library.Demo>
+        <Library.Pattern title="Component API">
+          <Library.Example title="...svgProps">
+            <Library.Callout>
+              Unlike other components in this package, Icon components take{' '}
+              <code>className</code>, not <code>classes</code>.
+            </Library.Callout>
+            <Library.Info>
+              <Library.InfoItem label="description">
+                Icon components accept SVG attributes.
+              </Library.InfoItem>
+              <Library.InfoItem label="type">
+                <code>
+                  {'preact.JSX.HTMLAttributes<'}
+                  <Link href="https://developer.mozilla.org/en-US/docs/Web/API/SVGSVGElement">
+                    SVGSVGElement
+                  </Link>
+                </code>
+                {'>'}
+              </Library.InfoItem>
+            </Library.Info>
           </Library.Example>
-        </Library.Pattern>
 
-        <Library.Pattern title="Sizing icons">
-          <p>
-            Icons are sized at <code>16×16</code> unless styled otherwise.
-          </p>
-          <p>
-            Icons are often sized relative to the surrounding text. The{' '}
-            <code>em</code> spacing value provided by this {"package's"}{' '}
-            Tailwind preset allows sizing at <code>1em</code>.
-          </p>
-
-          <p>
-            <Link
-              href="https://tailwindcss.com/docs/customizing-spacing"
-              underline="always"
-            >
-              <div className="flex items-center gap-x-1">
-                More information about {"tailwind's"} sizing utility classes
-                <Icons.ExternalIcon />
-              </div>
-            </Link>
-          </p>
-          <Library.Example>
-            <Library.Demo title="Sized icon components" withSource>
-              <div className="space-y-2">
-                <div className="text-xs items-center flex gap-x-2">
-                  <Icons.ArrowRightIcon className="w-em h-em" />
-                  Icon sized relative to some small text
-                </div>
-                <div className="text-lg items-center flex gap-x-2">
-                  <Icons.ArrowRightIcon className="w-em h-em" />
-                  Icon sized relative to some larger text
-                </div>
-              </div>
-            </Library.Demo>
-          </Library.Example>
+          <Library.Demo title="Styled icon component" withSource>
+            <Icons.CautionIcon className="text-yellow-notice w-16 h-16" />
+          </Library.Demo>
         </Library.Pattern>
       </Library.Section>
     </Library.Page>

--- a/src/pattern-library/components/patterns/data/ScrollBoxPage.tsx
+++ b/src/pattern-library/components/patterns/data/ScrollBoxPage.tsx
@@ -30,26 +30,34 @@ export default function ScrollBoxPage() {
       >
         <Library.Pattern>
           <Library.Usage componentName="ScrollBox" />
-          <Library.Example title="Basic ScrollBox">
-            <Library.Demo withSource>
-              <div className="w-[280px] h-[200px]">
-                <ScrollBox>
-                  <ul>
-                    <SampleListElements />
-                  </ul>
-                </ScrollBox>
-              </div>
-            </Library.Demo>
-          </Library.Example>
+          <Library.Demo title="Basic Scrollbox" withSource>
+            <div className="w-[280px] h-[200px]">
+              <ScrollBox>
+                <ul>
+                  <SampleListElements />
+                </ul>
+              </ScrollBox>
+            </div>
+          </Library.Demo>
         </Library.Pattern>
 
-        <Library.Pattern title="Props">
+        <Library.Pattern title="Component API">
+          <p>
+            <code>ScrollBox</code> takes all standard props from the composite
+            component API.
+          </p>
           <Library.Example title="borderless">
-            <p>
-              <code>ScrollBox</code> applies a border to the outer{' '}
-              <code>ScrollContainer</code> by default. This can be disabled with
-              the <code>borderless</code> boolean prop.
-            </p>
+            <Library.Info>
+              <Library.InfoItem label="description">
+                Disable the border on the <code>ScrollBox</code>
+              </Library.InfoItem>
+              <Library.InfoItem label="type">
+                <code>boolean</code>
+              </Library.InfoItem>
+              <Library.InfoItem label="default">
+                <code>false</code>
+              </Library.InfoItem>
+            </Library.Info>
             <Library.Demo title="Turning off borders" withSource>
               <div className="w-[280px] h-[200px]">
                 <ScrollBox borderless>
@@ -64,7 +72,7 @@ export default function ScrollBoxPage() {
       </Library.Section>
 
       <Library.Section
-        title="Customizing scrolling"
+        title="Working with scrolling components"
         intro={
           <p>
             <code>Scroll</code> and its allies allow for more customization
@@ -73,7 +81,7 @@ export default function ScrollBoxPage() {
           </p>
         }
       >
-        <Library.Pattern title="Working with Scroll components">
+        <Library.Pattern title="Composing Scroll components">
           <Library.Example>
             <p>
               Sizing constraints are dictated by the immediate parent container
@@ -113,7 +121,7 @@ export default function ScrollBoxPage() {
         <Library.Pattern>
           <Library.Usage componentName="Scroll" />
           <Library.Example>
-            <Library.Demo title="Using Scroll by itself" withSource>
+            <Library.Demo title="Basic Scroll" withSource>
               <div className="w-[320px] h-[200px]">
                 <Scroll>
                   <ul>
@@ -125,23 +133,26 @@ export default function ScrollBoxPage() {
           </Library.Example>
         </Library.Pattern>
 
-        <Library.Pattern title="Props">
+        <Library.Pattern title="Component API">
+          <p>
+            <code>Scroll</code> takes all standard props from the presentational
+            component API.
+          </p>
           <Library.Example title="variant">
-            <p>
-              <code>Scroll</code>
-              {"'s"} <code>raised</code> variant (default) renders CSS shadows
-              to hint that content is scrollable. These can be disabled by using
-              the <code>flat</code> variant.
-            </p>
-            <Library.Demo title="variant:'raised' (default)" withSource>
-              <div className="w-[320px] h-[200px]">
-                <Scroll variant="raised">
-                  <ul>
-                    <SampleListElements />
-                  </ul>
-                </Scroll>
-              </div>
-            </Library.Demo>
+            <Library.Info>
+              <Library.InfoItem label="description">
+                <code>Scroll</code>
+                {"'s"} default <code>{"'raised'"}</code> <code>variant</code>{' '}
+                renders CSS shadows to hint that content is scrollable. These
+                can be disabled by using the <code>flat</code> variant.
+              </Library.InfoItem>
+              <Library.InfoItem label="type">
+                <code>{`'raised' | 'flat'`}</code>
+              </Library.InfoItem>
+              <Library.InfoItem label="default">
+                <code>{'raised'}</code>
+              </Library.InfoItem>
+            </Library.Info>
 
             <Library.Demo title="variant:'flat'" withSource>
               <div className="w-[320px] h-[200px]">
@@ -204,31 +215,37 @@ export default function ScrollBoxPage() {
         <Library.Pattern>
           <Library.Usage componentName="ScrollContainer" />
 
-          <Library.Example>
-            <Library.Demo title="Using ScrollContainer" withSource>
-              <div className="w-[320px] h-[200px]">
-                <ScrollContainer>
-                  <div className="p-2 border-b">Non-scrolling content here</div>
-                  <Scroll>
-                    <ScrollContent>
-                      <ul>
-                        <SampleListElements />
-                      </ul>
-                    </ScrollContent>
-                  </Scroll>
-                  <div className="p-2 border-t">More non-scrolling content</div>
-                </ScrollContainer>
-              </div>
-            </Library.Demo>
-          </Library.Example>
+          <Library.Demo title="Basic ScrollContainer" withSource>
+            <div className="w-[320px] h-[200px]">
+              <ScrollContainer>
+                <div className="p-2 border-b">Non-scrolling content here</div>
+                <Scroll>
+                  <ScrollContent>
+                    <ul>
+                      <SampleListElements />
+                    </ul>
+                  </ScrollContent>
+                </Scroll>
+                <div className="p-2 border-t">More non-scrolling content</div>
+              </ScrollContainer>
+            </div>
+          </Library.Demo>
         </Library.Pattern>
 
-        <Library.Pattern title="Props">
+        <Library.Pattern title="Component API">
           <Library.Example title="borderless">
-            <p>
-              Turn off <code>ScrollContainer</code> borders with the{' '}
-              <code>borderless</code> boolean prop.
-            </p>
+            <Library.Info>
+              <Library.InfoItem label="description">
+                Disable the border on the <code>ScrollContainer</code>
+              </Library.InfoItem>
+              <Library.InfoItem label="type">
+                <code>boolean</code>
+              </Library.InfoItem>
+              <Library.InfoItem label="default">
+                <code>false</code>
+              </Library.InfoItem>
+            </Library.Info>
+
             <Library.Demo withSource>
               <div className="w-[320px] h-[200px]">
                 <ScrollContainer borderless>

--- a/src/pattern-library/components/patterns/data/TablePage.tsx
+++ b/src/pattern-library/components/patterns/data/TablePage.tsx
@@ -26,52 +26,65 @@ export default function TablePage() {
             componentName="Table, TableHead, TableBody, TableRow, TableCell"
             size="sm"
           />
-          <Library.Example title="Simple Table">
-            <Library.Demo withSource>
-              <Table title="Some sushi rolls">
-                <TableHead>
-                  <TableRow>
-                    <TableCell>Sushi roll name</TableCell>
-                    <TableCell>Definition</TableCell>
-                  </TableRow>
-                </TableHead>
-                <TableBody>
-                  <TableRow>
-                    <TableCell>Alaskan roll</TableCell>
-                    <TableCell>
-                      A variant of the California roll with smoked salmon on the
-                      inside, or layered on the outside.
-                    </TableCell>
-                  </TableRow>
-                  <TableRow>
-                    <TableCell>Boston roll</TableCell>
-                    <TableCell>
-                      An uramaki California roll with poached shrimp instead of
-                      imitation crab.
-                    </TableCell>
-                  </TableRow>
-                  <TableRow>
-                    <TableCell>British Columbia roll</TableCell>
-                    <TableCell>
-                      A roll containing grilled or barbecued salmon skin,
-                      cucumber, sweet sauce, sometimes with roe. Also sometimes
-                      referred to as salmon skin rolls outside of British
-                      Columbia, Canada.
-                    </TableCell>
-                  </TableRow>
-                  <TableRow>
-                    <TableCell>California roll</TableCell>
-                    <TableCell>
-                      A roll consisting of avocado, kani kama (imitation
-                      crab/crab stick) (also can contain real crab in{' '}
-                      {'premium'} varieties), cucumber, and tobiko, often made
-                      as uramaki (with rice on the outside, nori on the inside).
-                    </TableCell>
-                  </TableRow>
-                </TableBody>
-              </Table>
-            </Library.Demo>
+          <Library.Demo title="Basic Table" withSource>
+            <Table title="Some sushi rolls">
+              <TableHead>
+                <TableRow>
+                  <TableCell>Sushi roll name</TableCell>
+                  <TableCell>Definition</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                <TableRow>
+                  <TableCell>Alaskan roll</TableCell>
+                  <TableCell>
+                    A variant of the California roll with smoked salmon on the
+                    inside, or layered on the outside.
+                  </TableCell>
+                </TableRow>
+                <TableRow>
+                  <TableCell>Boston roll</TableCell>
+                  <TableCell>
+                    An uramaki California roll with poached shrimp instead of
+                    imitation crab.
+                  </TableCell>
+                </TableRow>
+                <TableRow>
+                  <TableCell>British Columbia roll</TableCell>
+                  <TableCell>
+                    A roll containing grilled or barbecued salmon skin,
+                    cucumber, sweet sauce, sometimes with roe. Also sometimes
+                    referred to as salmon skin rolls outside of British
+                    Columbia, Canada.
+                  </TableCell>
+                </TableRow>
+                <TableRow>
+                  <TableCell>California roll</TableCell>
+                  <TableCell>
+                    A roll consisting of avocado, kani kama (imitation crab/crab
+                    stick) (also can contain real crab in {'premium'}{' '}
+                    varieties), cucumber, and tobiko, often made as uramaki
+                    (with rice on the outside, nori on the inside).
+                  </TableCell>
+                </TableRow>
+              </TableBody>
+            </Table>
+          </Library.Demo>
+        </Library.Pattern>
 
+        <Library.Pattern title="Working with Tables">
+          <Library.Example title="Composing Table components">
+            <p>
+              All <code>Table*</code> (<code>TableHead</code>,{' '}
+              <code>TableFoot</code>, <code>TableRow</code>,{' '}
+              <code>TableCell</code>, <code>TableBody</code>) are presentational
+              components and take all standard props from the presentational
+              component API. All also accept HTML attributes for their
+              associated element.
+            </p>
+          </Library.Example>
+
+          <Library.Example title="Sizing Tables">
             <p>
               Table column width is established by the first row, which are
               typically headers.
@@ -124,12 +137,23 @@ export default function TablePage() {
           </Library.Example>
         </Library.Pattern>
 
-        <Library.Pattern title="Props">
+        <Library.Pattern title="Component API">
+          <p>
+            <code>Table</code> takes all standard props from the presentational
+            component API.
+          </p>
           <Library.Example title="stickyHeader">
-            <p>
-              Set this boolean prop to make the table headings sticky when in a
-              scrolling context.
-            </p>
+            <Library.Info>
+              <Library.InfoItem label="description">
+                Make the table headers sticky in scrolling contexts
+              </Library.InfoItem>
+              <Library.InfoItem label="type">
+                <code>boolean</code>
+              </Library.InfoItem>
+              <Library.InfoItem label="default">
+                <code>false</code>
+              </Library.InfoItem>
+            </Library.Info>
             <Library.Demo title="Table with stickyHeader and Scroll" withSource>
               <div className="h-[250px]">
                 <Scroll>
@@ -200,11 +224,20 @@ export default function TablePage() {
           </Library.Example>
 
           <Library.Example title="interactive">
-            <p>
-              Set this boolean prop if rows in the table are select-able or
-              otherwise interactive.
-            </p>
-            <Library.Demo withSource>
+            <Library.Info>
+              <Library.InfoItem label="description">
+                Set this boolean prop if rows in the table are select-able or
+                otherwise interactive.
+              </Library.InfoItem>
+              <Library.InfoItem label="type">
+                <code>boolean</code>
+              </Library.InfoItem>
+              <Library.InfoItem label="default">
+                <code>false</code>
+              </Library.InfoItem>
+            </Library.Info>
+
+            <Library.Demo title="Table with interactive set" withSource>
               <Table title="Some sushi rolls" interactive>
                 <TableHead>
                   <TableRow>
@@ -241,6 +274,18 @@ export default function TablePage() {
                 </TableBody>
               </Table>
             </Library.Demo>
+          </Library.Example>
+
+          <Library.Example title="...htmlAttributes">
+            <Library.Info>
+              <Library.InfoItem label="description">
+                <code>Link</code> accepts HTML attribute props applicable to{' '}
+                <code>HTMLTableElement</code>.
+              </Library.InfoItem>
+              <Library.InfoItem label="type">
+                <code>{'preact.JSX.HTMLAttributes<HTMLTableElement>'}</code>
+              </Library.InfoItem>
+            </Library.Info>
           </Library.Example>
         </Library.Pattern>
       </Library.Section>

--- a/src/pattern-library/components/patterns/data/ThumbnailPage.tsx
+++ b/src/pattern-library/components/patterns/data/ThumbnailPage.tsx
@@ -30,7 +30,7 @@ export default function ThumbnailPage() {
           </Library.Demo>
         </Library.Pattern>
 
-        <Library.Pattern title="Using Thumbnail">
+        <Library.Pattern title="Working with Thumbnails">
           <Library.Example title="Loading and placeholder content">
             <Library.Demo withSource title="Loading state">
               <div className="w-[250px]">

--- a/src/pattern-library/components/patterns/feedback/DialogPage.tsx
+++ b/src/pattern-library/components/patterns/feedback/DialogPage.tsx
@@ -4,7 +4,6 @@ import type { DialogProps } from '../../../../';
 import {
   ArrowRightIcon,
   Button,
-  CautionIcon,
   DataTable,
   Dialog,
   EditIcon,
@@ -174,13 +173,6 @@ export default function DialogPage() {
           </p>
         }
       >
-        <Library.Pattern title="Status">
-          <p>
-            <strong>
-              <code>Dialog</code> is a new component.
-            </strong>
-          </p>
-        </Library.Pattern>
         <Library.Pattern>
           <Library.Usage componentName="Dialog" />
           <Library.Demo title="Basic Dialog" withSource>
@@ -203,12 +195,40 @@ export default function DialogPage() {
           </Library.Demo>
         </Library.Pattern>
 
-        <Library.Pattern title="Props">
+        <Library.Pattern title="ComponentAPI">
+          <p>
+            <code>Dialog</code> accepts all standard composite component API
+            props.
+          </p>
+
+          <Library.Example title="classes">
+            <Library.Info>
+              <Library.InfoItem label="description">
+                Atypically for a composite component, <code>Dialog</code>{' '}
+                accepts <code>classes</code> (CSS classes). These will be
+                appended to the classes applied to the {"dialog's"} container
+                element.
+              </Library.InfoItem>
+              <Library.InfoItem label="type">
+                <code>string</code>
+              </Library.InfoItem>
+            </Library.Info>
+          </Library.Example>
+
           <Library.Example title="closeOnClickAway">
-            <p>
-              This boolean prop (default <code>false</code>) controls whether
-              the Dialog should close when there are click events outside of it.
-            </p>
+            <Library.Info>
+              <Library.InfoItem label="description">
+                The <code>Dialog</code> should close (invoke its{' '}
+                <code>onClose</code> callback) when there are click events
+                outside of it
+              </Library.InfoItem>
+              <Library.InfoItem label="type">
+                <code>boolean</code>
+              </Library.InfoItem>
+              <Library.InfoItem label="default">
+                <code>false</code>
+              </Library.InfoItem>
+            </Library.Info>
             <Library.Demo
               title="Dialog that closes on external clicks"
               withSource
@@ -222,29 +242,21 @@ export default function DialogPage() {
               </Dialog_>
             </Library.Demo>
           </Library.Example>
-          <Library.Example title="closeOnFocusAway">
-            <p>
-              This boolean prop (default <code>false</code>) controls whether
-              the Dialog should close when there are focus events outside of it.
-            </p>
-            <Library.Demo
-              title="Dialog that closes on external focus events"
-              withSource
-            >
-              <Dialog_
-                closeOnFocusAway
-                onClose={() => {}}
-                title="Close on Away Focus"
-              >
-                <p>This dialog will close if you focus outside of it</p>
-              </Dialog_>
-            </Library.Demo>
-          </Library.Example>
+
           <Library.Example title="closeOnEscape">
-            <p>
-              Enable close-on-ESC behavior by setting this boolean prop (default{' '}
-              <code>false</code>).
-            </p>
+            <Library.Info>
+              <Library.InfoItem label="description">
+                The <code>Dialog</code> should close (invoke its{' '}
+                <code>onClose</code> callback) when the <kbd>ESC</kbd> key is
+                pressed.
+              </Library.InfoItem>
+              <Library.InfoItem label="type">
+                <code>boolean</code>
+              </Library.InfoItem>
+              <Library.InfoItem label="default">
+                <code>false</code>
+              </Library.InfoItem>
+            </Library.Info>
 
             <Library.Demo
               title="Dialog with close-on-Escape behavior"
@@ -258,33 +270,99 @@ export default function DialogPage() {
             </Library.Demo>
           </Library.Example>
 
+          <Library.Example title="closeOnFocusAway">
+            <Library.Info>
+              <Library.InfoItem label="description">
+                The <code>Dialog</code> should close (invoke its{' '}
+                <code>onClose</code> callback) when there are focus events
+                outside of it.
+              </Library.InfoItem>
+              <Library.InfoItem label="type">
+                <code>boolean</code>
+              </Library.InfoItem>
+              <Library.InfoItem label="default">
+                <code>false</code>
+              </Library.InfoItem>
+            </Library.Info>
+            <Library.Demo
+              title="Dialog that closes on external focus events"
+              withSource
+            >
+              <Dialog_
+                closeOnFocusAway
+                onClose={() => {}}
+                title="Close on Away Focus"
+              >
+                <p>This dialog will close if you focus outside of it</p>
+              </Dialog_>
+            </Library.Demo>
+          </Library.Example>
+
           <Library.Example title="initialFocus">
-            <p>
-              The <code>initialFocus</code> prop determines how focus is routed
-              when a <code>Dialog</code> is mounted (opened). Accepted values:
-            </p>
-            <ul>
-              <li>
-                <code>{"'auto'"}</code> (default): Focus is routed to the
-                outermost element of the <code>Dialog</code> when opeend.
-              </li>
-              <li>
-                <code>RefObject{'<HTMLOrSVGElement>'}</code>: Focus will be
-                routed to the referenced element.
-              </li>
-              <li>
-                <code>{"'manual'"}</code>: Disable automatic focus routing.
-                Consumer is responsible for routing focus appropriately.
-              </li>
-            </ul>
+            <Library.Info>
+              <Library.InfoItem label="description">
+                Determine how initial focus is routed when the{' '}
+                <code>Dialog</code> is mounted (opened). By default (
+                <code>{`'auto'`}</code>), the dialog itself will be focused.
+                Provide a <code>ref</code> to focus a specific element
+                initially, or set to <code>{`'manual'`}</code> to opt out of any
+                focus routing.
+              </Library.InfoItem>
+              <Library.InfoItem label="type">
+                <code>{`preact.RefObject<HTMLOrSVGElement | null> | 'auto' | 'manual'`}</code>
+              </Library.InfoItem>
+              <Library.InfoItem label="default">
+                <code>{`'auto'`}</code>
+              </Library.InfoItem>
+            </Library.Info>
+          </Library.Example>
+
+          <Library.Example title="onClose">
+            <Library.Callout>
+              The <code>onClose</code> prop is optional, but should be
+              considered required for all new <code>Dialog</code>s. This
+              flexibility exists to support legacy use cases of{' '}
+              {'non-closeable'} dialogs.
+            </Library.Callout>
+            <Library.Info>
+              <Library.InfoItem label="description">
+                Callback invoked when the <code>Dialog</code> should be closed.{' '}
+                Note: <code>Dialog</code>s have no state — when rendered, they
+                are always open.
+              </Library.InfoItem>
+              <Library.InfoItem label="type">
+                <code>{`() => void`}</code>
+              </Library.InfoItem>
+            </Library.Info>
+            <Library.Demo title="Non-closeable Dialog example" withSource>
+              <Dialog_
+                icon={EditIcon}
+                title="Non-closeable dialog example"
+                _nonCloseable
+              >
+                <p>
+                  This is a {'"non-closeable"'} <code>Dialog</code>. This
+                  pattern should be avoided, but is supported for a few legacy
+                  use cases. You can close this modal by clicking the{' '}
+                  {'"Escape!"'} button.
+                </p>
+              </Dialog_>
+            </Library.Demo>
           </Library.Example>
 
           <Library.Example title="restoreFocus">
-            <p>
-              This boolean prop (default <code>false</code>) restores focus when
-              the Dialog is closed to the element that had focus before it was
-              opened.
-            </p>
+            <Library.Info>
+              <Library.InfoItem label="description">
+                Upon closing (unmounting), restore focus to the element that had
+                focus before the <code>Dialog</code> was opened (mounted).
+              </Library.InfoItem>
+              <Library.InfoItem label="type">
+                <code>boolean</code>
+              </Library.InfoItem>
+              <Library.InfoItem label="default">
+                <code>false</code>
+              </Library.InfoItem>
+            </Library.Info>
 
             <Library.Demo
               title="Dialog with focus restoration on close"
@@ -304,44 +382,18 @@ export default function DialogPage() {
             </Library.Demo>
           </Library.Example>
 
-          <Library.Example title="onClose">
-            <p>
-              It is possible to create a non-closeable <code>Dialog</code> by
-              omitting the <code>onClose</code> prop.
-            </p>
-            <div className="flex gap-x-2 items-center">
-              <CautionIcon className="text-yellow-notice w-6 h-6" />
-              <p>
-                This flexibility exists to support legacy use cases. Avoid
-                creating new non-closeable dialogs.
-              </p>
-            </div>
-            <Library.Demo title="Non-closeable Dialog example" withSource>
-              <Dialog_
-                icon={EditIcon}
-                title="Non-closeable dialog example"
-                _nonCloseable
-              >
-                <p>
-                  This is a {'"non-closeable"'} <code>Dialog</code>. This
-                  pattern should be avoided, but is supported for a few legacy
-                  use cases. You can close this modal by clicking the{' '}
-                  {'"Escape!"'} button.
-                </p>
-              </Dialog_>
-            </Library.Demo>
-          </Library.Example>
-
           <Library.Example title="transitionComponent">
-            <p>
-              It allows to provide a component which supports transitions, but
-              keeping the internal behavior (initial focus, closing, etc)
-              transparent to consumers.
-            </p>
-            <p>
-              The only requirement is that provided component needs to be a{' '}
-              <strong>TransitionComponent</strong>.
-            </p>
+            <Library.Info>
+              <Library.InfoItem label="description">
+                A <code>TransitionComponent</code> to use when this{' '}
+                <code>Dialog</code> is opened/mounted and closed/unmounted. By
+                default, no transition is applied.
+              </Library.InfoItem>
+              <Library.InfoItem label="type">
+                <code>TransitionComponent</code>
+              </Library.InfoItem>
+            </Library.Info>
+
             <Library.Demo
               title="Dialog with TransitionComponent example"
               withSource
@@ -356,32 +408,21 @@ export default function DialogPage() {
               </Dialog_>
             </Library.Demo>
           </Library.Example>
-        </Library.Pattern>
 
-        <Library.Pattern title="Forwarded Props: Panel">
-          <p>
-            These props are forwarded to <code>Panel</code>:
-          </p>
-          <ul>
-            <li>
-              <code>buttons</code>
-            </li>
-            <li>
-              <code>icon</code>
-            </li>
-            <li>
-              <code>onClose</code>
-            </li>
-            <li>
-              <code>paddingSize</code>
-            </li>
-            <li>
-              <code>title</code>
-            </li>
-          </ul>
-          <p>
-            <code>fullWidthHeader</code> is always <code>true</code>.
-          </p>
+          <Library.Example title="...panelProps">
+            <Library.Info>
+              <Library.InfoItem label="description">
+                <code>Dialog</code> uses <code>Panel</code> for layout. All{' '}
+                <Library.Link href="/layout-panel">Panel</Library.Link> props
+                are accepted and forwarded except for{' '}
+                <code>fullWidthHeader</code> (which is always set for{' '}
+                <code>Dialog</code>).
+              </Library.InfoItem>
+              <Library.InfoItem label="type">
+                <code>TransitionComponent</code>
+              </Library.InfoItem>
+            </Library.Info>
+          </Library.Example>
         </Library.Pattern>
       </Library.Section>
 
@@ -465,7 +506,8 @@ export default function DialogPage() {
               </InputGroup>
             </ModalDialog_>
           </Library.Demo>
-
+        </Library.Pattern>
+        <Library.Pattern title="Working with ModalDialogs">
           <Library.Example title="Handling long content">
             <p>
               By default, content in a <code>Dialog</code> or{' '}
@@ -486,8 +528,8 @@ export default function DialogPage() {
             <p>
               Modal dialogs should provide appropriate keyboard navigation even
               when there are multiple or complex embedded widgts, like data
-              tables (ARIA <code>{'`role="grid"`'}</code>) or tabs (ARIA{' '}
-              <code>{'`role="tablist"`'}</code>).
+              tables (ARIA <code>{`role="grid"`}</code>) or tabs (ARIA{' '}
+              <code>{`role="tablist"`}</code>).
             </p>
             <Library.Demo title="Modal with embedded ARIA widgets" withSource>
               <ModalDialog_
@@ -556,9 +598,10 @@ export default function DialogPage() {
             </p>
             <ul>
               <li>
-                <strong>Set a height on the ModalDialog</strong> itself. The
-                Modal will always render at this height. If contained content
-                height exceeds this height, it will scroll.
+                <strong>Set a height on the ModalDialog</strong> itself via the{' '}
+                <code>classes</code> prop. The Modal will always render at this
+                height. If contained content height exceeds this height, it will
+                scroll.
               </li>
               <li>
                 <strong>
@@ -641,43 +684,76 @@ export default function DialogPage() {
             </Library.Demo>
           </Library.Example>
         </Library.Pattern>
-        <Library.Pattern title="Props">
+        <Library.Pattern title="ComponentAPI">
           <Library.Example title="disableCloseOnEscape">
-            <p>
-              Set this boolean prop (default <code>false</code>) to disable
-              closing the modal when the <kbd>Escape</kbd> key is pressed.
-            </p>
+            <Library.Info>
+              <Library.InfoItem label="description">
+                Do not close the <code>ModalDialog</code> when <kbd>ESC</kbd> is
+                pressed.
+              </Library.InfoItem>
+              <Library.InfoItem label="type">
+                <code>boolean</code>
+              </Library.InfoItem>
+              <Library.InfoItem label="default">
+                <code>false</code>
+              </Library.InfoItem>
+            </Library.Info>
           </Library.Example>
+
           <Library.Example title="disableFocusTrap">
-            <p>
-              This boolean prop (default <code>false</code>) enables
-              modal-dialog focus trap and keyboard navigation as specified by{' '}
+            <Library.Info>
+              <Library.InfoItem label="description">
+                Do not trap focus in the modal.
+              </Library.InfoItem>
+              <Library.InfoItem label="type">
+                <code>boolean</code>
+              </Library.InfoItem>
+              <Library.InfoItem label="default">
+                <code>false</code>
+              </Library.InfoItem>
+            </Library.Info>
+
+            <Library.Callout>
+              <em>Note</em>: Modal focus trapping is part of{' '}
               <Link
                 href="https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/#keyboardinteraction"
                 underline="always"
               >
                 WAI-ARIA authoring guidelines
               </Link>
-              .
-            </p>
-            <p>
-              <em>Note</em>: Disabling this prop is not recommended and could
-              raise issues of accessibility.
-            </p>
+              . Disabling this prop is not recommended and could raise issues of
+              accessibility.
+            </Library.Callout>
           </Library.Example>
 
           <Library.Example title="disableRestoreFocus">
-            <p>
-              Set this boolean prop (default <code>false</code>) to disable the
-              restoration of focus after the <code>ModalDialog</code> is closed.
-            </p>
+            <Library.Info>
+              <Library.InfoItem label="description">
+                Do not restore focus to previously-focused element when the
+                modal is closed.
+              </Library.InfoItem>
+              <Library.InfoItem label="type">
+                <code>boolean</code>
+              </Library.InfoItem>
+              <Library.InfoItem label="default">
+                <code>false</code>
+              </Library.InfoItem>
+            </Library.Info>
           </Library.Example>
 
           <Library.Example title="size">
-            <p>
-              The <code>size</code> prop establishes the width of the modal
-              dialog.
-            </p>
+            <Library.Info>
+              <Library.InfoItem label="description">
+                Set the relative width of the modal element. Set to {`'custom'`}{' '}
+                to customize width via <code>classes</code>.
+              </Library.InfoItem>
+              <Library.InfoItem label="type">
+                <code>{`'sm' | 'md' | 'lg' | 'custom'`}]</code>
+              </Library.InfoItem>
+              <Library.InfoItem label="default">
+                <code>{`'md'`}</code>
+              </Library.InfoItem>
+            </Library.Info>
             <Library.Demo title="size='sm'" withSource>
               <ModalDialog_
                 buttons={<DialogButtons />}
@@ -711,12 +787,6 @@ export default function DialogPage() {
               </ModalDialog_>
             </Library.Demo>
 
-            <p>
-              To style your <code>ModalDialog</code> with a custom width, set{' '}
-              <code>size</code> to <code>{"'custom'"}</code> and provide sizing
-              CSS class(es) via the <code>classes</code> prop.
-            </p>
-
             <Library.Demo title="size='custom'" withSource>
               <ModalDialog_
                 buttons={<DialogButtons />}
@@ -742,36 +812,30 @@ export default function DialogPage() {
             </p>
           </Library.Example>
 
-          <Library.Example title="width">
-            <p>
-              The{' '}
-              <s>
-                <code>width</code>
-              </s>{' '}
-              prop is deprecated: use <code>size</code> instead.
-            </p>
-          </Library.Example>
-
-          <Library.Example title="Forwarded Props: Dialog">
-            <p>
-              <code>ModalDialog</code> forwards the following props (defaults in
-              parentheses) to <code>Dialog</code>:
-            </p>
-            <ul>
-              <li>
-                <code>closeOnClickAway</code> (<code>false</code>)
-              </li>
-              <li>
-                <code>closeOnFocusAway</code> (<code>false</code>)
-              </li>
-              <li>
-                <code>initialFocus</code> (<code>{"'auto'"}</code>)
-              </li>
-            </ul>
-            <p>
-              <code>Panel</code> props forwarded by <code>Dialog</code> are also
-              accepted.
-            </p>
+          <Library.Example title="...dialogProps">
+            <Library.Info>
+              <Library.InfoItem label="description">
+                Props forwarded to <code>Dialog</code> and <code>Panel</code>.
+              </Library.InfoItem>
+              <Library.InfoItem label="props">
+                All <code>Dialog</code> and <code>Panel</code> props,{' '}
+                <strong>except</strong>:
+                <ul>
+                  <li>
+                    <code>closeOnEscape (Dialog)</code>: Use{' '}
+                    <code>disableCloseOnEscape</code> instead
+                  </li>
+                  <li>
+                    <code>restoreFocus (Dialog)</code>: Use{' '}
+                    <code>disableRestoreFocus</code> instead
+                  </li>
+                  <li>
+                    <code>fullWidthHeader (Panel)</code>: always{' '}
+                    <code>true</code> for all dialogs
+                  </li>
+                </ul>
+              </Library.InfoItem>
+            </Library.Info>
           </Library.Example>
         </Library.Pattern>
       </Library.Section>

--- a/src/pattern-library/components/patterns/feedback/SpinnerPage.tsx
+++ b/src/pattern-library/components/patterns/feedback/SpinnerPage.tsx
@@ -124,7 +124,7 @@ export default function SpinnerPage() {
 
               <Library.InfoItem label="type">
                 <code>
-                  {`Omit<JSX.HTMLAttributes<HTMLElement>,'className' | 'open'>`}
+                  {`Omit<JSX.HTMLAttributes<HTMLElement>, 'className' | 'open'>`}
                 </code>
               </Library.InfoItem>
             </Library.Info>

--- a/src/pattern-library/components/patterns/feedback/SpinnerPage.tsx
+++ b/src/pattern-library/components/patterns/feedback/SpinnerPage.tsx
@@ -39,31 +39,50 @@ export default function SpinnerPage() {
           </Library.Example>
         </Library.Pattern>
 
-        <Library.Pattern title="Props">
+        <Library.Pattern title="Component API">
           <Library.Example title="color">
-            <Library.Demo title="color: 'text-light' (default)" withSource>
-              <Spinner color="text-light" size="md" />
-            </Library.Demo>
-            <Library.Demo title="color: 'text'" withSource>
-              <Spinner color="text" size="md" />
-            </Library.Demo>
+            <Library.Info>
+              <Library.InfoItem label="description">
+                Set the foreground color of the spinner icon.
+              </Library.InfoItem>
+              <Library.InfoItem label="type">
+                <code>{`'text' |'text-light' | 'text-inverted'`}]</code>
+              </Library.InfoItem>
+              <Library.InfoItem label="default">
+                <code>{`'text-light'`}</code>
+              </Library.InfoItem>
+            </Library.Info>
+            <Library.Demo title="Available Spinner colors" withSource>
+              <div className="flex gap-x-8 items-center">
+                <Spinner color="text-light" size="md" />
 
-            <Library.Demo title="color: 'text-inverted'" withSource>
-              <div className="bg-slate-7 rounded-lg flex items-center justify-center p-8">
-                <Spinner color="text-inverted" size="md" />
+                <Spinner color="text" size="md" />
+
+                <div className="bg-slate-7 rounded-lg flex items-center justify-center p-8">
+                  <Spinner color="text-inverted" size="md" />
+                </div>
               </div>
             </Library.Demo>
           </Library.Example>
 
           <Library.Example title="size">
-            <Library.Demo title="size: 'sm' (1em) (default)" withSource>
-              <Spinner size="sm" />
-            </Library.Demo>
-            <Library.Demo title="size: 'md' (2em)" withSource>
-              <Spinner size="md" />
-            </Library.Demo>
-            <Library.Demo title="size: 'lg' (4em)" withSource>
-              <Spinner size="lg" />
+            <Library.Info>
+              <Library.InfoItem label="description">
+                Set relative size of the spinner.
+              </Library.InfoItem>
+              <Library.InfoItem label="type">
+                <code>{`'sm' | 'md' | 'lg' `}</code>
+              </Library.InfoItem>
+              <Library.InfoItem label="default">
+                <code>{`'md'`}</code>
+              </Library.InfoItem>
+            </Library.Info>
+            <Library.Demo title="Spinner sizes" withSource>
+              <div className="flex gap-x-8 items-center">
+                <Spinner size="sm" />
+                <Spinner size="md" />
+                <Spinner size="lg" />
+              </div>
             </Library.Demo>
           </Library.Example>
         </Library.Pattern>
@@ -72,15 +91,19 @@ export default function SpinnerPage() {
         title="SpinnerOverlay"
         intro={
           <p>
-            <code>SpinnerOverlay</code> is a simple component encapsulating a
-            design pattern for a full-page loading spinner.
+            <code>SpinnerOverlay</code> is a simple component that composes a
+            spinner with an{' '}
+            <Library.Link href="/layout-overlay">
+              <code>Overlay</code>
+            </Library.Link>
+            .
           </p>
         }
       >
         <Library.Pattern>
           <Library.Usage componentName="SpinnerOverlay" />
           <Library.Example>
-            <Library.Demo>
+            <Library.Demo title="Basic SpinnerOverlay">
               <Button onClick={toggleOverlayOpen}>Show overlay</Button>
               {overlayOpen && <SpinnerOverlay onClick={toggleOverlayOpen} />}
             </Library.Demo>
@@ -92,11 +115,20 @@ export default function SpinnerPage() {
           </Library.Example>
         </Library.Pattern>
 
-        <Library.Pattern title="Props">
-          <p>
-            <code>SpinnerOverlay</code> accepts all HTML attributes except{' '}
-            <code>className</code>.
-          </p>
+        <Library.Pattern title="Component API">
+          <Library.Example title="...htmlAttributes">
+            <Library.Info>
+              <Library.InfoItem label="description">
+                HTML attributes applied to the outermost full-screen element.
+              </Library.InfoItem>
+
+              <Library.InfoItem label="type">
+                <code>
+                  {`Omit<JSX.HTMLAttributes<HTMLElement>,'className' | 'open'>`}
+                </code>
+              </Library.InfoItem>
+            </Library.Info>
+          </Library.Example>
         </Library.Pattern>
       </Library.Section>
     </Library.Page>


### PR DESCRIPTION
This large-diff housekeeping PR updates the section structure of the data and feedback group component documentation pages. This pass ensures that all component documentation pages use the same heading and section structure, removes a bit of outdated or unnecessary documentation, and standardizes API/props documentation.

This is in preparation for introducing section permalinks.

Part of #1030 
