### PR TITLE
Extract transition component handling to useTransitionComponent hook

### DIFF
--- a/src/hooks/use-transition-component.tsx
+++ b/src/hooks/use-transition-component.tsx
@@ -1,0 +1,102 @@
+import type { ComponentChildren } from 'preact';
+import type { JSX } from 'preact';
+import { useCallback, useEffect, useState } from 'preact/hooks';
+
+import type { TransitionComponent } from '../types';
+
+type TransitionComponentOptions = {
+  closed: boolean;
+  transitionComponent?: TransitionComponent;
+  onClose?: () => void;
+  onOpen?: () => void;
+};
+
+type TransitionComponentResult = {
+  closeHandler: () => void;
+  isClosed: boolean;
+  wrapWithTransition: (children: ComponentChildren) => JSX.Element;
+};
+
+export function useTransitionComponent({
+  closed,
+  transitionComponent,
+  onClose,
+  onOpen,
+}: TransitionComponentOptions): TransitionComponentResult {
+  // TODO To properly handle closing/opening with a TransitionComponent, these
+  //  two pieces of state need to be synced with the `closed` argument.
+  //  That makes the logic hard to follow. It would be good to revisit eventually
+  const [isClosed, setIsClosed] = useState(closed);
+  const [transitionComponentVisible, setTransitionComponentVisible] =
+    useState(false);
+
+  const closeHandler = useCallback(() => {
+    if (transitionComponent) {
+      // When a TransitionComponent is provided, the actual "onClose" will be
+      // called by that component, once the "out" transition has finished
+      setTransitionComponentVisible(false);
+    } else {
+      onClose?.();
+    }
+  }, [onClose, transitionComponent]);
+
+  const onTransitionEnd = useCallback(
+    (direction: 'in' | 'out') => {
+      if (direction === 'in') {
+        onOpen?.();
+      } else {
+        setIsClosed(true);
+        onClose?.();
+      }
+    },
+    [onOpen, onClose],
+  );
+
+  useEffect(() => {
+    if (closed && transitionComponent) {
+      setTransitionComponentVisible(false);
+    } else if (closed && !transitionComponent) {
+      setIsClosed(true);
+    } else {
+      setIsClosed(false);
+    }
+
+    if (!closed && !transitionComponent) {
+      onOpen?.();
+    }
+
+    // We only want to run this effect when opened or closed.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [closed]);
+
+  useEffect(() => {
+    if (!isClosed) {
+      setTransitionComponentVisible(true);
+    }
+  }, [isClosed]);
+
+  const wrapWithTransition = useCallback(
+    (children: ComponentChildren) => {
+      if (!transitionComponent) {
+        return <>{children}</>;
+      }
+
+      const TransitionComp = transitionComponent;
+      return (
+        <TransitionComp
+          direction={transitionComponentVisible ? 'in' : 'out'}
+          onTransitionEnd={onTransitionEnd}
+        >
+          {children}
+        </TransitionComp>
+      );
+    },
+    [transitionComponent, transitionComponentVisible, onTransitionEnd],
+  );
+
+  return {
+    closeHandler,
+    isClosed,
+    wrapWithTransition,
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ export { useClickAway } from './hooks/use-click-away';
 export { useFocusAway } from './hooks/use-focus-away';
 export { useKeyPress } from './hooks/use-key-press';
 export { useSyncedRef } from './hooks/use-synced-ref';
+export { useTransitionComponent } from './hooks/use-transition-component';
 
 // Components
 export * from './components/icons';


### PR DESCRIPTION
This PR extracts all the logic to manage `TransitionComponents` from `Dialog` to a reusable hook, opening the door to use it in other places with components that can expose a similar props API, while they internally use this hook.

As a good side effect, we can extract all the complexity to internally sync state to properly manage transitions, from the `Dialog` component, making it simpler.

> **Note**
> This PR is easier to review ignoring whitespaces.