### PR TITLE
Patterns deployment with hashes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:19.8.1-alpine as builder
+FROM node:20.2.0-alpine as builder
 
 COPY . /frontend-shared
 RUN cd /frontend-shared && \
@@ -6,12 +6,11 @@ RUN cd /frontend-shared && \
     yarn build-pattern-lib
 
 
-FROM nginx:1.24.0-alpine
+FROM nginx:1.25.0-alpine
 
 RUN rm -r /usr/share/nginx/html && rm /etc/nginx/conf.d/default.conf
 # Copy pattern library static assets, and put them in nginx document root folder
 COPY --from=builder /frontend-shared/build /usr/share/nginx/html
-COPY ./templates/index.html /usr/share/nginx/html/index.html
 COPY ./images /usr/share/nginx/html/images
 COPY conf/nginx.conf /etc/nginx/conf.d/default.conf
 

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -10,6 +10,17 @@ server {
         return 200 'Success!';
     }
 
+    # JS and CSS files can be saved for a year, as they include a hash.
+    location ~* \.(?:css|js)$ {
+        expires 1y;
+        add_header Cache-Control "public";
+    }
+    # TODO Decide on a sensible cache period for images
+    location ~* \.(?:jpg|gif|png|ico|svg)$ {
+        expires 1d;
+        add_header Cache-Control "public";
+    }
+
     # When requesting static paths with an extension, try them, and return a 404 if not found
     location ~* .+\..+ {
         try_files $uri $uri/ =404;
@@ -18,6 +29,8 @@ server {
     # When requesting a path without extension, try it, and return the index if not found
     # This allows for client-side route handling
     location / {
-        try_files $uri $uri/ /index.html$is_args$args;
+        # The index file references CSS and JS bundles, so we need to make sure it's always up to date
+        expires -1;
+        try_files $uri $uri/ /index.html;
     }
 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,18 +1,39 @@
-import { buildCSS, runTests, watchJS } from '@hypothesis/frontend-build';
+import {
+  buildCSS,
+  buildJS,
+  runTests,
+  watchJS,
+} from '@hypothesis/frontend-build';
 import gulp from 'gulp';
 
+import { buildPatternLibraryIndex } from './scripts/build-pattern-library-index.js';
 import { servePatternLibrary } from './scripts/serve-pattern-library.js';
 import tailwindConfig from './tailwind.config.js';
-
-gulp.task('serve-pattern-library', () => {
-  servePatternLibrary();
-});
 
 // The following tasks bundle assets for the pattern library for use locally
 // during development. Bundled JS and CSS are not published with the package.
 
+gulp.task('build-pattern-library-index', async () =>
+  buildPatternLibraryIndex()
+);
+
 gulp.task('bundle-css', () =>
   buildCSS(['./styles/pattern-library.scss'], { tailwindConfig })
+);
+
+gulp.task('bundle-js', () => buildJS('./rollup.config.js'));
+
+gulp.task(
+  'build-pattern-library',
+  gulp.series(
+    gulp.parallel('bundle-js', 'bundle-css'),
+    'build-pattern-library-index'
+  )
+);
+
+gulp.task(
+  'serve-pattern-library',
+  gulp.series('build-pattern-library', () => servePatternLibrary())
 );
 
 gulp.task(

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
   "scripts": {
     "build-lib": "babel src/ --out-dir lib/ --extensions '.js,.ts,.tsx' --source-maps --ignore '**/test' --ignore '**/karma.config.js'",
     "build": "yarn build-lib && tsc --build src/tsconfig.json",
-    "build-pattern-lib": "yarn gulp bundle-css && yarn rollup -c rollup.config.js",
+    "build-pattern-lib": "yarn gulp build-pattern-library",
     "typecheck": "tsc --build src/tsconfig.json",
     "lint": "eslint --cache .",
     "checkformatting": "prettier --cache --check '**/*.{js,scss,ts,tsx,md}'",

--- a/scripts/build-pattern-library-index.js
+++ b/scripts/build-pattern-library-index.js
@@ -1,0 +1,25 @@
+import { generateManifest } from '@hypothesis/frontend-build';
+import fs from 'fs';
+
+const templateMap = [
+  ['{{ css_bundle }}', 'styles/pattern-library.css'],
+  ['{{ js_bundle }}', 'scripts/pattern-library.bundle.js'],
+];
+
+export async function buildPatternLibraryIndex() {
+  const manifest = await generateManifest({
+    pattern: 'build/{scripts,styles}/pattern-library*.{css,js}',
+  });
+  const templateContent = fs
+    .readFileSync('templates/index.template.html')
+    .toString();
+
+  const processedTemplateContent = templateMap.reduce(
+    (content, [pattern, fileName]) => {
+      return content.replace(pattern, manifest[fileName] ?? pattern);
+    },
+    templateContent
+  );
+
+  fs.writeFileSync('build/index.html', processedTemplateContent);
+}

--- a/scripts/serve-pattern-library.js
+++ b/scripts/serve-pattern-library.js
@@ -14,7 +14,7 @@ export function servePatternLibrary(port = 4001) {
 
   // For any other path, serve the index.html file to allow client-side routing
   app.get('/:path?', (req, res) => {
-    res.sendFile(path.join(dirname, '../templates/index.html'));
+    res.sendFile(path.join(dirname, '../build/index.html'));
   });
 
   app.listen(port, () => {

--- a/templates/index.template.html
+++ b/templates/index.template.html
@@ -4,10 +4,10 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>UI component pattern library</title>
-  <link rel="stylesheet" href="/styles/pattern-library.css">
+  <link rel="stylesheet" href="/{{ css_bundle }}">
 </head>
 <body>
   <div id="app"></div>
-  <script type="module" src="/scripts/pattern-library.bundle.js"></script>
+  <script type="module" src="/{{ js_bundle }}"></script>
 </body>
 </html>


### PR DESCRIPTION
This PR introduces a number of changes with the intention to fix how Cloudflare caches the pattern library assets, trying to be as optimal as possible, and affecting building as little as possible.

* The `index.html` entry point used both during dev and in production, is now a template file, where the references to JS and CSS bundles is set dynamically.
* In order to resolve references to JS and CSS bundles we now use the `generateManifest` function from `frontend-build`, which brings the ability to have content hashes in URLs, without affecting the actual building of those assets.
* The `nginx.conf` file used in production now includes instructions to make sure proper `Cache-Control` headers are exposed to Cloudflare. Thos instructions imply that:
  * CSS/JS bundles are cached for 1 year, since the URLs will contain different hashes when their content changes
  * Images are cached for 1 day. This is an arbitrary value picked by me that we can change if needed.
  * The index file is not cached, as it contains references to bundles.
* Serving the pattern library locally now depends on bundling CSS and JS, and parsing the index template first, which results in some changes and new tasks being introduced in the gulpfile.

### Testing steps

There are a couple of things that need to be checked for regressions, and new logic to be tested.

* Dev server:
  * Delete all assets inside build folder.
  * Run `make dev`
  * Check that assets are built, and then dev server is started.
  * Visit http://localhost:4001 and confirm the patterns library site works.
  * Edit some file wait for the watch task to rebuild the bundle, and make sure the changes are reflected in http://localhost:4001
* Prod site:
  * Build the docker image: `docker build . -t hypothesis_frontend_shared`.
  * Run the image on a port of your choice. For example, port 89: `docker run --rm -p 89:5001 hypothesis_frontend_shared`
  * Visit http://localhost:89, and check in the console's network tab, that it loaded the CSS and JS bundles. Check that all those contain the response headers: `Cache-Control: public` and `Cache-Control: max-age=31536000`.
  * If you refresh the page, you should see how it directly loads resources from cache (for the bundles). The bundle requests should also not show in nginx logs, as the browser did not make the requests.

> This PR closes https://github.com/hypothesis/frontend-shared/issues/1084