### PR TITLE
Clean up Callout exports

### DIFF
--- a/src/components/feedback/index.ts
+++ b/src/components/feedback/index.ts
@@ -1,13 +1,13 @@
+export { default as Callout } from './Callout';
 export { default as Dialog } from './Dialog';
 export { default as Modal } from './Modal';
 export { default as ModalDialog } from './ModalDialog';
 export { default as Spinner } from './Spinner';
 export { default as SpinnerOverlay } from './SpinnerOverlay';
 
+export type { CalloutProps } from './Callout';
 export type { DialogProps } from './Dialog';
 export type { ModalProps } from './Modal';
 export type { ModalDialogProps } from './ModalDialog';
 export type { SpinnerProps } from './Spinner';
 export type { SpinnerOverlayProps } from './SpinnerOverlay';
-export { default as Callout } from './Callout';
-export type { CalloutProps } from './Callout';

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,7 @@ export {
   Thumbnail,
 } from './components/data';
 export {
+  Callout,
   Dialog,
   Modal,
   ModalDialog,
@@ -84,6 +85,7 @@ export type {
 } from './components/data';
 
 export type {
+  CalloutProps,
   DialogProps,
   ModalProps,
   ModalDialogProps,
@@ -123,5 +125,3 @@ export type {
 
 // Deprecated
 export { useElementShouldClose } from './hooks/use-element-should-close';
-export { Callout } from './components/feedback';
-export type { CalloutProps } from './components/feedback';


### PR DESCRIPTION
This tiny PR fixes a cleanup oversight when adding the new `Callout` component: clean up the exports.