### PR TITLE
Add explicit Cache-Control, to make sure Cloudflare does not cache resources for too long

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -12,12 +12,15 @@ server {
 
     # When requesting static paths with an extension, try them, and return a 404 if not found
     location ~* .+\..+ {
+        add_header Cache-Control "public, s-maxage=300, max-age=60, must-revalidate";
         try_files $uri $uri/ =404;
     }
 
     # When requesting a path without extension, try it, and return the index if not found
     # This allows for client-side route handling
     location / {
-        try_files $uri $uri/ /index.html$is_args$args;
+        # Ensure Cloudflare caches assets no longer than 5 minutes
+        add_header Cache-Control "public, s-maxage=300, max-age=60, must-revalidate";
+        try_files $uri $uri/ /index.html;
     }
 }


### PR DESCRIPTION
Until we implement a better solution, this PR adds explicit 5 minute cache for any resource served through the pattern library production nginx (index.html, CSS/JS bundles, and any other static resource).

This will make sure Cloudflare revalidates those assets after 5 minutes tops, and we don't end-up showing outdated content after a deployment.

Next steps would include improving this process to make it smarter (cache longer what doesn't change, while making sure new content is displayed right away after a deployment). We have discussed a few options on slack https://hypothes-is.slack.com/archives/C1M8NH76X/p1685957404405389

### Testing steps

* Check out this branch.
* Build the docker image: `docker build . -t hypothesis_frontend_shared`.
* Run the image on a port of your choice. For example, port 88: `docker run --rm -p 89:5001 hypothesis_frontend_shared`
* Visit http://localhost:88, and check in the console's network tab, that it loaded the root page and the CSS and JS bundles. Check that all those containe the response header: `Cache-Control: public, s-maxage=300, max-age=60, must-revalidate`.
* If you refresh the page, you should see how it either receives a 304 from nginx (for the document request), or it directly loads resources from cache (for the bundles). The bundle requests should also not show in nginx logs, as the browser did not make the requests.
* If you wait for 5 min and repeat the process, you should see how the assets are requested again to nginx (requests are loaded, although it returns 304 because the content did not change).

> This PR relates to https://github.com/hypothesis/frontend-shared/issues/1084