### PR TITLE
Allow closed state to be passed to Dialog for proper transition handling

### DIFF
--- a/src/pattern-library/components/patterns/prototype/TransitionComponentExperimentsPage.tsx
+++ b/src/pattern-library/components/patterns/prototype/TransitionComponentExperimentsPage.tsx
@@ -1,0 +1,204 @@
+import type { ComponentChildren } from 'preact';
+import { useState } from 'preact/hooks';
+import type { StateUpdater } from 'preact/hooks';
+
+import { Button, Dialog, Slider } from '../../../..';
+import Library from '../../Library';
+
+type DialogWrapperProps = {
+  children: ComponentChildren;
+  closed: boolean;
+  setClosed: StateUpdater<boolean>;
+};
+
+function DialogWrapper({ children, closed, setClosed }: DialogWrapperProps) {
+  return (
+    <div className="flex-col w-full space-y-2">
+      <Button onClick={() => setClosed(closed => !closed)} variant="primary">
+        {closed ? 'Show' : 'Hide'} dialog
+      </Button>
+      {children}
+    </div>
+  );
+}
+
+function DialogWithBrokenExternalClose() {
+  const [closed, setClosed] = useState(true);
+
+  return (
+    <DialogWrapper closed={closed} setClosed={setClosed}>
+      {!closed && (
+        <Dialog
+          title="Dialog"
+          onClose={() => setClosed(true)}
+          transitionComponent={Slider}
+        >
+          Hello world
+        </Dialog>
+      )}
+    </DialogWrapper>
+  );
+}
+
+function FixedDialog({ initiallyOpen = false, restoreFocus = false }) {
+  const [closed, setClosed] = useState(!initiallyOpen);
+
+  return (
+    <DialogWrapper closed={closed} setClosed={setClosed}>
+      <Dialog
+        title="Dialog"
+        onClose={() => setClosed(true)}
+        transitionComponent={Slider}
+        closed={closed}
+        initialFocus="manual"
+        restoreFocus={restoreFocus}
+      >
+        Hello world
+      </Dialog>
+    </DialogWrapper>
+  );
+}
+
+function NoTransitionDialog({ initiallyOpen = false, restoreFocus = false }) {
+  const [closed, setClosed] = useState(!initiallyOpen);
+
+  return (
+    <DialogWrapper closed={closed} setClosed={setClosed}>
+      <Dialog
+        title="Dialog"
+        onClose={() => setClosed(true)}
+        closed={closed}
+        initialFocus="manual"
+        restoreFocus={restoreFocus}
+      >
+        Hello world
+      </Dialog>
+    </DialogWrapper>
+  );
+}
+
+function DynamicallyRenderedDialog({
+  initiallyOpen = false,
+  restoreFocus = false,
+}) {
+  const [closed, setClosed] = useState(!initiallyOpen);
+
+  return (
+    <DialogWrapper closed={closed} setClosed={setClosed}>
+      {!closed && (
+        <Dialog
+          title="Dialog"
+          onClose={() => setClosed(true)}
+          initialFocus="manual"
+          restoreFocus={restoreFocus}
+        >
+          Hello world
+        </Dialog>
+      )}
+    </DialogWrapper>
+  );
+}
+
+export default function TransitionComponentsExperimentsPage() {
+  return (
+    <Library.Page
+      title="Closing dialogs when wrapping a TransitionComponent"
+      intro={
+        <p>
+          Some components (like <code>Dialog</code>) support a
+          <code>TransitionComponent</code> to be provided, and change their
+          behavior when that happens, by wrapping provided <code>onClose</code>{' '}
+          callback (among other things).
+        </p>
+      }
+    >
+      <Library.Section>
+        <Library.Pattern title="Current (broken) behavior">
+          <p>
+            Currently, the transition works fine when opening the Dialog, and if
+            closed using its own close button.
+          </p>
+          <p>
+            However, if it is closed using a external toggle, the transition is
+            lost.
+          </p>
+
+          <Library.Demo>
+            <DialogWithBrokenExternalClose />
+          </Library.Demo>
+        </Library.Pattern>
+
+        <Library.Pattern title="Fixing it">
+          <p>
+            This can be fixed by using the new <code>closed</code> property,
+            which makes the <code>Dialog</code> a fully controlled component.
+          </p>
+
+          <Library.Demo>
+            <FixedDialog />
+          </Library.Demo>
+        </Library.Pattern>
+
+        <Library.Pattern title="No transition">
+          <p>
+            This change does not affect dialogs with no{' '}
+            <code>TransitionComponent</code>, which can still be conditionally
+            rendered, or <i>closed</i> via the new <code>closed</code> prop.
+          </p>
+
+          <Library.Demo title="Using close prop">
+            <NoTransitionDialog />
+          </Library.Demo>
+
+          <Library.Demo title="Dynamically rendered">
+            <DynamicallyRenderedDialog />
+          </Library.Demo>
+        </Library.Pattern>
+
+        <Library.Pattern title="Initially open">
+          <p>
+            The three combinations that work can be configured to be initially
+            open.
+          </p>
+
+          <Library.Demo title="With transition">
+            <FixedDialog initiallyOpen />
+          </Library.Demo>
+
+          <Library.Demo title="Using close prop">
+            <NoTransitionDialog initiallyOpen />
+          </Library.Demo>
+
+          <Library.Demo title="Dynamically rendered">
+            <DynamicallyRenderedDialog initiallyOpen />
+          </Library.Demo>
+        </Library.Pattern>
+
+        <Library.Pattern title="Resotre focus">
+          <p>
+            When dialogs are provided with <code>restoreFocus</code> prop, the
+            behavior should also be the same both with the new{' '}
+            <code>closed</code> prop.
+          </p>
+          <p>
+            Try interacting with the components above with the keyboard, so that
+            the focus ring is displayed and you can see how focus is restored
+            after the dialog is closed.
+          </p>
+
+          <Library.Demo title="Using close prop with transition">
+            <FixedDialog restoreFocus />
+          </Library.Demo>
+
+          <Library.Demo title="Using close prop without transition">
+            <NoTransitionDialog restoreFocus />
+          </Library.Demo>
+
+          <Library.Demo title="Dynamically rendered">
+            <DynamicallyRenderedDialog restoreFocus />
+          </Library.Demo>
+        </Library.Pattern>
+      </Library.Section>
+    </Library.Page>
+  );
+}

--- a/src/pattern-library/routes.ts
+++ b/src/pattern-library/routes.ts
@@ -33,6 +33,7 @@ import LMSContentButtonPage from './components/patterns/prototype/LMSContentButt
 import LMSContentSelectionPage from './components/patterns/prototype/LMSContentSelectionPage';
 import SharedAnnotationsPage from './components/patterns/prototype/SharedAnnotationsPage';
 import TabbedDialogPage from './components/patterns/prototype/TabbedDialogPage';
+import TransitionComponentsExperimentsPage from './components/patterns/prototype/TransitionComponentExperimentsPage';
 import SliderPage from './components/patterns/transition/SliderPage';
 
 export const componentGroups = {
@@ -271,6 +272,12 @@ const routes: PlaygroundRoute[] = [
     group: 'prototype',
     component: LMSContentSelectionPage,
     route: '/lms-content-selection',
+  },
+  {
+    title: 'Transition components experiments',
+    group: 'prototype',
+    component: TransitionComponentsExperimentsPage,
+    route: '/transition-components-experiments',
   },
 ];
 


### PR DESCRIPTION
This PR introduces some changes on how the `Dialog` handles closed state, so that it can be passed to it for proper transition handling, but in a way that we can dynamically render the `Dialog` itself from consumer code, if a `TransitionComponent` is not provided.

> **Note**
> Most of the code changes here are because of the introduction of a prototype page to experiment with the new capabilities in `Dialog`.

### How to use it

Up until now, we had to do something like this:

```tsx
const [closed, setClosed] = useState(true);

return (
  <>
    {!closed && (
      <Dialog
        title="Dialog"
        onClose={() => setClosed(true)}
        transitionComponent={Slider}
      >
        Hello world
      </Dialog>
    )}
  </>
);
```

This works, as long as `setClosed(true)` is not called from outside the `Dialog` itself.

[01 - broken.webm](https://github.com/hypothesis/frontend-shared/assets/2719332/bbc123c1-994d-46b0-a333-49edd032de3e)

In order to fix that, a new `closed` prop is introduced, letting the `Dialog` itself both wrap `onClose`, but also react to changes to `closed`, and properly handle transitions in both cases:

```tsx
const [closed, setClosed] = useState(true);

return (
  <Dialog
    title="Dialog"
    closed={closed}
    onClose={() => setClosed(true)}
    transitionComponent={Slider}
  >
    Hello world
  </Dialog>
);
```

[02 - fixed.webm](https://github.com/hypothesis/frontend-shared/assets/2719332/1f5f8818-8a60-45d9-9bd9-555f9def8926)

When no `transitionComponent` is provided, then both options above are valid.

[03 - no-transition.webm](https://github.com/hypothesis/frontend-shared/assets/2719332/d211fa2f-c2ec-4748-9854-e71337b9352d)

> **Note**
> All examples can be tested by checking out this branch and going to http://localhost:4001/transition-components-experiments.

### State change flow

The way this works is currently a bit messy (I want to put some extra thought on it), as it requires deriving two pieces of state from the new `closed` prop.

The reason we cannot use the prop "directly" is that the prop might change sooner, but we want to delay the state to actually change, if there's a transition involved.

> These are the three pieces of state involved:
>
> * `closed`: The prop that is passed from consuming code.
> * `transitionComponentVisible`: Triggers in/out transition animations if a `TransitionComponent` is provided.
> * `isClosed`: Prevents children to be rendered when `true`. Set to `true` after `closed` is set to `true`, but with a "delay" in case of transition.

This explains how the different combinations of prop and state flows work:

#### With `TransitionComponent`

```
`closed` prop set to `true` 
└── immediately set `transitionComponentVisible` to `false`
    └── `out` animation triggers
        └── after animation ends (see `onTransitionEnd`), set `isClosed` to `true`
            └── children are not rendered anymore

`closed` prop set to `false`
└── immediately set `isClosed` to `false`
    ├── children are rendered
    └── immediately set `transitionComponentVisible` to `true`
        └── `in` animation triggers
```

#### Without `TransitionComponent`

```
`closed` prop set to `true`
└── immediately set `isClosed` to `true`
    └── children are not rendered anymore

`closed` prop set to `false`
└── immediately set `isClosed` to `false`
    └── children are rendered
```

The conclusion is that from the 4 possible combinations, only the first one justifies the need to "derive" `isClosed` state from `closed` prop.

### Considerations / thoughts / next steps

* `isClosed` feels like a too vague name for the internal state. It also might be confused with the `closed` prop.
* `close` and `isClosed` are true when not visible, while `transitionComponentVisible` is true when visible. Perhaps we should make the three consistent, maybe renaming to `transitionComponentHidden`.
* ~Removing the `if (isClosed) return null` logic simplifies the rest of the interactions, but leaves some DOM nodes for preact to handle forever.~ Scratch that. Without that check, then the `close` prop does nothing when no `transitionComponent` is provided, which would make it inconsistent.
* I think there should be a way to combine `isClosed` and `transitionComponentVisible`, but haven't nailed it yet.
* If we are planning to support transition components somewhere other than the `Dialog`, we may want to extract some of the logic, but I would start by copy-pasting once, and then it will be easier to identify what needs to be reused.
