### PR TITLE
Update shared-annotations sketches per PRD decisions

### DIFF
--- a/src/pattern-library/components/patterns/prototype/SharedAnnotationsPage.tsx
+++ b/src/pattern-library/components/patterns/prototype/SharedAnnotationsPage.tsx
@@ -1,25 +1,20 @@
 import type { ComponentChildren } from 'preact';
-import { useState } from 'preact/hooks';
 
 import {
-  Button,
   Card,
   CardActions,
   CardContent,
-  Checkbox,
   EditIcon,
   EllipsisIcon,
   GlobeIcon,
   GroupsFilledIcon,
   IconButton,
-  ModalDialog,
   PinIcon,
   ReplyIcon,
   TrashIcon,
   Tab,
   TabList,
 } from '../../../../';
-import type { ModalDialogProps } from '../../../../components/feedback/ModalDialog';
 import Library from '../../Library';
 import { LoremIpsum } from '../samples';
 import FakeAnnotationPublishControl from './FakeAnnotationPublishControl';
@@ -156,57 +151,19 @@ function FakeSidebar({ children }: { children: ComponentChildren }) {
   );
 }
 
-/**
- * Wrap the ModalDialog component with some state management to make reuse in
- * multiple examples plausible and convenient.
- */
-function ModalDialog_({ buttons, children, ...dialogProps }: ModalDialogProps) {
-  const [dialogOpen, setDialogOpen] = useState(false);
-  const closeDialog = () => setDialogOpen(false);
-
-  const openButton = (
-    <Button onClick={() => setDialogOpen(!dialogOpen)} variant="primary">
-      {dialogOpen ? 'Hide' : 'Show'} dialog
-    </Button>
-  );
-
-  return (
-    <>
-      {!dialogOpen && openButton}
-      {dialogOpen && (
-        <ModalDialog buttons={buttons} {...dialogProps} onClose={closeDialog}>
-          {children}
-        </ModalDialog>
-      )}
-    </>
-  );
-}
-
 export default function SharedAnnotationsPrototypePage() {
   return (
     <Library.Page
-      title="Re-using annotations in copied course assignments"
+      title="Sharing annotations with all assignment participants"
       intro={
-        <>
-          {' '}
-          <p>
-            Give instructors the ability to create and manage{' '}
-            <b className="font-semibold">course-shared content</b> that all
-            course participants can see regardless of section group membership.
-            Separately, provide instructors the ability to{' '}
-            <b className="font-semibold">pin content</b> such that it shows up
-            at the top of sidebar on every tab.
-          </p>
-          <p>
-            On first launch, or when editing settings for an assignment in a
-            copied course, give the instructor the option to{' '}
-            <b className="font-semibold">
-              copy all of the course-shared annotations they created in the
-              source assignment
-            </b>{' '}
-            to the copied assignment.
-          </p>
-        </>
+        <p>
+          Give instructors the ability to create and manage{' '}
+          <b className="font-semibold">course-shared content</b> that all
+          assignment participants can see regardless of section group
+          membership. Separately, provide instructors the ability to{' '}
+          <b className="font-semibold">pin content</b> such that it shows up at
+          the top of sidebar on every tab.
+        </p>
       }
     >
       <Library.Section>
@@ -215,39 +172,13 @@ export default function SharedAnnotationsPrototypePage() {
           low-fidelity wireframes to demonstrate UX and flow intent. They are
           not intended to represent polished design.
         </Library.Callout>
-        <Library.Section title="User stories">
-          <p>
-            The low-fidelity UI sketches in this document attempt to address the{' '}
-            <a href="https://docs.google.com/document/d/1jrWGqRaCab-jhqrHjSEQXjOzMo8JGBPJz3BdYec_Zk0">
-              user stories in this document
-            </a>{' '}
-            (access limited to Hypothesis team).
-          </p>
-        </Library.Section>
-        <p>As broken down here, there are three implied projects:</p>
-        <ol start={1}>
-          <li>Course-shared content</li>
-          <li>Pinned content</li>
-          <li>Annotation re-use for copied course assignments</li>
-        </ol>
-        <p>
-          <i>Pinned content</i> is independent functionality and could be
-          deferred if desired. <i>Annotation re-use</i> depends on{' '}
-          <i>course-shared content</i>.
-        </p>
-      </Library.Section>
-      <Library.Section
-        title="1. Course-shared content"
-        intro={
+        <Library.Section title="Creating and managing content shared to all participants">
           <p>
             An instructor may create top-level annotations that are visible to
-            everyone in the course, regardless of which section group they
-            belong to. An instructor may edit an annotation and move it into or
-            out of this “all-participants” group.
+            everyone in the assignment, regardless of which segment they belong
+            to. An instructor may edit an annotation and change its sharing
+            target.
           </p>
-        }
-      >
-        <Library.Section title="Creating and managing course-shared content">
           <Library.Section title="User interface: Creating or editing an annotation">
             <p>
               We might be able to extend the existing annotation-publish
@@ -262,61 +193,29 @@ export default function SharedAnnotationsPrototypePage() {
             </Library.Demo>
           </Library.Section>
 
-          <Library.Section title="User interface: When an annotation has replies">
-            <p>
-              It may be difficult technically and logically to deal with moving
-              annotations between course-shared and section-group-only once they
-              have replies. If that is the case, we could restrict moving an
-              annotation once it has replies.
-            </p>
-
-            <Library.Demo title="One option">
-              <div className="text-[13px] leading-none h-[200px]">
-                <FakeAnnotationPublishControl group="Section 1" noSharing />
-              </div>
-            </Library.Demo>
-
-            <Library.Demo title="Another option">
-              <div className="text-[13px] leading-none h-[200px]">
-                <FakeAnnotationPublishControl
-                  group="Section 1"
-                  noSharing
-                  noSharingMessage={'Annotations with replies cannot be moved'}
-                />
-              </div>
-            </Library.Demo>
-          </Library.Section>
-
           <Library.Section title="User interface: Improving experience in the future">
             <p>
-              It might be possible to consolidate some annotation actions into a{' '}
-              {'"manage-annotation menu"'} at the top right of a top-level
-              annotation card. And we could to distinguish between moving and
-              copying.
+              In the future, we might provide both share/move and copy options
+              for a root-level annotation.
             </p>
             <p>
-              This gives the user an option to copy a top-level annotation that
-              they authored. Annotations with replies could be copied but not
-              moved (replies would not get copied).
+              One option: it might be possible to consolidate some annotation
+              actions into a {'"manage-annotation menu"'} at the top right of a
+              top-level annotation card.
             </p>
             <Library.Demo title="Annotation card with context menu">
               <FakeSidebar>
                 <FakeAnnotation isOwn withManageMenu />
               </FakeSidebar>
             </Library.Demo>
-
-            <Library.Demo title="Annotation (with replies) and context menu">
-              <FakeSidebar>
-                <FakeAnnotation hasReplies isOwn withManageMenu />
-              </FakeSidebar>
-            </Library.Demo>
           </Library.Section>
         </Library.Section>
 
-        <Library.Section title="Displaying course-shared content">
+        <Library.Section title="Displaying shared content">
           <p>
-            Content visible to all course participants should be “merged into”
-            the annotation threads for the active group (section/reading group
+            Content visible to all assignment participants should be{' '}
+            {'"merged into"'}
+            the annotation threads for the active segment (section/reading group
             as indicated by the group selector in the top bar), but it should be
             easy to distinguish which annotation threads are shared to all
             participants.
@@ -346,15 +245,15 @@ export default function SharedAnnotationsPrototypePage() {
       </Library.Section>
 
       <Library.Section
-        title="2. Pinned Content"
+        title="Possible future feature: pinning content"
         intro={
           <p>
-            A top-level annotation can be “pinned” by authorized users, which
-            makes the annotation(s) show up at the top of the sidebar above the
-            annotation-type tabs at all times. This feature could help with the
-            use case of instructors wanting to put certain annotations front and
-            center, or provide instructions or prompts for the assignment as a
-            whole.{' '}
+            A top-level annotation can be {'"pinned"'} by authorized users,
+            which makes the annotation(s) show up at the top of the sidebar
+            above the annotation-type tabs at all times. This feature could help
+            with the use case of instructors wanting to put certain annotations
+            front and center, or provide instructions or prompts for the
+            assignment as a whole.{' '}
           </p>
         }
       >
@@ -401,47 +300,6 @@ export default function SharedAnnotationsPrototypePage() {
                 <FakeAnnotation />
                 <FakeAnnotation isOwn isShared />
               </FakeSidebar>
-            </Library.Demo>
-          </Library.Section>
-        </Library.Section>
-      </Library.Section>
-
-      <Library.Section
-        title="3. Re-using content in copied course assignments"
-        intro={
-          <p>
-            An instructor copies a course. Afterwards, they have the option to{' '}
-            <b>
-              copy over their own annotation content that was shared to all
-              participants
-            </b>{' '}
-            on an assignment-by-assignment basis. They could then edit or remove
-            any that they want to change or delete.
-          </p>
-        }
-      >
-        <Library.Section title="Copying annotations on first launch">
-          <Library.Section title="User interface: Modal on first launch">
-            <Library.Demo>
-              <ModalDialog_
-                title="Re-use content for this assignment?"
-                buttons={<Button variant="primary">Continue</Button>}
-              >
-                <p>
-                  It looks like this assignment was copied from another course.
-                  You can re-use your shared content in this assignment.
-                </p>
-                <div className="border-b" />
-                <Checkbox>Copy shared annotations to this assignment</Checkbox>
-                <div className="border-b" />
-                <p className="text-xs">
-                  <em>
-                    Only your annotations shared with all course participants
-                    will be copied. Replies are not copied. You can edit or
-                    remove individual copied annotations at any time.
-                  </em>
-                </p>
-              </ModalDialog_>
             </Library.Demo>
           </Library.Section>
         </Library.Section>


### PR DESCRIPTION
Update the prototype page for sharing annotations in LMS assignments to account for decisions made during the PRD process. Leave pinning sketches in place to guide possible future discussions.