### PR TITLE
Update plop templates

### DIFF
--- a/plop-templates/composite-component-test.hbs
+++ b/plop-templates/composite-component-test.hbs
@@ -1,7 +1,6 @@
 import { mount } from 'enzyme';
 
 import { testCompositeComponent } from '../../test/common-tests';
-
 import {{name}} from '../{{name}}';
 
 const createComponent = (Component, props = {}) => {

--- a/plop-templates/pattern-library-page.hbs
+++ b/plop-templates/pattern-library-page.hbs
@@ -3,23 +3,35 @@ import Library from '../../Library';
 
 export default function {{name}}Page() {
   return (
-    <Library.Page title="{{name}}" intro={<p>TODO</p>}>
-      <Library.Section
-        title="{{name}}"
-        intro={<p><code>{{name}}</code> is a {{category}} component</p>}
-      >
-
+    <Library.Page title="{{name}}" intro={<p>Summarize this component</p>}>
+      <Library.Section>
         <Library.Pattern>
           <Library.Usage componentName="{{name}}" />
           <Library.Example>
-            <Library.Demo withSource>
-              <{{name}}>Example of {{name}}</{{name}}>
+            <Library.Demo withSource title="Basic {{name}}">
+              <p>Add a basic demo of the component</p>
             </Library.Demo>
           </Library.Example>
         </Library.Pattern>
 
-        <Library.Pattern title="Props">
+        <Library.Pattern title="Working with {{name}}">
+          <p>TODO (optional)</p>
+        </Library.Pattern>
+
+        <Library.Pattern title="Component API">
           <Library.Example title="exampleProp">
+            <Library.Info>
+              <Library.InfoItem label="description">
+                prop description
+              </Library.InfoItem>
+              <Library.InfoItem label="type">
+                <code>boolean</code>
+              </Library.InfoItem>
+              <Library.InfoItem label="default">
+                <code>false</code>
+              </Library.InfoItem>
+            </Library.Info>
+
             <Library.Demo withSource>
               <p>TODO: Example of component with prop</p>
             </Library.Demo>

--- a/plop-templates/presentational-component-test.hbs
+++ b/plop-templates/presentational-component-test.hbs
@@ -1,7 +1,6 @@
 import { mount } from 'enzyme';
 
 import { testPresentationalComponent } from '../../test/common-tests';
-
 import {{name}} from '../{{name}}';
 
 const createComponent = (Component, props = {}) => {

--- a/plop-templates/simple-component-test.hbs
+++ b/plop-templates/simple-component-test.hbs
@@ -1,5 +1,4 @@
 import { testSimpleComponent } from '../../test/common-tests';
-
 import {{name}} from '../{{name}}';
 
 describe('{{name}}', () => {

--- a/plop-templates/simple-component.hbs
+++ b/plop-templates/simple-component.hbs
@@ -10,13 +10,11 @@ export type {{name}}Props = {
 const {{name}} = function {{name}}({ size = 'md' }: {{name}}Props) {
   return (
     <div
-      className={classnames(
-        {
-          'w-em h-em': size === 'sm',
-          'w-2em h-2em': size === 'md', // default
-          'w-4em h-4em': size === 'lg',
-        }
-      )}
+      className={classnames({
+        'w-em h-em': size === 'sm',
+        'w-2em h-2em': size === 'md', // default
+        'w-4em h-4em': size === 'lg',
+      })}
       data-component="{{name}}"
     />
   );


### PR DESCRIPTION
This little housekeeping PR updates plop templates to match the updated pattern-library documentation-page structure for convenience and consistency. I also cleaned up a few nits that prettier was complaining about (indents and spacing, etc.).