### PR TITLE
Add `Callout` presentational component

### DIFF
--- a/src/components/feedback/Callout.tsx
+++ b/src/components/feedback/Callout.tsx
@@ -1,0 +1,122 @@
+import classnames from 'classnames';
+import type { JSX } from 'preact';
+
+import type { PresentationalProps } from '../../types';
+import type { IconComponent } from '../../types';
+import { downcastRef } from '../../util/typing';
+import { CautionIcon, CheckIcon, CancelIcon } from '../icons';
+
+type ComponentProps = {
+  icon?: IconComponent;
+  status?: 'notice' | 'error' | 'success';
+
+  size?: 'sm' | 'md' | 'lg' | 'custom';
+  variant?: 'outlined' | 'raised' | 'custom';
+  unstyled?: boolean;
+};
+
+type HTMLAttributes = Omit<JSX.HTMLAttributes<HTMLElement>, 'size' | 'icon'>;
+
+export type CalloutProps = PresentationalProps &
+  ComponentProps &
+  HTMLAttributes;
+
+/**
+ * Render a banner-like alert message with corresponding icon and coloring
+ */
+const Callout = function Callout({
+  children,
+  classes,
+  elementRef,
+
+  icon: Icon,
+  status = 'notice',
+
+  size = 'md',
+  variant = 'outlined',
+  unstyled = false,
+
+  ...htmlAttributes
+}: CalloutProps) {
+  const styled = !unstyled;
+  const themed = styled && variant !== 'custom';
+  const sized = styled && size !== 'custom';
+
+  let StatusIcon = Icon;
+  if (!StatusIcon) {
+    switch (status) {
+      case 'success':
+        StatusIcon = CheckIcon;
+        break;
+      case 'error':
+        StatusIcon = CancelIcon;
+        break;
+      default:
+        StatusIcon = CautionIcon;
+        break;
+    }
+  }
+
+  // Only render an icon if no custom styling API props have been set.
+  const withIcon = themed && sized;
+
+  return (
+    <div
+      data-component="Callout"
+      {...htmlAttributes}
+      ref={downcastRef(elementRef)}
+      className={classnames(
+        styled && 'flex items-center border',
+        themed && {
+          'rounded-sm border': true,
+          'shadow hover:shadow-md cursor-pointer': variant === 'raised',
+          'border-yellow-notice': status === 'notice',
+          'border-green-success': status === 'success',
+          'border-red-error': status === 'error',
+        },
+        // Set background color, but only if rendering an icon
+        themed && {
+          'bg-yellow-notice': status === 'notice' && withIcon,
+          'bg-green-success': status === 'success' && withIcon,
+          'bg-red-error': status === 'error' && withIcon,
+          'bg-white': !withIcon,
+        },
+        classes
+      )}
+    >
+      {withIcon && (
+        <div
+          className={classnames({
+            'p-2': size === 'md',
+            'p-1.5': size === 'sm',
+            'p-3': size === 'lg',
+          })}
+        >
+          <StatusIcon
+            data-testid="callout-icon"
+            className={classnames('text-white', {
+              'w-[1.25em] h-[1.25em]': size === 'md', // default
+              'w-[0.85em] h-[0.85em]': size === 'sm',
+              'w-[1.5em] h-[1.5em]': size === 'lg',
+            })}
+          />
+        </div>
+      )}
+      <div
+        className={classnames(
+          sized && {
+            'p-2': size === 'md', // default
+            'py-1.5 px-2': size === 'sm',
+            'p-3': size === 'lg',
+          },
+          styled && 'grow',
+          themed && 'bg-white'
+        )}
+      >
+        {children}
+      </div>
+    </div>
+  );
+};
+
+export default Callout;

--- a/src/components/feedback/index.ts
+++ b/src/components/feedback/index.ts
@@ -9,3 +9,5 @@ export type { ModalProps } from './Modal';
 export type { ModalDialogProps } from './ModalDialog';
 export type { SpinnerProps } from './Spinner';
 export type { SpinnerOverlayProps } from './SpinnerOverlay';
+export { default as Callout } from './Callout';
+export type { CalloutProps } from './Callout';

--- a/src/components/feedback/test/Callout-test.js
+++ b/src/components/feedback/test/Callout-test.js
@@ -1,0 +1,80 @@
+import { mount } from 'enzyme';
+
+import {
+  testPresentationalComponent,
+  testStyledComponent,
+} from '../../test/common-tests';
+import Callout from '../Callout';
+
+const createComponent = (Component, props = {}) => {
+  return mount(<Component {...props}>This is a callout</Component>);
+};
+
+function FakeIcon(props) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="16"
+      height="16"
+      aria-hidden="true"
+      viewBox="0 0 16 16"
+      data-component="FakeIcon"
+      {...props}
+    >
+      <g fill="none">
+        <path d="M0 0h16v16H0z" />
+        <path stroke="currentColor" d="M10 12 6 8l4-4" />
+      </g>
+    </svg>
+  );
+}
+
+describe('Callout', () => {
+  testPresentationalComponent(Callout);
+  // This component does support the `size` prop, but setting it to `custom`
+  // does not change classes applied to the primary element, which makes the
+  // common size-prop test fail. Size is tested below.
+  testStyledComponent(Callout, { supportedProps: ['variant', 'unstyled'] });
+
+  describe('icons', () => {
+    it('renders appropriate icon for status', () => {
+      const notice = createComponent(Callout, { status: 'notice' });
+      const error = createComponent(Callout, { status: 'error' });
+      const success = createComponent(Callout, { status: 'success' });
+
+      assert.isTrue(notice.find('CautionIcon').exists());
+      assert.isTrue(error.find('CancelIcon').exists());
+      assert.isTrue(success.find('CheckIcon').exists());
+    });
+
+    it('renders a custom icon if provided', () => {
+      const wrapper = createComponent(Callout, {
+        icon: FakeIcon,
+        status: 'error',
+      });
+      assert.isTrue(wrapper.find('[data-component="FakeIcon"]').exists());
+    });
+
+    it('does not render an icon if styling is customized', () => {
+      const iconSelector = '[data-testid="callout-icon"]';
+      const defaultStyled = createComponent(Callout);
+      const unsized = createComponent(Callout, { size: 'custom' });
+      const unthemed = createComponent(Callout, { variant: 'custom' });
+      const unstyled = createComponent(Callout, { unstyled: true });
+      const withCustomIcon = createComponent(Callout, {
+        unstyled: true,
+        icon: FakeIcon,
+      });
+
+      assert.isTrue(defaultStyled.find(iconSelector).exists());
+
+      assert.isFalse(unsized.find(iconSelector).exists());
+      assert.isFalse(unthemed.find(iconSelector).exists());
+      assert.isFalse(unstyled.find(iconSelector).exists());
+      assert.isFalse(withCustomIcon.find(iconSelector).exists());
+      assert.isFalse(
+        withCustomIcon.find('[data-component="FakeIcon"]').exists()
+      );
+    });
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -123,3 +123,5 @@ export type {
 
 // Deprecated
 export { useElementShouldClose } from './hooks/use-element-should-close';
+export { Callout } from './components/feedback';
+export type { CalloutProps } from './components/feedback';

--- a/src/pattern-library/components/patterns/feedback/CalloutPage.tsx
+++ b/src/pattern-library/components/patterns/feedback/CalloutPage.tsx
@@ -1,0 +1,184 @@
+import { Callout, ProfileIcon } from '../../../../';
+import Library from '../../Library';
+
+export default function CalloutPage() {
+  return (
+    <Library.Page
+      title="Callout"
+      intro={
+        <p>
+          Callout is a presentational component that can be used for alerts,
+          banners or toast messages.
+        </p>
+      }
+    >
+      <Library.Section>
+        <Library.Pattern>
+          <Library.Usage componentName="Callout" />
+          <Library.Example>
+            <Library.Demo withSource title="Basic Callout">
+              <div className="flex flex-col gap-y-4">
+                <Callout status="notice">
+                  A callout with (default) notice status.
+                </Callout>
+                <Callout status="success">
+                  A callout with a success message.
+                </Callout>
+                <Callout status="error">
+                  A callout with an error message.
+                </Callout>
+              </div>
+            </Library.Demo>
+          </Library.Example>
+        </Library.Pattern>
+
+        <Library.Pattern title="Component API">
+          <p>
+            <code>Callout</code> accepts all standard{' '}
+            <Library.Link href="/using-components#presentational-components-api">
+              presentational component props
+            </Library.Link>
+            .
+          </p>
+
+          <Library.Example title="icon">
+            <Library.Info>
+              <Library.InfoItem label="description">
+                Custom icon to display in callout.
+              </Library.InfoItem>
+              <Library.InfoItem label="type">
+                <code>{`IconComponent`}</code>
+              </Library.InfoItem>
+            </Library.Info>
+
+            <Library.Demo title="Callout with custom icon" withSource>
+              <Callout icon={ProfileIcon} status="success">
+                This callout has a custom icon
+              </Callout>
+            </Library.Demo>
+          </Library.Example>
+
+          <Library.Example title="status">
+            <Library.Info>
+              <Library.InfoItem label="description">
+                Will theme the callout with an appropriate icon and coloring
+                (unless overridden by the <code>icon</code> prop or Styling API
+                props).
+              </Library.InfoItem>
+              <Library.InfoItem label="type">
+                <code>{`'notice' | 'success' | 'error'`}</code>
+              </Library.InfoItem>
+              <Library.InfoItem label="default">
+                <code>{`'notice'`}</code>
+              </Library.InfoItem>
+            </Library.Info>
+          </Library.Example>
+
+          <Library.Example title="...htmlAttributes">
+            <Library.Info>
+              <Library.InfoItem label="description">
+                <code>Callout</code> accepts HTML attribute props applicable to{' '}
+                <code>HTMLElement</code>.
+              </Library.InfoItem>
+              <Library.InfoItem label="type">
+                <code>{`Omit<JSX.HTMLAttributes<HTMLElement>, 'size' | 'icon'>`}</code>
+              </Library.InfoItem>
+            </Library.Info>
+          </Library.Example>
+        </Library.Pattern>
+
+        <Library.Pattern title="Styling API">
+          <p>
+            <code>Callout</code> accepts the following props from the{' '}
+            <Library.Link href="/using-components#presentational-components-styling-api">
+              presentational component styling API
+            </Library.Link>
+            .
+          </p>
+
+          <Library.Example title="variant">
+            <Library.Info>
+              <Library.InfoItem label="description">
+                Set the <code>Callout</code> theming.
+              </Library.InfoItem>
+              <Library.InfoItem label="type">
+                <code>{`'outlined' | 'raised' | 'custom'`}</code>
+              </Library.InfoItem>
+              <Library.InfoItem label="default">
+                <code>{`'outlined'`}</code>
+              </Library.InfoItem>
+            </Library.Info>
+            <Library.Demo title="Callout variants" withSource>
+              <div className="flex flex-col gap-y-4">
+                <Callout variant="outlined">
+                  This is an <strong>outlined</strong> (default) callout.
+                </Callout>
+                <Callout variant="raised">
+                  This is a <strong>raised</strong> callout, which provides
+                  dimensionality and interactive cursor.
+                </Callout>
+              </div>
+            </Library.Demo>
+
+            <Library.Demo title="Callout with custom variant" withSource>
+              <Callout variant="custom">
+                Note that no icon is rendered when variant is{' '}
+                <code>{`'custom'`}</code>.
+              </Callout>
+            </Library.Demo>
+          </Library.Example>
+
+          <Library.Example title="size">
+            <Library.Info>
+              <Library.InfoItem label="description">
+                Set the relative internal sizing of the callout. Set to{' '}
+                <code>{`'custom'`}</code> to disable sizing classes and set your
+                own with <code>classes</code>.
+              </Library.InfoItem>
+              <Library.InfoItem label="type">
+                <code>{`'sm' | 'md' | 'lg' | 'custom'`}</code>
+              </Library.InfoItem>
+              <Library.InfoItem label="default">
+                <code>{`'md'`}</code>
+              </Library.InfoItem>
+            </Library.Info>
+
+            <Library.Demo title="Callout sizes" withSource>
+              <div className="flex flex-col gap-y-4">
+                <Callout status="success" size="sm">
+                  A callout with a small size.
+                </Callout>
+                <Callout status="success" size="md">
+                  A callout with a medium size.
+                </Callout>
+                <Callout status="success" size="lg">
+                  A callout with a large size.
+                </Callout>
+
+                <Callout status="success" size="custom" classes="p-4">
+                  Note that no icon is rendered if size is{' '}
+                  <code>{`'custom'`}</code>
+                </Callout>
+              </div>
+            </Library.Demo>
+          </Library.Example>
+
+          <Library.Example title="unstyled">
+            <Library.Info>
+              <Library.InfoItem label="description">
+                Set this to disable all styling and provide your own styling
+                with <code>classes</code>. No icon will be rendered.
+              </Library.InfoItem>
+              <Library.InfoItem label="type">
+                <code>boolean</code>
+              </Library.InfoItem>
+              <Library.InfoItem label="default">
+                <code>false</code>
+              </Library.InfoItem>
+            </Library.Info>
+          </Library.Example>
+        </Library.Pattern>
+      </Library.Section>
+    </Library.Page>
+  );
+}

--- a/src/pattern-library/routes.ts
+++ b/src/pattern-library/routes.ts
@@ -11,6 +11,7 @@ import IconsPage from './components/patterns/data/IconsPage';
 import ScrollBoxPage from './components/patterns/data/ScrollBoxPage';
 import TablePage from './components/patterns/data/TablePage';
 import ThumbnailPage from './components/patterns/data/ThumbnailPage';
+import CalloutPage from './components/patterns/feedback/CalloutPage';
 import DialogPage from './components/patterns/feedback/DialogPage';
 import ModalPage from './components/patterns/feedback/ModalPage';
 import SpinnerPage from './components/patterns/feedback/SpinnerPage';
@@ -130,6 +131,12 @@ const routes: PlaygroundRoute[] = [
     group: 'data',
     component: ThumbnailPage,
     route: '/data-thumbnail',
+  },
+  {
+    title: 'Callout',
+    group: 'feedback',
+    component: CalloutPage,
+    route: '/feedback-callout',
   },
   {
     title: 'Dialogs',


### PR DESCRIPTION
This PR adds a new component, `Callout`, which we can use to style alert banners and toast messages. This is like toast messages without any behavior. We'll need toast messages for the video annotations app, so this is part of #1075.

Pattern-library documentation at http://localhost:4001/feedback-callout

The component styling echoes that of toast messages in the `client`. We should be able to use this component in place of [`ToastMessageItem`](https://github.com/hypothesis/client/blob/5baf673b8ec1bbdc1a5fac2b95d2749f74852d01/src/shared/components/BaseToastMessages.tsx#L29) in the `client`.

![image](https://github.com/hypothesis/frontend-shared/assets/439947/6ea985d7-af55-4041-97c1-a70a1c73fd2a)
