### PR TITLE
Add optional input and output directory arguments to `scripts/generate-icons.js`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ coverage/
 # Use Yarn rather than npm to manage the lockfile.
 package-lock.json
 
+.eslintcache

--- a/package.json
+++ b/package.json
@@ -67,9 +67,9 @@
     "build": "yarn build-lib && tsc --build src/tsconfig.json",
     "build-pattern-lib": "yarn gulp bundle-css && yarn rollup -c rollup.config.js",
     "typecheck": "tsc --build src/tsconfig.json",
-    "lint": "eslint .",
-    "checkformatting": "prettier --check '**/*.{js,scss,ts,tsx,md}'",
-    "format": "prettier --list-different --write '**/*.{js,scss,ts,tsx,md}'",
+    "lint": "eslint --cache .",
+    "checkformatting": "prettier --cache --check '**/*.{js,scss,ts,tsx,md}'",
+    "format": "prettier --cache --list-different --write '**/*.{js,scss,ts,tsx,md}'",
     "test": "gulp test",
     "plop": "plop",
     "push": "yarn build && yalc push"

--- a/scripts/generate-icons.js
+++ b/scripts/generate-icons.js
@@ -1,3 +1,6 @@
+/* eslint-env node */
+
+/* eslint-disable no-console */
 import { readdirSync, readFileSync, writeFileSync } from 'node:fs';
 import * as path from 'node:path';
 import { format } from 'prettier';
@@ -118,8 +121,15 @@ function generateIconIndex(componentDir) {
   writeFileSync(outputFile, outputSrc);
 }
 
-const inputDir = 'images/icons';
-const outputDir = 'src/components/icons';
+const argv = process.argv;
+
+if (argv.includes('--help')) {
+  console.log(`Usage: ${path.basename(argv[1])} [input_dir] [output_dir]`);
+  process.exit(0);
+}
+
+const inputDir = argv[2] ?? 'images/icons';
+const outputDir = argv[3] ?? 'src/components/icons';
 
 const svgFiles = readdirSync(inputDir).filter(file => file.endsWith('.svg'));
 for (let file of svgFiles) {


### PR DESCRIPTION
Add optional arguments to `scripts/generate-icons.js` to allow custom input/output dirs to be specified. This allows the script to be re-used to generate icons in other projects, or for other purposes. Per commit notes, I'm not using a proper CLI parser because the args are so simple. This can be changed if the syntax gets more complex.

The initial use case is to generate icon components for the video player app. The changes in this PR are enough for that. It would be convenient if the script was included in the package, then we could add a `package.json` script to run it in the downstream project.

While testing this I noticed that incremental runs of ESLint and Prettier were taking a long time because caching was not enabled, so I fixed that in a separate commit.