### PR TITLE
Quality pass: fix small inconsistencies in pattern-library docs

### DIFF
--- a/src/pattern-library/components/patterns/data/DataTablePage.tsx
+++ b/src/pattern-library/components/patterns/data/DataTablePage.tsx
@@ -203,6 +203,13 @@ export default function DataTablePage() {
 
         <Library.Pattern title="Component API">
           <p>
+            <code>DataTable</code> accepts all standard{' '}
+            <Library.Link href="/using-components#composite-components-api">
+              composite component props
+            </Library.Link>
+            .
+          </p>
+          <p>
             <code>rows</code>, <code>columns</code> and <code>title</code> are
             required.
           </p>
@@ -481,16 +488,14 @@ export default function DataTablePage() {
             </Library.Demo>
           </Library.Example>
 
-          <Library.Example title="title">
+          <Library.Example title="...htmlAttributes">
             <Library.Info>
               <Library.InfoItem label="description">
-                A title used for accessibility purposes.
+                <code>DataTable</code> accepts HTML element attributes except
+                those detailed below.
               </Library.InfoItem>
               <Library.InfoItem label="type">
-                <code>string</code>
-              </Library.InfoItem>
-              <Library.InfoItem label="required">
-                <code>true</code>
+                <code>{`Omit<JSX.HTMLAttributes<HTMLElement>, 'size' | 'rows' | 'role' | 'loading'>`}</code>
               </Library.InfoItem>
             </Library.Info>
           </Library.Example>

--- a/src/pattern-library/components/patterns/data/IconsPage.tsx
+++ b/src/pattern-library/components/patterns/data/IconsPage.tsx
@@ -43,7 +43,7 @@ export default function IconsPage() {
         </Library.Pattern>
 
         <Library.Pattern title="Component API">
-          <Library.Example title="...svgProps">
+          <Library.Example title="...htmlProps">
             <Library.Callout>
               Unlike other components in this package, Icon components take{' '}
               <code>className</code>, not <code>classes</code>.

--- a/src/pattern-library/components/patterns/data/ScrollBoxPage.tsx
+++ b/src/pattern-library/components/patterns/data/ScrollBoxPage.tsx
@@ -43,8 +43,11 @@ export default function ScrollBoxPage() {
 
         <Library.Pattern title="Component API">
           <p>
-            <code>ScrollBox</code> takes all standard props from the composite
-            component API.
+            <code>ScrollBox</code> accepts all standard{' '}
+            <Library.Link href="/using-components#composite-components-api">
+              composite component props
+            </Library.Link>
+            .
           </p>
           <Library.Example title="borderless">
             <Library.Info>
@@ -135,8 +138,11 @@ export default function ScrollBoxPage() {
 
         <Library.Pattern title="Component API">
           <p>
-            <code>Scroll</code> takes all standard props from the presentational
-            component API.
+            <code>Scroll</code> accepts all standard{' '}
+            <Library.Link href="/using-components#presentational-components-api">
+              presentational component props
+            </Library.Link>
+            .
           </p>
           <Library.Example title="variant">
             <Library.Info>
@@ -163,6 +169,17 @@ export default function ScrollBoxPage() {
                 </Scroll>
               </div>
             </Library.Demo>
+          </Library.Example>
+
+          <Library.Example title="...htmlAttributes">
+            <Library.Info>
+              <Library.InfoItem label="description">
+                <code>Scroll</code> accepts HTML element attributes
+              </Library.InfoItem>
+              <Library.InfoItem label="type">
+                <code>{`JSX.HTMLAttributes<HTMLElement>`}</code>
+              </Library.InfoItem>
+            </Library.Info>
           </Library.Example>
         </Library.Pattern>
       </Library.Section>
@@ -191,6 +208,26 @@ export default function ScrollBoxPage() {
                 </Scroll>
               </div>
             </Library.Demo>
+          </Library.Example>
+        </Library.Pattern>
+
+        <Library.Pattern title="Component API">
+          <p>
+            <code>ScrollContent</code> accepts all standard{' '}
+            <Library.Link href="/using-components#presentational-components-api">
+              presentational component props
+            </Library.Link>
+            .
+          </p>
+          <Library.Example title="...htmlAttributes">
+            <Library.Info>
+              <Library.InfoItem label="description">
+                <code>Scroll</code> accepts HTML element attributes
+              </Library.InfoItem>
+              <Library.InfoItem label="type">
+                <code>{`JSX.HTMLAttributes<HTMLDivElement>`}</code>
+              </Library.InfoItem>
+            </Library.Info>
           </Library.Example>
         </Library.Pattern>
       </Library.Section>
@@ -233,6 +270,13 @@ export default function ScrollBoxPage() {
         </Library.Pattern>
 
         <Library.Pattern title="Component API">
+          <p>
+            <code>ScrollContainer</code> accepts all standard{' '}
+            <Library.Link href="/using-components#presentational-components-api">
+              presentational component props
+            </Library.Link>
+            .
+          </p>
           <Library.Example title="borderless">
             <Library.Info>
               <Library.InfoItem label="description">
@@ -260,6 +304,17 @@ export default function ScrollBoxPage() {
                 </ScrollContainer>
               </div>
             </Library.Demo>
+          </Library.Example>
+
+          <Library.Example title="...htmlAttributes">
+            <Library.Info>
+              <Library.InfoItem label="description">
+                <code>ScrollContainer</code> accepts HTML element attributes
+              </Library.InfoItem>
+              <Library.InfoItem label="type">
+                <code>{`JSX.HTMLAttributes<HTMLDivElement>`}</code>
+              </Library.InfoItem>
+            </Library.Info>
           </Library.Example>
         </Library.Pattern>
       </Library.Section>

--- a/src/pattern-library/components/patterns/data/TablePage.tsx
+++ b/src/pattern-library/components/patterns/data/TablePage.tsx
@@ -138,10 +138,11 @@ export default function TablePage() {
         </Library.Pattern>
 
         <Library.Pattern title="Component API">
-          <p>
-            <code>Table</code> takes all standard props from the presentational
-            component API.
-          </p>
+          <code>Table</code> accepts all standard{' '}
+          <Library.Link href="/using-components#presentational-components-api">
+            presentational component props
+          </Library.Link>
+          .
           <Library.Example title="stickyHeader">
             <Library.Info>
               <Library.InfoItem label="description">
@@ -222,7 +223,6 @@ export default function TablePage() {
               </div>
             </Library.Demo>
           </Library.Example>
-
           <Library.Example title="interactive">
             <Library.Info>
               <Library.InfoItem label="description">
@@ -275,7 +275,6 @@ export default function TablePage() {
               </Table>
             </Library.Demo>
           </Library.Example>
-
           <Library.Example title="...htmlAttributes">
             <Library.Info>
               <Library.InfoItem label="description">

--- a/src/pattern-library/components/patterns/data/ThumbnailPage.tsx
+++ b/src/pattern-library/components/patterns/data/ThumbnailPage.tsx
@@ -84,8 +84,11 @@ export default function ThumbnailPage() {
 
         <Library.Pattern title="Component API">
           <p>
-            <code>Thumbnail</code> takes all standard props from the composite
-            component API.
+            <code>Thumbnail</code> accepts all standard{' '}
+            <Library.Link href="/using-components#composite-components-api">
+              composite component props
+            </Library.Link>
+            .
           </p>
 
           <Library.Example title="borderless">
@@ -270,6 +273,17 @@ export default function ThumbnailPage() {
                 </div>
               </div>
             </Library.Demo>
+          </Library.Example>
+
+          <Library.Example title="...htmlAttributes">
+            <Library.Info>
+              <Library.InfoItem label="description">
+                <code>Thubmnail</code> accepts HTML element attributes
+              </Library.InfoItem>
+              <Library.InfoItem label="type">
+                <code>{`Omit<JSX.HTMLAttributes<HTMLElement>, 'size' | 'loading' | 'placeholder'>`}</code>
+              </Library.InfoItem>
+            </Library.Info>
           </Library.Example>
         </Library.Pattern>
       </Library.Section>

--- a/src/pattern-library/components/patterns/feedback/DialogPage.tsx
+++ b/src/pattern-library/components/patterns/feedback/DialogPage.tsx
@@ -195,10 +195,13 @@ export default function DialogPage() {
           </Library.Demo>
         </Library.Pattern>
 
-        <Library.Pattern title="ComponentAPI">
+        <Library.Pattern title="Component API">
           <p>
-            <code>Dialog</code> accepts all standard composite component API
-            props.
+            <code>Dialog</code> accepts all standard{' '}
+            <Library.Link href="/using-components#composite-components-api">
+              composite component props
+            </Library.Link>
+            .
           </p>
 
           <Library.Example title="title">

--- a/src/pattern-library/components/patterns/feedback/DialogPage.tsx
+++ b/src/pattern-library/components/patterns/feedback/DialogPage.tsx
@@ -201,6 +201,20 @@ export default function DialogPage() {
             props.
           </p>
 
+          <Library.Example title="title">
+            <Library.Info>
+              <Library.InfoItem label="description">
+                A <code>title</code> is required for all dialogs.
+              </Library.InfoItem>
+              <Library.InfoItem label="type">
+                <code>string</code>
+              </Library.InfoItem>
+              <Library.InfoItem label="required">
+                <code>true</code>
+              </Library.InfoItem>
+            </Library.Info>
+          </Library.Example>
+
           <Library.Example title="classes">
             <Library.Info>
               <Library.InfoItem label="description">
@@ -419,7 +433,7 @@ export default function DialogPage() {
                 <code>Dialog</code>).
               </Library.InfoItem>
               <Library.InfoItem label="type">
-                <code>TransitionComponent</code>
+                <code>{`Omit<PanelProps, 'fullWidthHeader'>`}</code>
               </Library.InfoItem>
             </Library.Info>
           </Library.Example>
@@ -685,6 +699,20 @@ export default function DialogPage() {
           </Library.Example>
         </Library.Pattern>
         <Library.Pattern title="ComponentAPI">
+          <Library.Example title="title">
+            <Library.Info>
+              <Library.InfoItem label="description">
+                A <code>title</code> is required for all modal dialogs.
+              </Library.InfoItem>
+              <Library.InfoItem label="type">
+                <code>string</code>
+              </Library.InfoItem>
+              <Library.InfoItem label="required">
+                <code>true</code>
+              </Library.InfoItem>
+            </Library.Info>
+          </Library.Example>
+
           <Library.Example title="disableCloseOnEscape">
             <Library.Info>
               <Library.InfoItem label="description">
@@ -812,7 +840,7 @@ export default function DialogPage() {
             </p>
           </Library.Example>
 
-          <Library.Example title="...dialogProps">
+          <Library.Example title="...dialogAndPanelProps">
             <Library.Info>
               <Library.InfoItem label="description">
                 Props forwarded to <code>Dialog</code> and <code>Panel</code>.
@@ -834,6 +862,9 @@ export default function DialogPage() {
                     <code>true</code> for all dialogs
                   </li>
                 </ul>
+              </Library.InfoItem>
+              <Library.InfoItem label="type">
+                <code>{`Omit<DialogProps, 'restoreFocus' | 'closeOnEscape'>`}</code>
               </Library.InfoItem>
             </Library.Info>
           </Library.Example>

--- a/src/pattern-library/components/patterns/input/CheckboxPage.tsx
+++ b/src/pattern-library/components/patterns/input/CheckboxPage.tsx
@@ -153,7 +153,7 @@ const handleControlledChange = e => {
             </Library.InfoItem>
           </Library.Info>
         </Library.Example>
-        <Library.Example title="...inputProps">
+        <Library.Example title="...htmlAttributes">
           <Library.Info>
             <Library.InfoItem label="description">
               <code>Checkbox</code> accepts HTML attributes for input elements

--- a/src/pattern-library/components/patterns/input/OptionButtonPage.tsx
+++ b/src/pattern-library/components/patterns/input/OptionButtonPage.tsx
@@ -119,22 +119,9 @@ export default function OptionButtonPage() {
                 </Library.Link>{' '}
                 component API props. Styling API props are not forwarded.
               </Library.InfoItem>
-              <Library.InfoItem label="props">
-                All <code>Button</code> props except styling API props:
-                <ul>
-                  <li>
-                    <code>classes</code>
-                  </li>
-                  <li>
-                    <code>unstyled</code>
-                  </li>
-                  <li>
-                    <code>variant</code>
-                  </li>
-                  <li>
-                    <code>size</code>
-                  </li>
-                </ul>
+
+              <Library.InfoItem label="type">
+                <code>{`Omit<ButtonProps, 'size' | 'unstyled' | 'classes' | 'variant'>`}</code>
               </Library.InfoItem>
             </Library.Info>
           </Library.Example>

--- a/src/pattern-library/components/patterns/navigation/TabPage.tsx
+++ b/src/pattern-library/components/patterns/navigation/TabPage.tsx
@@ -265,6 +265,23 @@ export default function TabPage() {
               </Library.InfoItem>
             </Library.Info>
           </Library.Example>
+
+          <Library.Example title="...buttonProps">
+            <Library.Info>
+              <Library.InfoItem label="description">
+                <code>Tab</code> forwards{' '}
+                <Library.Link href="/input-button">
+                  <code>Button</code>
+                </Library.Link>{' '}
+                component API props, including HTML attributes. Styling API
+                props are not forwarded.
+              </Library.InfoItem>
+
+              <Library.InfoItem label="type">
+                <code>{`Omit<ButtonProps, 'variant' | 'size' | 'unstyled'>`}</code>
+              </Library.InfoItem>
+            </Library.Info>
+          </Library.Example>
         </Library.Pattern>
       </Library.Section>
       <Library.Section


### PR DESCRIPTION
This eye-meltingly dull housekeeping PR resolves a few inconsistencies in naming and linking in  pattern-library component document.

It ensures all "Component API" sections link to the relevant section of common API docs, and that rest props are named more consistently.

This should suffice to:

Fixes https://github.com/hypothesis/frontend-shared/issues/1030

That is, at this point, I feel like the section structure and naming are standardized enough that we could generate permalinks and it wouldn't be disastrous.