### PR TITLE
Add new `OptionButton` component

### DIFF
--- a/src/components/input/OptionButton.tsx
+++ b/src/components/input/OptionButton.tsx
@@ -1,0 +1,76 @@
+import classnames from 'classnames';
+import type { ComponentChildren } from 'preact';
+
+import { CheckIcon } from '../icons/';
+import Button from './Button';
+import type { ButtonProps } from './Button';
+
+export type OptionButtonProps = {
+  /** Optional content to render at the right side of the button */
+  details?: ComponentChildren;
+  /** alias for `pressed`: this option button is selected **/
+  selected?: boolean;
+} & Omit<ButtonProps, 'size' | 'unstyled' | 'classes' | 'variant'>;
+
+/**
+ * Render a button representing one of a set of options, with optional
+ * right-aligned `details` content
+ */
+const OptionButton = function OptionButton({
+  children,
+  details,
+  selected = false,
+
+  pressed,
+  ...buttonProps
+}: OptionButtonProps) {
+  const isPressed = selected || pressed;
+  return (
+    <Button
+      classes={classnames(
+        'group', // Facilitate styling children based on this element's state
+        'w-full gap-x-2 px-2 py-1',
+        'border border-stone-300 bg-stone-50',
+        'enabled:hover:border-slate-5 enabled:hover:bg-slate-0',
+        'disabled:border-stone-200',
+        'aria-pressed:border-slate-5 aria-pressed:bg-slate-0 aria-pressed:shadow-inner',
+        'aria-expanded:border-slate-5 aria-expanded:bg-slate-0 aria-expanded:shadow-inner'
+      )}
+      size="custom"
+      variant="custom"
+      pressed={isPressed}
+      {...buttonProps}
+    >
+      <div className="grow flex items-center gap-x-1 text-start">
+        {isPressed && (
+          <div className="rounded-full bg-slate-600 p-0.5">
+            <CheckIcon className="w-[0.6em] h-[0.6em] text-white" />
+          </div>
+        )}
+        <div
+          className="text-slate-600 font-semibold group-disabled:text-stone-400"
+          data-testid="option-button-label"
+        >
+          {children}
+        </div>
+      </div>
+      <div className="text-end">
+        {details && (
+          <span
+            className={classnames(
+              'uppercase text-[0.8em] text-stone-500',
+              'group-enabled:group-hover:text-stone-600',
+              'group-disabled:text-stone-400',
+              'group-aria-pressed:text-slate-600 group-aria-expanded:text-slate-600'
+            )}
+            data-testid="option-button-details"
+          >
+            {details}
+          </span>
+        )}
+      </div>
+    </Button>
+  );
+};
+
+export default OptionButton;

--- a/src/components/input/index.ts
+++ b/src/components/input/index.ts
@@ -4,6 +4,7 @@ export { default as Checkbox } from './Checkbox';
 export { default as IconButton } from './IconButton';
 export { default as Input } from './Input';
 export { default as InputGroup } from './InputGroup';
+export { default as OptionButton } from './OptionButton';
 export { default as Select } from './Select';
 
 export type { ButtonProps } from './Button';
@@ -12,4 +13,5 @@ export type { CheckboxProps } from './Checkbox';
 export type { IconButtonProps } from './IconButton';
 export type { InputProps } from './Input';
 export type { InputGroupProps } from './InputGroup';
+export type { OptionButtonProps } from './OptionButton';
 export type { SelectProps } from './Select';

--- a/src/components/input/test/OptionButton-test.js
+++ b/src/components/input/test/OptionButton-test.js
@@ -1,0 +1,42 @@
+import { mount } from 'enzyme';
+
+import { testSimpleComponent } from '../../test/common-tests';
+import OptionButton from '../OptionButton';
+
+describe('OptionButton', () => {
+  const createComponent = (props = {}) => {
+    return mount(
+      <OptionButton {...props}>This is content inside of a Button</OptionButton>
+    );
+  };
+
+  testSimpleComponent(OptionButton);
+
+  it('applies appropriate ARIA attributes for button state', () => {
+    const pressed = createComponent({ pressed: true });
+    const selected = createComponent({ selected: true });
+
+    assert.equal(
+      pressed.find('button').getDOMNode().getAttribute('aria-pressed'),
+      'true'
+    );
+    assert.equal(
+      selected.find('button').getDOMNode().getAttribute('aria-pressed'),
+      'true'
+    );
+  });
+
+  it('renders optional details content', () => {
+    const noDetails = createComponent();
+    const withDetails = createComponent({ details: 'PDF' });
+
+    function getDetails(wrapper) {
+      return wrapper.find('[data-testid="option-button-details"]');
+    }
+
+    assert.isNotOk(getDetails(noDetails).exists());
+    const details = getDetails(withDetails);
+    assert.isOk(details);
+    assert.equal(details.text(), 'PDF');
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,6 +36,7 @@ export {
   IconButton,
   Input,
   InputGroup,
+  OptionButton,
   Select,
 } from './components/input';
 export {
@@ -97,6 +98,7 @@ export type {
   IconButtonProps,
   InputProps,
   InputGroupProps,
+  OptionButtonProps,
   SelectProps,
 } from './components/input';
 

--- a/src/pattern-library/components/patterns/input/OptionButtonPage.tsx
+++ b/src/pattern-library/components/patterns/input/OptionButtonPage.tsx
@@ -1,0 +1,145 @@
+import { OptionButton } from '../../../../';
+import Library from '../../Library';
+
+export default function OptionButtonPage() {
+  return (
+    <Library.Page
+      title="OptionButton"
+      intro={
+        <p>
+          <code>OptionButton</code> is a simple component for presenting an
+          option as part of a set of options. It can be used in places where it
+          is impractical or undesirable to use an equivalent{' '}
+          <code>{`input type="radio"`}</code> or <code>select</code> element.{' '}
+          <code>OptionButton</code> wraps{' '}
+          <Library.Link href="/input-button">
+            <code>Button</code>
+          </Library.Link>
+          .
+        </p>
+      }
+    >
+      <Library.Section>
+        <Library.Pattern>
+          <Library.Usage componentName="OptionButton" />
+          <Library.Example>
+            <Library.Demo withSource title="Basic OptionButton">
+              <div className="w-[250px]">
+                <OptionButton>Option Alpha</OptionButton>
+              </div>
+            </Library.Demo>
+          </Library.Example>
+        </Library.Pattern>
+
+        <Library.Pattern title="Working with OptionButton">
+          <Library.Example title="Multiple OptionButtons">
+            <p>
+              <code>OptionButton</code> is designed for use in a set, similar to
+              an <code>option</code> element or a radio button. While not
+              enforced, a maximum of one <code>OptionButton</code> in a set
+              should be selected. There is also <code>disabled</code>
+              styling.
+            </p>
+            <p>
+              To facilitate alignment, <code>OptionButton</code> stretches to
+              the full width of its container.
+            </p>
+            <Library.Demo withSource>
+              <div className="w-[280px] space-y-2">
+                <OptionButton>Option Alpha</OptionButton>
+                <OptionButton selected>Option Bravo</OptionButton>
+                <OptionButton>Option Charlie-Delta-Echo</OptionButton>
+                <OptionButton disabled>Option Foxtrot</OptionButton>
+                <OptionButton>Option Golf</OptionButton>
+              </div>
+            </Library.Demo>
+          </Library.Example>
+        </Library.Pattern>
+
+        <Library.Pattern title="Component API">
+          <Library.Example title="details">
+            <Library.Info>
+              <Library.InfoItem label="description">
+                Optional content to display at right side of button. Be sure to
+                set a useful <code>title</code> (used for generating{' '}
+                <code>aria-label</code>) when constructing such buttons.
+              </Library.InfoItem>
+              <Library.InfoItem label="type">
+                <code>preact.ComponentChildren</code>
+              </Library.InfoItem>
+            </Library.Info>
+
+            <Library.Demo title="OptionButton with details" withSource>
+              <div className="w-[250px]">
+                <OptionButton
+                  details="PDF"
+                  title="Select a PDF from Google Drive"
+                >
+                  Google Drive
+                </OptionButton>
+              </div>
+            </Library.Demo>
+          </Library.Example>
+
+          <Library.Example title="selected">
+            <Library.Info>
+              <Library.InfoItem label="description">
+                The option represented by the button is selected. A maximum of
+                one <code>OptionButton</code> in a set should be selected at any
+                time. This is an alias for the <code>Button</code>{' '}
+                <code>pressed</code> prop.
+              </Library.InfoItem>
+              <Library.InfoItem label="type">
+                <code>boolean</code>
+              </Library.InfoItem>
+              <Library.InfoItem label="default">
+                <code>false</code>
+              </Library.InfoItem>
+            </Library.Info>
+
+            <Library.Demo title="Selected OptionButton" withSource>
+              <div className="w-[250px]">
+                <OptionButton
+                  details="PDF"
+                  title="Select a PDF from Google Drive"
+                  selected
+                >
+                  Google Drive
+                </OptionButton>
+              </div>
+            </Library.Demo>
+          </Library.Example>
+
+          <Library.Example title="...buttonProps">
+            <Library.Info>
+              <Library.InfoItem label="description">
+                <code>OptionButton</code> accepts and forwards all{' '}
+                <Library.Link href="/input-button">
+                  <code>Button</code>
+                </Library.Link>{' '}
+                component API props. Styling API props are not forwarded.
+              </Library.InfoItem>
+              <Library.InfoItem label="props">
+                All <code>Button</code> props except styling API props:
+                <ul>
+                  <li>
+                    <code>classes</code>
+                  </li>
+                  <li>
+                    <code>unstyled</code>
+                  </li>
+                  <li>
+                    <code>variant</code>
+                  </li>
+                  <li>
+                    <code>size</code>
+                  </li>
+                </ul>
+              </Library.InfoItem>
+            </Library.Info>
+          </Library.Example>
+        </Library.Pattern>
+      </Library.Section>
+    </Library.Page>
+  );
+}

--- a/src/pattern-library/components/patterns/prototype/LMSContentButtonPage.tsx
+++ b/src/pattern-library/components/patterns/prototype/LMSContentButtonPage.tsx
@@ -1,61 +1,7 @@
-import classnames from 'classnames';
 import type { ComponentChildren } from 'preact';
 
-import { Button, Card, CardHeader, CardContent, CheckIcon } from '../../../../';
-import type { ButtonProps } from '../../../../';
+import { Card, CardHeader, CardContent, OptionButton } from '../../../../';
 import Library from '../../Library';
-
-type ContentButtonProps = { contentType: string } & ButtonProps;
-
-function ContentButton({
-  children,
-  classes,
-  contentType = 'pdf',
-  pressed,
-  ...buttonProps
-}: ContentButtonProps) {
-  return (
-    <Button
-      classes={classnames(
-        'w-full rounded-sm gap-x-2 px-2 py-1',
-        'border border-stone-300 bg-stone-50',
-        'group',
-        'enabled:hover:border-slate-5 enabled:hover:bg-slate-0',
-        'disabled:border-stone-200',
-        'aria-pressed:border-slate-5 aria-pressed:bg-slate-0 aria-pressed:shadow-inner',
-        'aria-expanded:border-slate-5 aria-expanded:bg-slate-0 aria-expanded:shadow-inner',
-        classes
-      )}
-      size="custom"
-      variant="custom"
-      pressed={pressed}
-      {...buttonProps}
-    >
-      <div className="grow flex items-center gap-x-1 text-start">
-        {pressed && (
-          <div className="rounded-full bg-slate-600 p-0.5">
-            <CheckIcon className="w-[0.6em] h-[0.6em] text-white" />
-          </div>
-        )}
-        <div className="text-slate-600 font-semibold group-disabled:text-stone-400">
-          {children}
-        </div>
-      </div>
-      <div className="text-end">
-        <span
-          className={classnames(
-            'uppercase text-[0.8em] text-stone-500',
-            'group-enabled:group-hover:text-stone-600',
-            'group-disabled:text-stone-400',
-            'group-aria-pressed:text-slate-600 group-aria-expanded:text-slate-600'
-          )}
-        >
-          {contentType}
-        </span>
-      </div>
-    </Button>
-  );
-}
 
 /**
  * A relatively simplified layout representation of the LMS content-selection
@@ -86,15 +32,20 @@ function ContentPanel({ children }: { children: ComponentChildren }) {
   );
 }
 
-export default function LMSContentButtonPage() {
+export default function LMSOptionButtonPage() {
   return (
     <Library.Page
       title="LMS content selection buttons"
       intro={
         <p>
-          The proposed LMS <code>ContentButton</code> encapsulates a new button
-          design pattern for the assignment content-configuration screen in LMS.
-          It is based on a selected design approach in the{' '}
+          The new{' '}
+          <Library.Link href="/input-option-button">
+            <code>OptionButton</code>
+          </Library.Link>{' '}
+          encapsulates a new button design pattern for selecting an option from
+          a list of options. The assignment content-configuration screen in LMS
+          will use this new button. It is based on a selected design approach in
+          the{' '}
           <Library.Link href="/lms-content-selection">
             set of available sketches
           </Library.Link>
@@ -103,94 +54,56 @@ export default function LMSContentButtonPage() {
       }
     >
       <Library.Section>
-        <Library.Pattern title="Working with ContentButton">
-          <Library.Example title="Button states">
-            <Library.Demo title="ContentButton with hover styling">
-              <div className="bg-white p-8">
-                <div className="w-[16em] text-[14px]">
-                  <ContentButton contentType="PDF">Google Drive</ContentButton>
-                </div>
-              </div>
-            </Library.Demo>
+        <Library.Pattern title="OptionButtons in context">
+          <Library.Demo>
+            <div className="w-[700px]">
+              <ContentPanel>
+                <OptionButton details="Web Page | PDF">URL</OptionButton>
+                <OptionButton details="PDF">Canvas</OptionButton>
+                <OptionButton details="PDF">Google Drive</OptionButton>
+                <OptionButton details="Article">JSTOR</OptionButton>
+                <OptionButton details="PDF">OneDrive</OptionButton>
+                <OptionButton details="Book">VitalSource</OptionButton>
+                <OptionButton details="Video">YouTube</OptionButton>
+              </ContentPanel>
+            </div>
+          </Library.Demo>
 
-            <Library.Demo title="Pressed (active) ContentButton">
-              <div className="bg-white p-8">
-                <div className="w-[16em] text-[14px]">
-                  <ContentButton pressed contentType="PDF">
-                    Google Drive
-                  </ContentButton>
-                </div>
-              </div>
-            </Library.Demo>
+          <Library.Callout>
+            <em>NB:</em> There is currently no use of <code>disabled</code> or{' '}
+            <code>pressed</code> states in the LMS content-selection interface.
+            But the new button provides styling for those states.
+          </Library.Callout>
 
-            <Library.Demo title="Disabled ContentButton">
-              <div className="bg-white p-8">
-                <div className="w-[16em] text-[14px]">
-                  <ContentButton disabled contentType="PDF">
-                    Google Drive
-                  </ContentButton>
-                </div>
-              </div>
-            </Library.Demo>
-          </Library.Example>
+          <Library.Demo title="With selected content, and one disabled content option">
+            <div className="w-[700px]">
+              <ContentPanel>
+                <OptionButton details="Web Page | PDF">URL</OptionButton>
+                <OptionButton details="PDF">Canvas</OptionButton>
+                <OptionButton details="PDF" pressed>
+                  Google Drive
+                </OptionButton>
+                <OptionButton details="Article">JSTOR</OptionButton>
+                <OptionButton details="PDF">OneDrive</OptionButton>
+                <OptionButton details="Book">VitalSource</OptionButton>
+                <OptionButton details="Video">YouTube</OptionButton>
+              </ContentPanel>
+            </div>
+          </Library.Demo>
 
-          <Library.Example title="ContentButtons in context">
-            <Library.Demo>
-              <div className="w-[700px]">
-                <ContentPanel>
-                  <ContentButton contentType="Web Page | PDF">
-                    URL
-                  </ContentButton>
-                  <ContentButton contentType="PDF">Canvas</ContentButton>
-                  <ContentButton contentType="PDF">Google Drive</ContentButton>
-                  <ContentButton contentType="Article">JSTOR</ContentButton>
-                  <ContentButton contentType="PDF">OneDrive</ContentButton>
-                  <ContentButton contentType="Book">VitalSource</ContentButton>
-                  <ContentButton contentType="Video">YouTube</ContentButton>
-                </ContentPanel>
-              </div>
-            </Library.Demo>
-
-            <Library.Callout>
-              <em>NB:</em> There is currently no use of <code>disabled</code> or{' '}
-              <code>pressed</code> states in the LMS content-selection
-              interface. But the new button provides styling for those states.
-            </Library.Callout>
-
-            <Library.Demo title="With selected content, and one disabled content option">
-              <div className="w-[700px]">
-                <ContentPanel>
-                  <ContentButton contentType="Web Page | PDF">
-                    URL
-                  </ContentButton>
-                  <ContentButton contentType="PDF">Canvas</ContentButton>
-                  <ContentButton contentType="PDF" pressed>
-                    Google Drive
-                  </ContentButton>
-                  <ContentButton contentType="Article">JSTOR</ContentButton>
-                  <ContentButton contentType="PDF">OneDrive</ContentButton>
-                  <ContentButton contentType="Book">VitalSource</ContentButton>
-                  <ContentButton contentType="Video">YouTube</ContentButton>
-                </ContentPanel>
-              </div>
-            </Library.Demo>
-
-            <Library.Demo title="With different options, and one disabled option">
-              <div className="w-[700px]">
-                <ContentPanel>
-                  <ContentButton contentType="Web Page | PDF">
-                    URL
-                  </ContentButton>
-                  <ContentButton contentType="PDF">Canvas</ContentButton>
-                  <ContentButton contentType="PDF">Google Drive</ContentButton>
-                  <ContentButton contentType="PDF">OneDrive</ContentButton>
-                  <ContentButton contentType="Book" disabled>
-                    VitalSource
-                  </ContentButton>
-                </ContentPanel>
-              </div>
-            </Library.Demo>
-          </Library.Example>
+          <Library.Demo title="With different options, and one disabled option">
+            <div className="w-[700px]">
+              <ContentPanel>
+                <OptionButton details="Web Page | PDF">URL</OptionButton>
+                <OptionButton details="PDF">Canvas</OptionButton>
+                <OptionButton details="PDF">Google Drive</OptionButton>
+                <OptionButton details="PDF">OneDrive</OptionButton>
+                <OptionButton details="Book" disabled>
+                  VitalSource
+                </OptionButton>
+              </ContentPanel>
+            </div>
+          </Library.Demo>
         </Library.Pattern>
       </Library.Section>
     </Library.Page>

--- a/src/pattern-library/routes.ts
+++ b/src/pattern-library/routes.ts
@@ -18,6 +18,7 @@ import ButtonsPage from './components/patterns/input/ButtonPage';
 import CheckboxPage from './components/patterns/input/CheckboxPage';
 import InputGroupPage from './components/patterns/input/InputGroupPage';
 import InputPage from './components/patterns/input/InputPage';
+import OptionButtonPage from './components/patterns/input/OptionButtonPage';
 import SelectPage from './components/patterns/input/SelectPage';
 import CardPage from './components/patterns/layout/CardPage';
 import OverlayPage from './components/patterns/layout/OverlayPage';
@@ -171,6 +172,12 @@ const routes: PlaygroundRoute[] = [
     group: 'input',
     component: InputGroupPage,
     route: '/input-input-group',
+  },
+  {
+    title: 'OptionButton',
+    group: 'input',
+    component: OptionButtonPage,
+    route: '/input-option-button',
   },
   {
     title: 'Select',


### PR DESCRIPTION
This PR adds a new `OptionButton` component. It is a semi-generalized implementation of the new button we need to satisfy https://github.com/hypothesis/lms/issues/2955 

I ended up creating a new button that is intended for use "when you might otherwise use a radio button or select element but you need a button instead." In full purity, the set of buttons in the LMS content-selection interface that we're targeting should maybe instead be radio buttons or a select element. But it's impractical to make that big of a change right now, so this component serves as an option-like button.

It takes an optional `details` prop (for content to render at the right edge of the button), aliases `selected` to `pressed` and otherwise forwards all other non-styling props to `Button`. Eh, the [pattern-library docs](http://localhost:4001/input-option-button) explain this more clearly.

I've also updated the [pattern-library prototype page](http://localhost:4001/lms-content-button) for LMS content selection to use this component.

![image](https://github.com/hypothesis/frontend-shared/assets/439947/a9e68369-8840-4a92-a9da-641e8c96cd41)
