### PR TITLE
Make Button components implement Styling API, deprecate `ButtonBase`

### DIFF
--- a/src/components/input/Button.tsx
+++ b/src/components/input/Button.tsx
@@ -95,9 +95,9 @@ const Button = function Button({
       {...ariaProps}
       {...htmlAttributes}
       className={classnames(
-        styled && {
+        {
           'focus-visible-ring transition-colors whitespace-nowrap flex items-center':
-            true,
+            styled,
         },
         themed && {
           'font-semibold rounded-sm': true,

--- a/src/components/input/ButtonBase.tsx
+++ b/src/components/input/ButtonBase.tsx
@@ -48,6 +48,8 @@ export type ButtonBaseProps = BaseProps &
 
 /**
  * Base component for Button components. Applies common attributes.
+ *
+ * @deprecated Use `Button` or `IconButton` with `unstyled` set instead
  */
 const ButtonBase = function ButtonBase({
   elementRef,

--- a/src/components/input/IconButton.tsx
+++ b/src/components/input/IconButton.tsx
@@ -2,30 +2,34 @@ import classnames from 'classnames';
 
 import type { IconComponent, PresentationalProps } from '../../types';
 import { downcastRef } from '../../util/typing';
-import ButtonBase from './ButtonBase';
-import type { ButtonCommonProps, HTMLButtonAttributes } from './ButtonBase';
+import type { ButtonProps } from './Button';
+import Button from './ButtonBase';
 import { inputGroupStyles } from './InputGroup';
 
 type ComponentProps = {
   icon?: IconComponent;
-  size?: 'xs' | 'sm' | 'md' | 'lg';
 
   /**
    * Disable minimum tap target sizing for touch devices. This may be necessary
    * in legacy patterns where there isn't enough room in the interface for these
    * larger dimensions.
+   *
+   * @deprecated Set `size` to `'custom'` instead
    */
   disableTouchSizing?: boolean;
-  variant?: 'primary' | 'secondary' | 'dark';
 
   /** Required for `IconButton` as there is no text label */
   title: string;
+
+  // Styling API
+  size?: 'xs' | 'sm' | 'md' | 'lg' | 'custom';
+  unstyled?: boolean;
+  variant?: 'primary' | 'secondary' | 'dark' | 'custom';
 };
 
 export type IconButtonProps = PresentationalProps &
-  ButtonCommonProps &
-  ComponentProps &
-  HTMLButtonAttributes;
+  Omit<ButtonProps, 'title' | 'size' | 'variant'> &
+  ComponentProps;
 
 /**
  * Render a button that only contains an icon.
@@ -43,17 +47,28 @@ const IconButton = function IconButton({
   size = 'md',
   title,
   variant = 'secondary',
+  unstyled = false,
 
   ...htmlAttributes
 }: IconButtonProps) {
+  const styled = !unstyled;
+  const themed = styled && variant !== 'custom';
+  const sized = styled && size !== 'custom';
+
   return (
-    <ButtonBase
+    <Button
       data-component="IconButton"
       {...htmlAttributes}
       classes={classnames(
-        'focus-visible-ring transition-colors whitespace-nowrap flex items-center',
-        'justify-center gap-x-2 rounded-sm',
-        {
+        styled && {
+          'focus-visible-ring transition-colors rounded-sm whitespace-nowrap':
+            true,
+          'flex items-center justify-center': true,
+          // Adapt styling when in an InputGroup
+        },
+        // Adapt styles when in an InputGroup
+        styled && inputGroupStyles,
+        themed && {
           // variant
           'text-grey-7 bg-transparent enabled:hover:text-grey-9 aria-pressed:text-brand aria-expanded:text-brand':
             variant === 'secondary', //default
@@ -61,19 +76,17 @@ const IconButton = function IconButton({
             variant === 'primary',
           'text-grey-7 bg-grey-2 enabled:hover:text-grey-9 enabled:hover:bg-grey-3 disabled:text-grey-5 aria-pressed:bg-grey-3 aria-expanded:bg-grey-3':
             variant === 'dark',
-
-          // size
+        },
+        sized && {
+          'gap-x-2': true,
           'p-2': size === 'md', // Default
           'p-1': size === 'xs',
           'p-1.5': size === 'sm',
           'p-2.5': size === 'lg',
 
-          // Responsive
           'touch:min-w-touch-minimum touch:min-h-touch-minimum':
             !disableTouchSizing,
         },
-        // Adapt styling when this component is inside an InputGroup
-        inputGroupStyles,
         classes
       )}
       elementRef={downcastRef(elementRef)}
@@ -84,7 +97,7 @@ const IconButton = function IconButton({
     >
       {Icon && <Icon className="w-em h-em" />}
       {children}
-    </ButtonBase>
+    </Button>
   );
 };
 

--- a/src/components/input/IconButton.tsx
+++ b/src/components/input/IconButton.tsx
@@ -60,11 +60,10 @@ const IconButton = function IconButton({
       data-component="IconButton"
       {...htmlAttributes}
       classes={classnames(
-        styled && {
+        {
           'focus-visible-ring transition-colors rounded-sm whitespace-nowrap':
-            true,
-          'flex items-center justify-center': true,
-          // Adapt styling when in an InputGroup
+            styled,
+          'flex items-center justify-center': styled,
         },
         // Adapt styles when in an InputGroup
         styled && inputGroupStyles,

--- a/src/components/input/test/Button-test.js
+++ b/src/components/input/test/Button-test.js
@@ -1,7 +1,10 @@
 import { mount } from 'enzyme';
 
 import { CancelIcon } from '../../icons';
-import { testPresentationalComponent } from '../../test/common-tests';
+import {
+  testPresentationalComponent,
+  testStyledComponent,
+} from '../../test/common-tests';
 import Button from '../Button';
 
 describe('Button', () => {
@@ -12,6 +15,7 @@ describe('Button', () => {
   };
 
   testPresentationalComponent(Button);
+  testStyledComponent(Button);
 
   it('renders proportionally-sized icon', () => {
     const wrapper = createComponent({ icon: CancelIcon });

--- a/src/components/input/test/Button-test.js
+++ b/src/components/input/test/Button-test.js
@@ -25,4 +25,44 @@ describe('Button', () => {
     assert.isTrue(icon.hasClass('h-em'));
     assert.isTrue(icon.hasClass('w-em'));
   });
+
+  it('applies role="button" by default', () => {
+    const wrapper = createComponent();
+    const outerEl = wrapper.find('button').getDOMNode();
+
+    assert.isTrue(outerEl.hasAttribute('role'));
+    assert.equal(outerEl.getAttribute('role'), 'button');
+  });
+
+  it('applies appropriate ARIA attributes for button state', () => {
+    const pressed = createComponent({ pressed: true });
+    const expanded = createComponent({ expanded: true });
+
+    assert.equal(
+      pressed.find('button').getDOMNode().getAttribute('aria-pressed'),
+      'true'
+    );
+    assert.equal(
+      expanded.find('button').getDOMNode().getAttribute('aria-expanded'),
+      'true'
+    );
+  });
+
+  it('sets appropriate ARIA attributes for tabs', () => {
+    const wrapper = createComponent({ role: 'tab' });
+
+    assert.equal(
+      wrapper.find('button').getDOMNode().getAttribute('role'),
+      'tab'
+    );
+  });
+
+  it('sets aria-label attribute', () => {
+    const wrapper = createComponent({ title: 'Click me' });
+
+    assert.equal(
+      wrapper.find('button').getDOMNode().getAttribute('aria-label'),
+      'Click me'
+    );
+  });
 });

--- a/src/components/input/test/IconButton-test.js
+++ b/src/components/input/test/IconButton-test.js
@@ -1,7 +1,10 @@
 import { mount } from 'enzyme';
 
 import { CancelIcon } from '../../icons';
-import { testPresentationalComponent } from '../../test/common-tests';
+import {
+  testPresentationalComponent,
+  testStyledComponent,
+} from '../../test/common-tests';
 import IconButton from '../IconButton';
 
 describe('IconButton', () => {
@@ -10,6 +13,7 @@ describe('IconButton', () => {
   };
 
   testPresentationalComponent(IconButton, { componentName: 'IconButton' });
+  testStyledComponent(IconButton);
 
   it('renders proportionally-sized icon', () => {
     const wrapper = createComponent({ icon: CancelIcon });

--- a/src/components/navigation/test/Link-test.js
+++ b/src/components/navigation/test/Link-test.js
@@ -1,40 +1,10 @@
-import { mount } from 'enzyme';
-
-import { testPresentationalComponent } from '../../test/common-tests';
+import {
+  testPresentationalComponent,
+  testStyledComponent,
+} from '../../test/common-tests';
 import Link from '../Link';
 
 describe('Link', () => {
-  const createComponent = (props = {}) => {
-    return mount(
-      <Link href="http://www.example.com" {...props}>
-        This is content inside of a Link
-      </Link>
-    );
-  };
-
   testPresentationalComponent(Link, { componentName: 'Link' });
-
-  // TODO: Extract tests to common-tests and enhance as more components add
-  // support for the styling API
-  function getStyles(wrapper) {
-    return wrapper.find('a').prop('className');
-  }
-
-  it('applies component styles', () => {
-    const withStyles = createComponent();
-    assert.isNotEmpty(getStyles(withStyles));
-  });
-
-  it('does not apply any styles if `unstyled` is set', () => {
-    const noStyles = createComponent({ unstyled: true });
-    assert.isEmpty(getStyles(noStyles));
-  });
-
-  it('does not apply theming styles if variant is set to `custom`', () => {
-    const withStyles = createComponent();
-    const noThemeStyles = createComponent({ variant: 'custom' });
-    assert.isTrue(
-      getStyles(withStyles).length > getStyles(noThemeStyles).length
-    );
-  });
+  testStyledComponent(Link, { supportedProps: ['variant', 'unstyled'] });
 });

--- a/src/components/test/common-tests.js
+++ b/src/components/test/common-tests.js
@@ -103,6 +103,75 @@ export function testCompositeComponent(
 }
 
 /**
+ * @typedef StyledTestOpts
+ * @prop  {Array<'size'|'unstyled'|'variant'>} supportedProps Which styling
+ *   props are supported
+ */
+/**
+ * Set of tests common to all components that support the Styling API
+ *
+ * @param {import('preact').FunctionComponent} Component
+ * @param {CommonTestOpts & StyledTestOpts} opts
+ */
+export function testStyledComponent(
+  Component,
+  {
+    componentName,
+    createContent = createComponent,
+    elementSelector,
+    supportedProps = ['size', 'unstyled', 'variant'],
+  } = {}
+) {
+  const displayName = componentName ?? Component.displayName ?? Component.name;
+
+  describe(`Common styling API functionality for ${displayName}`, () => {
+    it('applies classes to primary element', () => {
+      const wrapper = createContent(Component);
+      const primaryEl = primaryElement(wrapper, elementSelector);
+
+      assert.isNotEmpty(primaryEl.classList);
+    });
+
+    if (supportedProps.includes('unstyled')) {
+      // It may be necessary to accept exceptions (classes that are always set,
+      // even when unstyled) as another test option in the future
+      it('does not apply any styles when `unstyled` is set', () => {
+        const wrapper = createContent(Component, { unstyled: true });
+        const primaryEl = primaryElement(wrapper, elementSelector);
+
+        assert.isEmpty(primaryEl.classList);
+      });
+    }
+
+    if (supportedProps.includes('variant')) {
+      // It may be necessary to accept exceptions (classes that are always set,
+      // even when unstyled) as another test option in the future
+      it('does not apply theming styles when variant is `custom`', () => {
+        const styled = createContent(Component);
+        const unStyled = createContent(Component, { variant: 'custom' });
+        assert.isTrue(
+          primaryElement(styled, elementSelector).classList.length >
+            primaryElement(unStyled, elementSelector).classList.length
+        );
+      });
+    }
+
+    if (supportedProps.includes('size')) {
+      // It may be necessary to accept exceptions (classes that are always set,
+      // even when unstyled) as another test option in the future
+      it('does not apply size styles when variant is `custom`', () => {
+        const styled = createContent(Component);
+        const unStyled = createContent(Component, { size: 'custom' });
+        assert.isTrue(
+          primaryElement(styled, elementSelector).classList.length >
+            primaryElement(unStyled, elementSelector).classList.length
+        );
+      });
+    }
+  });
+}
+
+/**
  * Set of tests common to all presentational components
  *
  * @param {import('preact').FunctionComponent} Component

--- a/src/pattern-library/components/patterns/input/ButtonPage.tsx
+++ b/src/pattern-library/components/patterns/input/ButtonPage.tsx
@@ -526,12 +526,15 @@ export default function ButtonPage() {
         intro={
           <>
             <p>
-              <code>ButtonBase</code> is a base presentational component that
-              allows style customization of buttons.
+              <Library.StatusChip status="deprecated" /> Use the styling API of{' '}
+              <code>Button</code> or <code>IconButton</code> for customized
+              styling instead.
             </p>
             <p>
-              <code>ButtonBase</code> applies minimal common styling. Turn off
-              all styling by setting the <code>unstyled</code> prop.
+              <code>ButtonBase</code> is a base presentational component that
+              allows style customization of buttons. <code>ButtonBase</code>{' '}
+              applies minimal common styling. Turn off all styling by setting
+              the <code>unstyled</code> prop.
             </p>
           </>
         }
@@ -539,49 +542,18 @@ export default function ButtonPage() {
         <Library.Pattern>
           <Library.Usage componentName="ButtonBase" />
 
-          <Library.Example>
-            <p>
-              <code>ButtonBase</code> applies color transition and layout basic
-              styling, but no colors, padding, hover or state styling.
-            </p>
-            <p>
-              This example shows a <code>ButtonBase</code> with some additional{' '}
-              <code>classes</code>. These <code>classes</code> are appended to
-              the {"component's"} base styling classes.
-            </p>
-
-            <Library.Demo
-              title="ButtonBase with some additional styles"
-              withSource
+          <Library.Demo
+            title="ButtonBase with some additional styles"
+            withSource
+          >
+            <ButtonBase
+              classes="border bg-grey-0 hover:bg-grey-1"
+              onClick={() => alert('You clicked the button')}
             >
-              <ButtonBase
-                classes="border bg-grey-0 hover:bg-grey-1"
-                onClick={() => alert('You clicked the button')}
-              >
-                <CheckIcon />
-                Click me
-              </ButtonBase>
-            </Library.Demo>
-          </Library.Example>
-        </Library.Pattern>
-        <Library.Pattern title="Props">
-          <Library.Example title="unstyled">
-            <p>
-              Set <code>unstyled</code> to style your button from scratch. This
-              example shows an unstyled <code>ButtonBase</code> with the same{' '}
-              <code>classes</code> as above. <em>Only</em> the classes in{' '}
-              <code>classes</code> are applied.
-            </p>
-            <Library.Demo title="ButtonBase unstyled" withSource>
-              <ButtonBase
-                classes="border bg-grey-0 hover:bg-grey-1"
-                onClick={() => alert('You clicked the button')}
-                unstyled
-              >
-                <CheckIcon /> Click me
-              </ButtonBase>
-            </Library.Demo>
-          </Library.Example>
+              <CheckIcon />
+              Click me
+            </ButtonBase>
+          </Library.Demo>
         </Library.Pattern>
       </Library.Section>
     </Library.Page>

--- a/src/pattern-library/components/patterns/input/ButtonPage.tsx
+++ b/src/pattern-library/components/patterns/input/ButtonPage.tsx
@@ -242,7 +242,7 @@ export default function ButtonPage() {
         title="IconButton"
         intro={
           <p>
-            <code>IconButton</code> is for buttons that contain only an icon.
+            <code>IconButton</code> is for icon-only <code>Button</code>s.
           </p>
         }
       >
@@ -259,27 +259,12 @@ export default function ButtonPage() {
           </Library.Example>
         </Library.Pattern>
 
-        <Library.Pattern title="Props">
-          <Library.Example title="icon">
-            <p>
-              The <code>IconButton</code>
-              {"'s"} <code>icon</code> prop accepts an icon component and will
-              render it sized proportionally to the local font size.
-            </p>
-            <Library.Demo withSource>
-              <span className="text-xl">
-                <IconButton icon={ShareIcon} title="Share" />
-              </span>
-              <IconButton icon={ShareIcon} title="Share" />
-              <span className="text-xs">
-                <IconButton icon={ShareIcon} title="Share" />
-              </span>
-            </Library.Demo>
-          </Library.Example>
-          <Library.Example title="icon: customizing styles">
+        <Library.Pattern title="Working with IconButtons">
+          <Library.Example title="Styling the icon">
             <p>
               If you need more control over icon styles, use an icon component
-              directly in the content instead.
+              directly in the content instead of passing an <code>icon</code>{' '}
+              prop.
             </p>
             <Library.Demo withSource>
               <IconButton title="Share">
@@ -290,17 +275,92 @@ export default function ButtonPage() {
               </IconButton>
             </Library.Demo>
           </Library.Example>
+        </Library.Pattern>
+
+        <Library.Pattern title="Component API">
+          <Library.Example title="title">
+            <Library.Info>
+              <Library.InfoItem label="description">
+                A <code>title</code> is required for <code>IconButton</code>s.
+              </Library.InfoItem>
+              <Library.InfoItem label="type">
+                <code>string</code>
+              </Library.InfoItem>
+              <Library.InfoItem label="required">
+                <code>true</code>
+              </Library.InfoItem>
+            </Library.Info>
+          </Library.Example>
+
+          <Library.Example title="disableTouchSizing">
+            <Library.Info>
+              <Library.InfoItem label="status">
+                <Library.StatusChip status="deprecated" /> Set <code>size</code>{' '}
+                to <code>{`'custom'`}</code> and set sizing classes manually
+                instead.
+              </Library.InfoItem>
+              <Library.InfoItem label="description">
+                Disable minimum sizing on touch devices (
+                <code>pointer: coarse</code>). Buttons will be at least 44px in
+                each dimension on these devices by default.
+              </Library.InfoItem>
+              <Library.InfoItem label="type">
+                <code>boolean</code>
+              </Library.InfoItem>
+              <Library.InfoItem label="default">
+                <code>false</code>
+              </Library.InfoItem>
+            </Library.Info>
+          </Library.Example>
+
+          <Library.Example title="...buttonProps">
+            <code>IconButton</code> accepts and forwards all props from the{' '}
+            <code>Button</code> component API.
+          </Library.Example>
+
+          <Library.Example title="...htmlAttributes">
+            <Library.Info>
+              <Library.InfoItem label="description">
+                <code>IconButton</code> accepts HTML attribute props applicable
+                to <code>HTMLButtonElement</code>.
+              </Library.InfoItem>
+              <Library.InfoItem label="type">
+                <code>{`Omit<preact.JSX.HTMLAttributes<HTMLButtonElement>, 'icon' | 'size'>`}</code>
+              </Library.InfoItem>
+            </Library.Info>
+          </Library.Example>
+        </Library.Pattern>
+
+        <Library.Pattern title="Styling API">
+          <p>
+            <code>IconButton</code> accepts the following props from the{' '}
+            <Library.Link href="/using-components#presentational-components-styling-api">
+              presentational component styling API
+            </Library.Link>
+            .
+          </p>
           <Library.Example title="variant">
-            <p>
-              These examples show each variant in each of the supported states.
-              These states are associated with the <code>pressed</code>,{' '}
-              <code>expanded</code> and <code>disabled</code> boolean props.
-            </p>
+            <Library.Info>
+              <Library.InfoItem label="description">
+                Set a defined theme on the button. Set to {`'custom'`} to
+                disable theming and provide your own theming with{' '}
+                <code>classes</code>.
+              </Library.InfoItem>
+              <Library.InfoItem label="type">
+                <code>{`'primary' | 'secondary' | 'dark' | 'custom'`}</code>
+              </Library.InfoItem>
+              <Library.InfoItem label="default">
+                <code>{`'secondary'`}</code>
+              </Library.InfoItem>
+            </Library.Info>
 
             <p>
-              For customization, use <code>ButtonBase</code>.
+              The following examples show themed <code>IconButton</code>s in
+              default state, <code>pressed</code>, <code>expanded</code> and{' '}
+              <code>disabled</code>.
             </p>
-            <Library.Demo title="variant: 'secondary' (default)" withSource>
+
+            <Library.Demo title="variant: 'secondary'" withSource>
               <IconButton
                 variant="secondary"
                 title="Watch out!"
@@ -380,32 +440,83 @@ export default function ButtonPage() {
                 disabled
               />
             </Library.Demo>
+
+            <Library.Demo
+              title="variant: 'custom' with custom theming"
+              withSource
+            >
+              <IconButton
+                classes="border rounded text-slate-600"
+                variant="custom"
+                title="Watch out!"
+                icon={CautionIcon}
+              />
+              <IconButton
+                classes="border rounded text-slate-800 bg-stone-100 border-slate-400"
+                variant="custom"
+                title="Watch out!"
+                icon={CautionIcon}
+                pressed
+              />
+              <IconButton
+                variant="custom"
+                classes="border rounded text-slate-800 bg-stone-100 border-slate-400"
+                title="Watch out!"
+                icon={CautionIcon}
+                expanded
+              />
+              <IconButton
+                classes="border rounded text-slate-400"
+                variant="custom"
+                title="Watch out!"
+                icon={CautionIcon}
+                disabled
+              />
+            </Library.Demo>
           </Library.Example>
+
           <Library.Example title="size">
-            <p>
-              The <code>size</code> prop affects padding and spacing within the{' '}
-              <code>IconButton</code>.
-            </p>
-            <Library.Demo title="size: 'xs', 'sm', 'md' and 'lg'" withSource>
+            <Library.Info>
+              <Library.InfoItem label="description">
+                Set relative internal sizing. Set to {`'custom'`} to disable
+                sizing classes and set your own with <code>classes</code>.
+              </Library.InfoItem>
+              <Library.InfoItem label="type">
+                <code>{`'xs' | 'sm' | 'md' | 'lg' | 'custom'`}</code>
+              </Library.InfoItem>
+              <Library.InfoItem label="default">
+                <code>{`'md'`}</code>
+              </Library.InfoItem>
+            </Library.Info>
+            <Library.Demo
+              title="size: 'xs', 'sm', 'md', 'lg' and 'custom'"
+              withSource
+            >
               <IconButton icon={EditIcon} size="xs" title="Edit" />
               <IconButton icon={EditIcon} size="sm" title="Edit" />
               <IconButton icon={EditIcon} size="md" title="Edit" />
               <IconButton icon={EditIcon} size="lg" title="Edit" />
+              <IconButton
+                icon={EditIcon}
+                size="custom"
+                title="Edit"
+                classes="p-3"
+              />
             </Library.Demo>
           </Library.Example>
-
-          <Library.Example title="disableTouchSizing">
-            <p>
-              By default, <code>IconButton</code> will apply styles for touch
-              devices (<code>pointer: coarse</code>) to ensure the minimum
-              dimensions are equal or greater to our defined touch-target
-              minimums (44×44px). In some cases that is undesirable. Disable
-              with the <code>disableTouchSizing</code> boolean prop.
-            </p>
-
-            <Library.Demo title="Disabling touch-target sizing" withSource>
-              <IconButton icon={EditIcon} title="Edit" disableTouchSizing />
-            </Library.Demo>
+          <Library.Example title="unstyled">
+            <Library.Info>
+              <Library.InfoItem label="description">
+                Set this to disable all styling and provide your own styling
+                with <code>classes</code>.
+              </Library.InfoItem>
+              <Library.InfoItem label="type">
+                <code>boolean</code>
+              </Library.InfoItem>
+              <Library.InfoItem label="default">
+                <code>false</code>
+              </Library.InfoItem>
+            </Library.Info>
           </Library.Example>
         </Library.Pattern>
       </Library.Section>

--- a/src/pattern-library/components/patterns/input/ButtonPage.tsx
+++ b/src/pattern-library/components/patterns/input/ButtonPage.tsx
@@ -20,56 +20,109 @@ export default function ButtonPage() {
         </p>
       }
     >
-      <Library.Section
-        title="Button"
-        intro={
-          <p>
-            The <code>Button</code> component can be used for buttons with
-            textual labels and, optionally, an icon.
-          </p>
-        }
-      >
+      <Library.Section title="Button">
         <Library.Pattern>
           <Library.Usage componentName="Button" />
           <Library.Example>
             <Library.Demo title="Basic Button" withSource>
-              <Button onClick={() => alert('You clicked the button')}>
+              <Button
+                icon={CheckIcon}
+                onClick={() => alert('You clicked the button')}
+              >
                 Click me
               </Button>
             </Library.Demo>
           </Library.Example>
         </Library.Pattern>
 
-        <Library.Pattern title="Props">
-          <Library.Example title="icon">
-            <p>
-              The <code>Button</code>
-              {"'s"} <code>icon</code> prop accepts an icon component and will
-              render it to the left of content, sized proportionally to the
-              local font size.
-            </p>
-            <Library.Demo
-              title="Icons are sized proportionally to button label content"
-              withSource
-            >
-              <span className="text-xl">
-                <Button icon={CancelIcon}>Cancel</Button>
-              </span>
-              <Button icon={CancelIcon}>Cancel</Button>
-              <span className="text-xs">
-                <Button icon={CancelIcon}>Cancel</Button>
-              </span>
-            </Library.Demo>
+        <Library.Pattern title="Component API">
+          <code>Button</code> accepts all standard{' '}
+          <Library.Link href="/using-components#presentational-components-api">
+            presentational component props
+          </Library.Link>
+          .
+          <Library.Example title="expanded">
+            <Library.Info>
+              <Library.InfoItem label="description">
+                This {"button's"} associated content is expanded.
+              </Library.InfoItem>
+              <Library.InfoItem label="type">
+                <code>boolean</code>
+              </Library.InfoItem>
+              <Library.InfoItem label="default">
+                <code>false</code>
+              </Library.InfoItem>
+            </Library.Info>
           </Library.Example>
+          <Library.Example title="icon">
+            <Library.Info>
+              <Library.InfoItem label="description">
+                An SVG icon to display to the left of the {"button's"} content.
+              </Library.InfoItem>
+              <Library.InfoItem label="type">
+                <code>IconComponent</code>
+              </Library.InfoItem>
+            </Library.Info>
+          </Library.Example>
+          <Library.Example title="pressed">
+            <Library.Info>
+              <Library.InfoItem label="description">
+                This button is active
+              </Library.InfoItem>
+              <Library.InfoItem label="type">
+                <code>boolean</code>
+              </Library.InfoItem>
+              <Library.InfoItem label="default">
+                <code>false</code>
+              </Library.InfoItem>
+            </Library.Info>
+          </Library.Example>
+          <Library.Example title="title">
+            <Library.Info>
+              <Library.InfoItem label="description">
+                Used to set an <code>aria-label</code> attribute
+              </Library.InfoItem>
+              <Library.InfoItem label="type">
+                <code>string</code>
+              </Library.InfoItem>
+            </Library.Info>
+          </Library.Example>
+          <Library.Example title="...htmlAttributes">
+            <Library.Info>
+              <Library.InfoItem label="description">
+                <code>Button</code> accepts HTML attribute props applicable to{' '}
+                <code>HTMLButtonElement</code>.
+              </Library.InfoItem>
+              <Library.InfoItem label="type">
+                <code>{`Omit<preact.JSX.HTMLAttributes<HTMLButtonElement>, 'icon' | 'size'>`}</code>
+              </Library.InfoItem>
+            </Library.Info>
+          </Library.Example>
+        </Library.Pattern>
 
+        <Library.Pattern title="Styling API">
+          <p>
+            <code>Button</code> accepts the following props from the{' '}
+            <Library.Link href="/using-components#presentational-components-styling-api">
+              presentational component styling API
+            </Library.Link>
+            .
+          </p>
           <Library.Example title="variant">
-            <p>
-              These examples show each variant in each of the supported states,
-              as well as an example with an icon. These states are associated
-              with the <code>pressed</code>, <code>expanded</code> and{' '}
-              <code>disabled</code> boolean props.
-            </p>
-            <Library.Demo title="variant: 'secondary' (default)" withSource>
+            <Library.Info>
+              <Library.InfoItem label="description">
+                Set a defined theme on the button. Set to {`'custom'`} to
+                disable theming and provide your own theming with{' '}
+                <code>classes</code>.
+              </Library.InfoItem>
+              <Library.InfoItem label="type">
+                <code>{`'primary' | 'secondary' | 'custom'`}</code>
+              </Library.InfoItem>
+              <Library.InfoItem label="default">
+                <code>{`'secondary'`}</code>
+              </Library.InfoItem>
+            </Library.Info>
+            <Library.Demo title="variant: 'secondary'" withSource>
               <Button variant="secondary">Default</Button>
               <Button variant="secondary">
                 <CancelIcon />
@@ -102,25 +155,83 @@ export default function ButtonPage() {
                 Disabled
               </Button>
             </Library.Demo>
+
+            <Library.Demo title="variant: 'custom' (custom theming)" withSource>
+              <Button variant="custom" classes="border rounded">
+                Default
+              </Button>
+              <Button variant="custom" classes="border rounded">
+                <EditIcon />
+                Default
+              </Button>
+              <Button variant="custom" pressed classes="border rounded">
+                Pressed
+              </Button>
+              <Button variant="custom" expanded classes="border rounded">
+                Expanded
+              </Button>
+              <Button variant="custom" disabled classes="border rounded">
+                Disabled
+              </Button>
+            </Library.Demo>
           </Library.Example>
-          <Library.Example title="size: 'xs', 'sm', 'md' (default), 'lg'">
-            <p>
-              The <code>size</code> prop affects padding and spacing within the{' '}
-              <code>Button</code>, but other sizing (e.g. font size) is
-              inherited.
-            </p>
-            <Library.Demo withSource>
+
+          <Library.Example title="size">
+            <Library.Info>
+              <Library.InfoItem label="description">
+                Set the relative internal sizing of the button. Set to{' '}
+                {`'custom'`} to disable sizing classes and set your own with{' '}
+                <code>classes</code>.
+              </Library.InfoItem>
+              <Library.InfoItem label="type">
+                <code>{`'xs' | 'sm' | 'md' | 'lg' | 'custom'`}</code>
+              </Library.InfoItem>
+              <Library.InfoItem label="default">
+                <code>{`'md'`}</code>
+              </Library.InfoItem>
+            </Library.Info>
+            <Library.Demo title="Button sizes" withSource>
               <Button icon={EditIcon} size="xs">
-                X-Small (xs)
+                (xs)
               </Button>
               <Button icon={EditIcon} size="sm">
-                Small (sm)
+                (sm)
               </Button>
               <Button icon={ReplyIcon} size="md">
-                Medium (md, default)
+                (md)
               </Button>
               <Button icon={CheckIcon} size="lg">
-                Large (lg)
+                (lg)
+              </Button>
+              <Button icon={CheckIcon} size="custom" classes="p-2 gap-x-3">
+                (custom)
+              </Button>
+            </Library.Demo>
+          </Library.Example>
+
+          <Library.Example title="unstyled">
+            <Library.Info>
+              <Library.InfoItem label="description">
+                Set this to disable all styling and provide your own styling
+                with <code>classes</code>.
+              </Library.InfoItem>
+              <Library.InfoItem label="type">
+                <code>boolean</code>
+              </Library.InfoItem>
+              <Library.InfoItem label="default">
+                <code>false</code>
+              </Library.InfoItem>
+            </Library.Info>
+
+            <Library.Demo
+              title="unstyled Button with custom styling"
+              withSource
+            >
+              <Button
+                unstyled
+                classes="border rounded p-2 bg-stone-100 font-normal color-slate-600 hover:bg-stone-50 hover:color-slate-700 hover:shadow-lg"
+              >
+                Custom button
               </Button>
             </Library.Demo>
           </Library.Example>


### PR DESCRIPTION
This PR:

* Updates `Button` and `IconButton` to implement the styling API: `size`, `unstyled` and `variant`
* Extracts common styling-API basic tests to `common-tests` for reuse
* Deprecates `ButtonBase`
* Updates the heck out of Button* documentation in the pattern library

Previously, `IconButton` and `Button` both wrapped `ButtonBase`. Now, `IconButton` wraps `Button`. The integration of styling API props obviates the need for `ButtonBase`.

These are all additive changes.

As usual with these PR diffs, the bulk is the documentation changes.

### Checking it out

I recommend reviewing the documentation and examples on the [Button pattern library page](http://localhost:4001/input-button)

Fixes https://github.com/hypothesis/frontend-shared/issues/676
Part of #1030 
