### PR TITLE
Extract and polish select LMS content button design

### DIFF
--- a/src/pattern-library/components/patterns/prototype/LMSContentButtonPage.tsx
+++ b/src/pattern-library/components/patterns/prototype/LMSContentButtonPage.tsx
@@ -1,0 +1,198 @@
+import classnames from 'classnames';
+import type { ComponentChildren } from 'preact';
+
+import { Button, Card, CardHeader, CardContent, CheckIcon } from '../../../../';
+import type { ButtonProps } from '../../../../';
+import Library from '../../Library';
+
+type ContentButtonProps = { contentType: string } & ButtonProps;
+
+function ContentButton({
+  children,
+  classes,
+  contentType = 'pdf',
+  pressed,
+  ...buttonProps
+}: ContentButtonProps) {
+  return (
+    <Button
+      classes={classnames(
+        'w-full rounded-sm gap-x-2 px-2 py-1',
+        'border border-stone-300 bg-stone-50',
+        'group',
+        'enabled:hover:border-slate-5 enabled:hover:bg-slate-0',
+        'disabled:border-stone-200',
+        'aria-pressed:border-slate-5 aria-pressed:bg-slate-0 aria-pressed:shadow-inner',
+        'aria-expanded:border-slate-5 aria-expanded:bg-slate-0 aria-expanded:shadow-inner',
+        classes
+      )}
+      size="custom"
+      variant="custom"
+      pressed={pressed}
+      {...buttonProps}
+    >
+      <div className="grow flex items-center gap-x-1 text-start">
+        {pressed && (
+          <div className="rounded-full bg-slate-600 p-0.5">
+            <CheckIcon className="w-[0.6em] h-[0.6em] text-white" />
+          </div>
+        )}
+        <div className="text-slate-600 font-semibold group-disabled:text-stone-400">
+          {children}
+        </div>
+      </div>
+      <div className="text-end">
+        <span
+          className={classnames(
+            'uppercase text-[0.8em] text-stone-500',
+            'group-enabled:group-hover:text-stone-600',
+            'group-disabled:text-stone-400',
+            'group-aria-pressed:text-slate-600 group-aria-expanded:text-slate-600'
+          )}
+        >
+          {contentType}
+        </span>
+      </div>
+    </Button>
+  );
+}
+
+/**
+ * A relatively simplified layout representation of the LMS content-selection
+ * panel
+ */
+function ContentPanel({ children }: { children: ComponentChildren }) {
+  return (
+    <Card classes="text-[14px]">
+      <CardHeader variant="secondary" title="Assignment details" />
+      <CardContent size="lg">
+        <div className="grid grid-cols-[11rem_1fr] gap-x-6">
+          <div className="space-y-1.5 pt-1 leading-none">
+            <div className="text-end font-medium text-slate-600 uppercase">
+              Assignment content
+            </div>
+            <div className="text-end font-normal text-stone-500">
+              <p>Select content for your assignment</p>
+            </div>
+          </div>
+          <div>
+            <div className="grid grid-cols-2 gap-y-2 gap-x-3 max-w-[28rem]">
+              {children}
+            </div>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+export default function LMSContentButtonPage() {
+  return (
+    <Library.Page
+      title="LMS content selection buttons"
+      intro={
+        <p>
+          The proposed LMS <code>ContentButton</code> encapsulates a new button
+          design pattern for the assignment content-configuration screen in LMS.
+          It is based on a selected design approach in the{' '}
+          <Library.Link href="/lms-content-selection">
+            set of available sketches
+          </Library.Link>
+          .
+        </p>
+      }
+    >
+      <Library.Section>
+        <Library.Pattern title="Working with ContentButton">
+          <Library.Example title="Button states">
+            <Library.Demo title="ContentButton with hover styling">
+              <div className="bg-white p-8">
+                <div className="w-[16em] text-[14px]">
+                  <ContentButton contentType="PDF">Google Drive</ContentButton>
+                </div>
+              </div>
+            </Library.Demo>
+
+            <Library.Demo title="Pressed (active) ContentButton">
+              <div className="bg-white p-8">
+                <div className="w-[16em] text-[14px]">
+                  <ContentButton pressed contentType="PDF">
+                    Google Drive
+                  </ContentButton>
+                </div>
+              </div>
+            </Library.Demo>
+
+            <Library.Demo title="Disabled ContentButton">
+              <div className="bg-white p-8">
+                <div className="w-[16em] text-[14px]">
+                  <ContentButton disabled contentType="PDF">
+                    Google Drive
+                  </ContentButton>
+                </div>
+              </div>
+            </Library.Demo>
+          </Library.Example>
+
+          <Library.Example title="ContentButtons in context">
+            <Library.Demo>
+              <div className="w-[700px]">
+                <ContentPanel>
+                  <ContentButton contentType="Web Page | PDF">
+                    URL
+                  </ContentButton>
+                  <ContentButton contentType="PDF">Canvas</ContentButton>
+                  <ContentButton contentType="PDF">Google Drive</ContentButton>
+                  <ContentButton contentType="Article">JSTOR</ContentButton>
+                  <ContentButton contentType="PDF">OneDrive</ContentButton>
+                  <ContentButton contentType="Book">VitalSource</ContentButton>
+                  <ContentButton contentType="Video">YouTube</ContentButton>
+                </ContentPanel>
+              </div>
+            </Library.Demo>
+
+            <Library.Callout>
+              <em>NB:</em> There is currently no use of <code>disabled</code> or{' '}
+              <code>pressed</code> states in the LMS content-selection
+              interface. But the new button provides styling for those states.
+            </Library.Callout>
+
+            <Library.Demo title="With selected content, and one disabled content option">
+              <div className="w-[700px]">
+                <ContentPanel>
+                  <ContentButton contentType="Web Page | PDF">
+                    URL
+                  </ContentButton>
+                  <ContentButton contentType="PDF">Canvas</ContentButton>
+                  <ContentButton contentType="PDF" pressed>
+                    Google Drive
+                  </ContentButton>
+                  <ContentButton contentType="Article">JSTOR</ContentButton>
+                  <ContentButton contentType="PDF">OneDrive</ContentButton>
+                  <ContentButton contentType="Book">VitalSource</ContentButton>
+                  <ContentButton contentType="Video">YouTube</ContentButton>
+                </ContentPanel>
+              </div>
+            </Library.Demo>
+
+            <Library.Demo title="With different options, and one disabled option">
+              <div className="w-[700px]">
+                <ContentPanel>
+                  <ContentButton contentType="Web Page | PDF">
+                    URL
+                  </ContentButton>
+                  <ContentButton contentType="PDF">Canvas</ContentButton>
+                  <ContentButton contentType="PDF">Google Drive</ContentButton>
+                  <ContentButton contentType="PDF">OneDrive</ContentButton>
+                  <ContentButton contentType="Book" disabled>
+                    VitalSource
+                  </ContentButton>
+                </ContentPanel>
+              </div>
+            </Library.Demo>
+          </Library.Example>
+        </Library.Pattern>
+      </Library.Section>
+    </Library.Page>
+  );
+}

--- a/src/pattern-library/components/patterns/prototype/LMSContentSelectionPage.tsx
+++ b/src/pattern-library/components/patterns/prototype/LMSContentSelectionPage.tsx
@@ -4,7 +4,6 @@ import type { ComponentChildren } from 'preact';
 import {
   ArrowRightIcon,
   Button,
-  ButtonBase,
   Card,
   CardHeader,
   CardContent,
@@ -23,9 +22,13 @@ import Library from '../../Library';
 
 function Button1({ children }: { children: ComponentChildren }) {
   return (
-    <ButtonBase classes="bg-slate-0 p-2 rounded-sm border border-slate-3 gap-x-1">
+    <Button
+      classes="bg-slate-0 rounded-sm border border-slate-3 gap-x-1 p-2"
+      variant="custom"
+      size="custom"
+    >
       {children}
-    </ButtonBase>
+    </Button>
   );
 }
 
@@ -37,14 +40,18 @@ function Button2({
   contentType?: string;
 }) {
   return (
-    <ButtonBase classes="w-[15em] bg-slate-0 rounded-sm border border-slate-3 gap-x-2 items-center">
+    <Button
+      classes="w-[15em] bg-slate-0 rounded-sm border border-slate-3 gap-x-2 items-center"
+      variant="custom"
+      size="custom"
+    >
       <div className="grow text-start p-2">
         <strong>{children}</strong>
       </div>
       <div className="text-end p-2">
         <span className="uppercase text-[11px]">{contentType}</span>
       </div>
-    </ButtonBase>
+    </Button>
   );
 }
 
@@ -56,16 +63,20 @@ function Button3({
   contentType?: string;
 }) {
   return (
-    <ButtonBase classes="w-[15em] bg-stone-50 rounded-sm border border-stone-300 gap-x-2 items-center">
-      <div className="grow text-start p-2">
+    <Button
+      classes="w-[15em] rounded-sm gap-x-2 p-2 border border-stone-300 bg-stone-50"
+      size="custom"
+      variant="custom"
+    >
+      <div className="grow text-start">
         <strong className="text-slate-600">{children}</strong>
       </div>
-      <div className="text-end p-2">
-        <span className="uppercase text-[11px] text-stone-500">
+      <div className="text-end">
+        <span className="uppercase text-[0.8em] text-stone-500">
           {contentType}
         </span>
       </div>
-    </ButtonBase>
+    </Button>
   );
 }
 
@@ -77,7 +88,11 @@ function Button4({
   contentType?: string;
 }) {
   return (
-    <ButtonBase classes="w-full bg-stone-50 rounded-sm border border-stone-300 gap-x-2 items-center">
+    <Button
+      classes="w-full bg-stone-50 rounded-sm border border-stone-300 gap-x-2 items-center"
+      size="custom"
+      variant="custom"
+    >
       <div className="grow text-start p-2">
         <strong className="text-slate-600">{children}</strong>
       </div>
@@ -86,7 +101,7 @@ function Button4({
           {contentType}
         </span>
       </div>
-    </ButtonBase>
+    </Button>
   );
 }
 
@@ -101,7 +116,11 @@ function Button5({
 }) {
   const Icon = icon ?? FilePdfFilledIcon;
   return (
-    <ButtonBase classes="w-full bg-stone-50 hover:bg-stone-100 rounded border border-stone-300 hover:border-stone-400 items-center">
+    <Button
+      classes="w-full bg-stone-50 hover:bg-stone-100 rounded border border-stone-300 hover:border-stone-400 items-center"
+      size="custom"
+      variant="custom"
+    >
       <div className="p-1.5 bg-stone-200 rounded-l">
         <Icon className="text-stone-500" />
       </div>
@@ -113,7 +132,7 @@ function Button5({
           {contentType}
         </span>
       </div>
-    </ButtonBase>
+    </Button>
   );
 }
 
@@ -130,13 +149,15 @@ function Button6({
 }) {
   const Icon = icon ?? FilePdfIcon;
   return (
-    <ButtonBase
+    <Button
       classes={classnames(
         'group bg-stone-50 hover:bg-slate-100 shadow hover:shadow-lg rounded border border-stone-300 hover:border-stone-400 justify-center',
         {
           'shadow-inner': selected,
         }
       )}
+      size="custom"
+      variant="custom"
     >
       <div className="flex flex-col items-center w-full gap-y-2 pt-2">
         <Icon
@@ -170,7 +191,7 @@ function Button6({
           </span>
         </div>
       </div>
-    </ButtonBase>
+    </Button>
   );
 }
 

--- a/src/pattern-library/routes.ts
+++ b/src/pattern-library/routes.ts
@@ -26,6 +26,7 @@ import LinkButtonPage from './components/patterns/navigation/LinkButtonPage';
 import LinkPage from './components/patterns/navigation/LinkPage';
 import PointerButtonPage from './components/patterns/navigation/PointerButtonPage';
 import TabPage from './components/patterns/navigation/TabPage';
+import LMSContentButtonPage from './components/patterns/prototype/LMSContentButtonPage';
 import LMSContentSelectionPage from './components/patterns/prototype/LMSContentSelectionPage';
 import SharedAnnotationsPage from './components/patterns/prototype/SharedAnnotationsPage';
 import SliderPage from './components/patterns/transition/SliderPage';
@@ -226,13 +227,19 @@ const routes: PlaygroundRoute[] = [
     route: '/transitions-slider',
   },
   {
-    title: 'Shared Annotations',
+    title: 'LMS: Content Button',
+    group: 'prototype',
+    component: LMSContentButtonPage,
+    route: '/lms-content-button',
+  },
+  {
+    title: 'Sketches: Shared Annotations',
     group: 'prototype',
     component: SharedAnnotationsPage,
     route: '/shared-annotations-ui',
   },
   {
-    title: 'LMS Content Selection',
+    title: 'Sketches: Content selection',
     group: 'prototype',
     component: LMSContentSelectionPage,
     route: '/lms-content-selection',


### PR DESCRIPTION
This PR adds a [new pattern-library page](http://localhost:4001/lms-content-button) that extracts a button component per the selected design approach for LMS content-selection buttons.

We can merge this and deploy the pattern library to get feedback.

I also updated uses of `ButtonBase` to `Button` in the content-selection sketches.

![image](https://github.com/hypothesis/frontend-shared/assets/439947/cd8257d5-410a-475e-bc3e-91f8015d7992)
