### PR TITLE
Update pattern-library documentation structure for "Input" components.

### DIFF
--- a/src/pattern-library/components/patterns/input/CheckboxPage.tsx
+++ b/src/pattern-library/components/patterns/input/CheckboxPage.tsx
@@ -23,17 +23,30 @@ export default function CheckboxPage() {
         <Library.Usage componentName="Checkbox" />
         <Library.Example>
           <Library.Demo title="Basic Checkbox" withSource>
-            <Checkbox>Click me</Checkbox>
+            <div className="flex flex-col">
+              <Checkbox>Click me</Checkbox>
+              <Checkbox disabled>Disabled</Checkbox>
+            </div>
           </Library.Demo>
         </Library.Example>
       </Library.Pattern>
 
-      <Library.Pattern title="Props">
-        <Library.Example title="checked">
+      <Library.Pattern title="Working with Checkboxes">
+        <Library.Example title="Controlled Checkboxes">
           <p>
-            When the <code>checked</code> prop is present, <code>Checkbox</code>{' '}
-            will behave as a controlled component.
+            The presence of a <code>checked</code> prop will make the{' '}
+            <code>Checkbox</code> behave as a controlled component. Consuming
+            components should respond to the <code>onChange</code> event.
           </p>
+          <Library.Demo
+            title="Controlling a Checkbox with `checked`"
+            withSource
+          >
+            <Checkbox checked={checked} onChange={handleControlledChange}>
+              Controlled checkbox
+            </Checkbox>
+          </Library.Demo>
+
           <Library.Code
             content={`const [checked, setChecked] = useState(false);
 
@@ -49,13 +62,8 @@ const handleControlledChange = e => {
 </Checkbox>
 `}
             size="sm"
-            title="Controlled Checkbox usage example"
+            title="When the `checked prop` is present, Checkbox will behave as a controlled component"
           />
-          <Library.Demo title="Controlled Checkbox" withSource>
-            <Checkbox checked={checked} onChange={handleControlledChange}>
-              Controlled checkbox
-            </Checkbox>
-          </Library.Demo>
 
           <Library.Demo
             title="Don't forget to handle events for controlled Checkboxes"
@@ -69,11 +77,55 @@ const handleControlledChange = e => {
           </Library.Demo>
         </Library.Example>
 
-        <Library.Example title="defaultChecked">
+        <Library.Example title="Customizing Checkbox icons">
           <p>
-            For uncontrolled <code>Checkbox</code>es,{' '}
-            <code>defaultChecked</code> sets initial checked state.
+            <code>Checkbox</code> uses icons to style the checkbox, in unchecked
+            and checked states. Custom icons may be provided if desired.
           </p>
+          <Library.Demo
+            withSource
+            title="Checkbox with custom icon and checkedIcon"
+          >
+            <Checkbox icon={HideIcon} checkedIcon={ShowIcon} defaultChecked />
+          </Library.Demo>
+        </Library.Example>
+      </Library.Pattern>
+
+      <Library.Pattern title="Component API">
+        <code>Checkbox</code> accepts all standard{' '}
+        <Library.Link href="/using-components#presentational-components-api">
+          presentational component props
+        </Library.Link>
+        .
+        <Library.Example title="checked">
+          <Library.Info>
+            <Library.InfoItem label="description">
+              Set whether the <code>Checkbox</code> is checked. The presence of
+              this component indicates that the <code>Checkbox</code> is being
+              used as a controlled component.
+            </Library.InfoItem>
+            <Library.InfoItem label="type">
+              <code>{`boolean`}</code>
+            </Library.InfoItem>
+            <Library.InfoItem label="default">
+              <code>{`undefined`}</code>
+            </Library.InfoItem>
+          </Library.Info>
+        </Library.Example>
+        <Library.Example title="defaultChecked">
+          <Library.Info>
+            <Library.InfoItem label="description">
+              Whether the <code>Checkbox</code> is initially checked. For use
+              when <code>Checkbox</code> is an uncontrolled component.
+            </Library.InfoItem>
+            <Library.InfoItem label="type">
+              <code>{`boolean`}</code>
+            </Library.InfoItem>
+            <Library.InfoItem label="default">
+              <code>{`false`}</code>
+            </Library.InfoItem>
+          </Library.Info>
+
           <Library.Demo
             title="Uncontrolled Checkbox with defaultChecked"
             withSource
@@ -81,42 +133,35 @@ const handleControlledChange = e => {
             <Checkbox defaultChecked>Default checked</Checkbox>
           </Library.Demo>
         </Library.Example>
-
-        <Library.Example title="disabled">
-          <p>
-            <code>disabled</code> styling reduces the opacity of the component.
-          </p>
-          <Library.Demo withSource>
-            <Checkbox>Enabled</Checkbox>
-            <Checkbox disabled>Disabled</Checkbox>
-          </Library.Demo>
+        <Library.Example title="icon">
+          <Library.Info>
+            <Library.InfoItem label="description">
+              <code>IconComponent</code> to use as the (unchecked) checkbox icon
+            </Library.InfoItem>
+            <Library.InfoItem label="type">
+              <code>{`IconComponent`}</code>
+            </Library.InfoItem>
+          </Library.Info>
         </Library.Example>
-
-        <Library.Example title="icon and checkedIcon">
-          <p>
-            Custom icons may be used for styling checkboxes. Use the{' '}
-            <code>icon</code> and <code>checkedIcon</code> props to set custom{' '}
-            <code>IconComponent</code>s to use for the unchecked and checked
-            checkbox styling, respectively.
-          </p>
-          <Library.Demo withSource>
-            <Checkbox icon={HideIcon} checkedIcon={ShowIcon} defaultChecked />
-          </Library.Demo>
+        <Library.Example title="checkedIcon">
+          <Library.Info>
+            <Library.InfoItem label="description">
+              <code>IconComponent</code> to use as the (checked) checkbox icon
+            </Library.InfoItem>
+            <Library.InfoItem label="type">
+              <code>{`IconComponent`}</code>
+            </Library.InfoItem>
+          </Library.Info>
         </Library.Example>
-
-        <Library.Example title="onChange">
-          <p>
-            Any provided <code>onChange</code> function is invoked when there is
-            a <code>change</code> event on the checkbox <code>input</code> — in
-            other words, it behaves just like a normal <code>onChange</code>{' '}
-            handler for an input.
-          </p>
-
-          <p>
-            Remember: <code>Checkbox</code> accepts any valid{' '}
-            <code>HTMLInput</code> attribute. You can also use{' '}
-            <code>onClick</code>, <code>onInput</code>, etc.
-          </p>
+        <Library.Example title="...inputProps">
+          <Library.Info>
+            <Library.InfoItem label="description">
+              <code>Checkbox</code> accepts HTML attributes for input elements
+            </Library.InfoItem>
+            <Library.InfoItem label="type">
+              <code>{`JSX.HTMLAttributes<HTMLInputElement>`}</code>
+            </Library.InfoItem>
+          </Library.Info>
         </Library.Example>
       </Library.Pattern>
     </Library.Page>

--- a/src/pattern-library/components/patterns/input/InputGroupPage.tsx
+++ b/src/pattern-library/components/patterns/input/InputGroupPage.tsx
@@ -11,20 +11,21 @@ import Library from '../../Library';
 
 export default function InputGroupPage() {
   return (
-    <Library.Page title="InputGroup">
-      <Library.Section
-        intro={
-          <p>
-            <code>InputGroup</code> is a presentational component that provides
-            layout for groups of input components.
-          </p>
-        }
-      >
+    <Library.Page
+      title="InputGroup"
+      intro={
+        <p>
+          <code>InputGroup</code> is a presentational component that provides
+          layout and styling for groups of input components.
+        </p>
+      }
+    >
+      <Library.Section>
         <Library.Pattern>
           <Library.Usage componentName="InputGroup" />
           <Library.Example>
             <Library.Demo
-              title="Basic InputGroup with an Input and an IconButton"
+              title="Basic InputGroup containing an Input and an IconButton"
               withSource
             >
               <div className="w-[350px]">
@@ -34,7 +35,26 @@ export default function InputGroupPage() {
                 </InputGroup>
               </div>
             </Library.Demo>
+          </Library.Example>
+        </Library.Pattern>
 
+        <Library.Pattern title="Working with InputGroups">
+          <Library.Example title="Composing InputGroups">
+            <p>
+              The following input components can be used in an{' '}
+              <code>InputGroup</code>:
+            </p>
+            <ul>
+              <li>
+                <code>Input</code>
+              </li>
+              <li>
+                <code>IconButton</code>
+              </li>
+              <li>
+                <code>Select</code>
+              </li>
+            </ul>
             <Library.Demo
               title="Select and IconButton components in InputGroup"
               withSource
@@ -61,13 +81,8 @@ export default function InputGroupPage() {
               </div>
             </Library.Demo>
           </Library.Example>
-
-          <Library.Example title="Scaling InputGroup size">
-            <p>
-              This example demonstrates <code>InputGroup</code> inputs scaling
-              to the local font size.
-            </p>
-            <Library.Demo withSource>
+          <Library.Example title="Sizing InputGroups">
+            <Library.Demo title="Scaling to local font size" withSource>
               <div className="w-[350px]">
                 <div className="text-xs">
                   <InputGroup>
@@ -83,22 +98,25 @@ export default function InputGroupPage() {
               </div>
             </Library.Demo>
           </Library.Example>
-          <Library.Example title="Group-able Inputs">
-            <p>
-              The following input components are supported by{' '}
-              <code>InputGroup</code>:
-            </p>
-            <ul>
-              <li>
-                <code>Input</code>
-              </li>
-              <li>
-                <code>IconButton</code>
-              </li>
-              <li>
-                <code>Select</code>
-              </li>
-            </ul>
+        </Library.Pattern>
+
+        <Library.Pattern title="Component API">
+          <p>
+            <code>InputGroup</code> accepts all standard{' '}
+            <Library.Link href="/using-components#presentational-components-api">
+              presentational component props
+            </Library.Link>
+            .
+          </p>
+          <Library.Example title="...htmlAttributes">
+            <Library.Info>
+              <Library.InfoItem label="description">
+                <code>InputGroup</code> accepts HTML attributes.
+              </Library.InfoItem>
+              <Library.InfoItem label="type">
+                <code>{`JSX.HTMLAttributes<HTMLElement>`}</code>
+              </Library.InfoItem>
+            </Library.Info>
           </Library.Example>
         </Library.Pattern>
       </Library.Section>

--- a/src/pattern-library/components/patterns/input/InputPage.tsx
+++ b/src/pattern-library/components/patterns/input/InputPage.tsx
@@ -7,18 +7,12 @@ export default function InputPage() {
       title="Input"
       intro={
         <p>
-          <code>Input</code> styles text inputs.
+          <code>Input</code> is a presentational component for styling textual{' '}
+          <code>input</code> elements.
         </p>
       }
     >
-      <Library.Section
-        intro={
-          <p>
-            <code>Input</code> is a presentational component for styling textual{' '}
-            <code>input</code> elements.
-          </p>
-        }
-      >
+      <Library.Section>
         <Library.Pattern>
           <Library.Usage componentName="Input" />
 
@@ -32,7 +26,9 @@ export default function InputPage() {
               </div>
             </Library.Demo>
           </Library.Example>
+        </Library.Pattern>
 
+        <Library.Pattern title="Working with Inputs">
           <Library.Example title="Accessibility">
             <p>
               Hypothesis does not currently have a design pattern for labeling
@@ -50,35 +46,43 @@ export default function InputPage() {
               </div>
             </Library.Demo>
           </Library.Example>
+          <Library.Example title="Disabled inputs">
+            <p>
+              <code>Input</code>s can be disabled by applying the HTML{' '}
+              <code>disabled</code> attribute.
+            </p>
+            <Library.Demo withSource>
+              <div className="w-[350px]">
+                <Input
+                  aria-label="Example input"
+                  placeholder="Placeholder..."
+                  disabled
+                />
+              </div>
+            </Library.Demo>
+          </Library.Example>
         </Library.Pattern>
 
-        <Library.Pattern title="Props">
-          <Library.Example title="type">
-            <p>
-              <code>Input</code> currently supports the following{' '}
-              <code>type</code> values:
-            </p>
-            <ul>
-              <li>
-                <code>text</code> (default)
-              </li>
-              <li>
-                <code>url</code>
-              </li>
-              <li>
-                <code>email</code>
-              </li>
-              <li>
-                <code>text</code>
-              </li>
-            </ul>
-          </Library.Example>
-
+        <Library.Pattern title="Component API">
+          <code>Input</code> accepts all standard{' '}
+          <Library.Link href="/using-components#presentational-components-api">
+            presentational component props
+          </Library.Link>
+          .
           <Library.Example title="hasError">
-            <p>
-              Set <code>hasError</code> to indicate that there is an associated
-              error for the <code>Input</code>.
-            </p>
+            <Library.Info>
+              <Library.InfoItem label="description">
+                Set <code>hasError</code> to indicate that there is an
+                associated error for the <code>Input</code>.
+              </Library.InfoItem>
+              <Library.InfoItem label="type">
+                <code>{`boolean`}</code>
+              </Library.InfoItem>
+              <Library.InfoItem label="default">
+                <code>{`false`}</code>
+              </Library.InfoItem>
+            </Library.Info>
+
             <Library.Demo withSource>
               <div className="w-[350px]">
                 <Input
@@ -89,17 +93,28 @@ export default function InputPage() {
               </div>
             </Library.Demo>
           </Library.Example>
-
-          <Library.Example title="disabled">
-            <Library.Demo withSource>
-              <div className="w-[350px]">
-                <Input
-                  aria-label="Example input"
-                  placeholder="Disabled..."
-                  disabled
-                />
-              </div>
-            </Library.Demo>
+          <Library.Example title="type">
+            <Library.Info>
+              <Library.InfoItem label="description">
+                <code>Input</code> supports several input types
+              </Library.InfoItem>
+              <Library.InfoItem label="type">
+                <code>{`'text' | 'url' | 'email' | 'search'`}</code>
+              </Library.InfoItem>
+              <Library.InfoItem label="default">
+                <code>{`'text'`}</code>
+              </Library.InfoItem>
+            </Library.Info>
+          </Library.Example>
+          <Library.Example title="...htmlAttributes">
+            <Library.Info>
+              <Library.InfoItem label="description">
+                <code>Input</code> accepts HTML attributes for input elements.
+              </Library.InfoItem>
+              <Library.InfoItem label="type">
+                <code>{`JSX.HTMLAttributes<HTMLInputElement>`}</code>
+              </Library.InfoItem>
+            </Library.Info>
           </Library.Example>
         </Library.Pattern>
       </Library.Section>

--- a/src/pattern-library/components/patterns/input/SelectPage.tsx
+++ b/src/pattern-library/components/patterns/input/SelectPage.tsx
@@ -32,15 +32,7 @@ export default function SelectPage() {
         </p>
       }
     >
-      <Library.Section
-        intro={
-          <p>
-            <code>Select</code> styles <code>{'<select>'}</code> elements. Note
-            that <code>{'<option>'}</code> elements, with a few browser-specific
-            exceptions, cannot be styled with CSS.
-          </p>
-        }
-      >
+      <Library.Section>
         <Library.Pattern>
           <Library.Usage componentName="Select" />
 
@@ -55,13 +47,16 @@ export default function SelectPage() {
                 </SelectWrapper>
               </div>
             </Library.Demo>
+          </Library.Example>
+        </Library.Pattern>
 
-            <Library.Demo title="Setting Select width" withSource>
-              <div className="w-[250px]">
-                <SelectWrapper aria-label="Example input" />
-              </div>
-            </Library.Demo>
-
+        <Library.Pattern title="Working with Selects">
+          <p>
+            <code>Select</code> styles <code>{'<select>'}</code> elements. Note
+            that <code>{'<option>'}</code> elements, with a few browser-specific
+            exceptions, cannot be styled with CSS.
+          </p>
+          <Library.Example title="Composing and styling Selects">
             <Library.Demo title="Select in an InputGroup" withSource>
               <div className="w-[380px]">
                 <InputGroup>
@@ -79,28 +74,57 @@ export default function SelectPage() {
                 </InputGroup>
               </div>
             </Library.Demo>
+            <Library.Demo title="Setting Select width" withSource>
+              <div className="w-[250px]">
+                <SelectWrapper aria-label="Example input" />
+              </div>
+            </Library.Demo>
+          </Library.Example>
+
+          <Library.Example title="Disabled Selects">
+            <Library.Demo title="disabled Select" withSource>
+              <div className="w-[350px]">
+                <SelectWrapper aria-label="Example input" disabled />
+              </div>
+            </Library.Demo>
           </Library.Example>
         </Library.Pattern>
 
-        <Library.Pattern title="Props">
+        <Library.Pattern title="Component API">
+          <code>Select</code> accepts all standard{' '}
+          <Library.Link href="/using-components#presentational-components-api">
+            presentational component props
+          </Library.Link>
+          .
           <Library.Example title="hasError">
-            <p>
-              Set <code>hasError</code> to indicate that there is an associated
-              error.
-            </p>
+            <Library.Info>
+              <Library.InfoItem label="description">
+                Set <code>hasError</code> to indicate that there is an
+                associated error for the <code>Select</code>.
+              </Library.InfoItem>
+              <Library.InfoItem label="type">
+                <code>{`boolean`}</code>
+              </Library.InfoItem>
+              <Library.InfoItem label="default">
+                <code>{`false`}</code>
+              </Library.InfoItem>
+            </Library.Info>
+
             <Library.Demo withSource>
               <div className="w-[350px]">
                 <SelectWrapper aria-label="Example input" hasError />
               </div>
             </Library.Demo>
           </Library.Example>
-
-          <Library.Example title="disabled">
-            <Library.Demo withSource>
-              <div className="w-[350px]">
-                <SelectWrapper aria-label="Example input" disabled />
-              </div>
-            </Library.Demo>
+          <Library.Example title="...htmlAttributes">
+            <Library.Info>
+              <Library.InfoItem label="description">
+                <code>Select</code> accepts HTML attributes for select elements.
+              </Library.InfoItem>
+              <Library.InfoItem label="type">
+                <code>{`JSX.HTMLAttributes<HTMLSelectElement>`}</code>
+              </Library.InfoItem>
+            </Library.Info>
           </Library.Example>
         </Library.Pattern>
       </Library.Section>


### PR DESCRIPTION
This housekeeping PR is part of https://github.com/hypothesis/frontend-shared/issues/1030

This updates the documentation structure for components in the "Input" group. `Button` was already done.

See #1030 for structure details if you're curious.