### PR TITLE
Update uses of `rounded` tailwind utilities to use default value correctly

### DIFF
--- a/src/components/feedback/Callout.tsx
+++ b/src/components/feedback/Callout.tsx
@@ -68,7 +68,7 @@ const Callout = function Callout({
       className={classnames(
         styled && 'flex items-center border',
         themed && {
-          'rounded-sm border': true,
+          'rounded border': true,
           'shadow hover:shadow-md cursor-pointer': variant === 'raised',
           'border-yellow-notice': status === 'notice',
           'border-green-success': status === 'success',

--- a/src/components/feedback/Callout.tsx
+++ b/src/components/feedback/Callout.tsx
@@ -110,7 +110,7 @@ const Callout = function Callout({
             'p-3': size === 'lg',
           },
           styled && 'grow',
-          themed && 'bg-white'
+          themed && 'bg-white rounded-r'
         )}
       >
         {children}

--- a/src/components/input/Button.tsx
+++ b/src/components/input/Button.tsx
@@ -100,7 +100,7 @@ const Button = function Button({
             styled,
         },
         themed && {
-          'font-semibold rounded-sm': true,
+          'font-semibold rounded': true,
           'text-grey-7 bg-grey-1 enabled:hover:text-grey-9 enabled:hover:bg-grey-2 aria-pressed:text-grey-9 aria-expanded:text-grey-9':
             variant === 'secondary', // default
           'text-grey-1 bg-grey-7 enabled:hover:bg-grey-8 disabled:text-grey-4':

--- a/src/components/input/IconButton.tsx
+++ b/src/components/input/IconButton.tsx
@@ -61,7 +61,7 @@ const IconButton = function IconButton({
       {...htmlAttributes}
       classes={classnames(
         {
-          'focus-visible-ring transition-colors rounded-sm whitespace-nowrap':
+          'focus-visible-ring transition-colors rounded whitespace-nowrap':
             styled,
           'flex items-center justify-center': styled,
         },

--- a/src/components/input/InputRoot.tsx
+++ b/src/components/input/InputRoot.tsx
@@ -43,7 +43,7 @@ const InputRoot = function InputRoot({
       // @ts-ignore-next
       ref={downcastRef(elementRef)}
       className={classnames(
-        'focus-visible-ring ring-inset border rounded-sm w-full p-2',
+        'focus-visible-ring ring-inset border rounded w-full p-2',
         'bg-grey-0 focus:bg-white disabled:bg-grey-1',
         'placeholder:text-color-grey-5 disabled:placeholder:color-grey-6',
         { 'ring-inset ring-2 ring-red-error': hasError },

--- a/src/components/layout/Card.tsx
+++ b/src/components/layout/Card.tsx
@@ -42,7 +42,7 @@ const Card = function Card({
       {...htmlAttributes}
       ref={downcastRef(elementRef)}
       className={classnames(
-        'rounded-sm border bg-white',
+        'rounded border bg-white',
         {
           'shadow hover:shadow-md': variant === 'raised', // default
           'shadow-md': active && variant === 'raised',

--- a/src/components/navigation/Link.tsx
+++ b/src/components/navigation/Link.tsx
@@ -46,7 +46,7 @@ const Link = function Link({
       {...htmlAttributes}
       className={classnames(
         styled && {
-          'focus-visible-ring rounded-sm': true,
+          'focus-visible-ring rounded': true,
           // underline
           // TODO: Underline should be controlled by `variant` and should default
           // to `always`

--- a/src/components/navigation/LinkButton.tsx
+++ b/src/components/navigation/LinkButton.tsx
@@ -50,7 +50,7 @@ const LinkButton = function LinkButton({
       elementRef={downcastRef(elementRef)}
       classes={classnames(
         styled && {
-          'focus-visible-ring transition-colors whitespace-nowrap rounded-sm':
+          'focus-visible-ring transition-colors whitespace-nowrap rounded':
             true,
           inline: inline,
           'flex items-center': !inline,

--- a/src/pattern-library/components/PlaygroundApp.tsx
+++ b/src/pattern-library/components/PlaygroundApp.tsx
@@ -65,7 +65,7 @@ function NavLink({ route }: { route: PlaygroundRoute }) {
         <RouteLink href={route.route ?? ''}>
           <Link
             classes={classnames(
-              'pl-4 w-full border-l-2 hover:border-l-brand',
+              'pl-4 rounded-l-none w-full border-l-2 hover:border-l-brand',
 
               {
                 'border-l-2 border-brand font-semibold': isActive,

--- a/src/pattern-library/components/patterns/StylingComponentsPage.tsx
+++ b/src/pattern-library/components/patterns/StylingComponentsPage.tsx
@@ -33,24 +33,24 @@ export default function StylingComponentsPage() {
         <Library.Section title="Component CSS layers and associated styling props">
           <div className="grid grid-cols-6 gap-2 my-8 items-center border py-4 px-2 rounded border-stone-400">
             <div />
-            <div className="col-span-4 border rounded p-3 text-center">
+            <div className="col-span-4 border rounded-md p-3 text-center">
               Functional and behavioral
             </div>
             <div />
             <div className="text-right">
               <code>unstyled</code>
             </div>
-            <div className="col-span-4 border rounded p-3 text-center">
+            <div className="col-span-4 border rounded-md p-3 text-center">
               Core and layout
             </div>
             <div />
             <div className="text-right">
               <code>variant</code>
             </div>
-            <div className="col-span-2 border rounded p-3 text-center">
+            <div className="col-span-2 border rounded-md p-3 text-center">
               Theming
             </div>
-            <div className="col-span-2 border rounded p-3 text-center">
+            <div className="col-span-2 border rounded-md p-3 text-center">
               Dimensions
             </div>
             <div>
@@ -226,7 +226,7 @@ export default function StylingComponentsPage() {
             <Link
               unstyled
               href="http://www.example.com"
-              classes="border rounded bg-slate-500 p-2 text-white hover:text-slate-100 hover:bg-slate-600"
+              classes="border rounded-md bg-slate-500 p-2 text-white hover:text-slate-100 hover:bg-slate-600"
             >
               Customized link
             </Link>

--- a/src/pattern-library/components/patterns/data/IconsPage.tsx
+++ b/src/pattern-library/components/patterns/data/IconsPage.tsx
@@ -31,7 +31,7 @@ export default function IconsPage() {
               const IconComponent = Icons[iconName];
               return (
                 <div
-                  className="flex flex-col gap-y-4 border rounded-sm p-4 items-center justify-center"
+                  className="flex flex-col gap-y-4 border rounded p-4 items-center justify-center"
                   key={iconName}
                 >
                   <IconComponent />

--- a/src/pattern-library/components/patterns/input/ButtonPage.tsx
+++ b/src/pattern-library/components/patterns/input/ButtonPage.tsx
@@ -157,20 +157,20 @@ export default function ButtonPage() {
             </Library.Demo>
 
             <Library.Demo title="variant: 'custom' (custom theming)" withSource>
-              <Button variant="custom" classes="border rounded">
+              <Button variant="custom" classes="border rounded-md">
                 Default
               </Button>
-              <Button variant="custom" classes="border rounded">
+              <Button variant="custom" classes="border rounded-md">
                 <EditIcon />
                 Default
               </Button>
-              <Button variant="custom" pressed classes="border rounded">
+              <Button variant="custom" pressed classes="border rounded-md">
                 Pressed
               </Button>
-              <Button variant="custom" expanded classes="border rounded">
+              <Button variant="custom" expanded classes="border rounded-md">
                 Expanded
               </Button>
-              <Button variant="custom" disabled classes="border rounded">
+              <Button variant="custom" disabled classes="border rounded-md">
                 Disabled
               </Button>
             </Library.Demo>
@@ -229,7 +229,7 @@ export default function ButtonPage() {
             >
               <Button
                 unstyled
-                classes="border rounded p-2 bg-stone-100 font-normal color-slate-600 hover:bg-stone-50 hover:color-slate-700 hover:shadow-lg"
+                classes="border rounded-md p-2 bg-stone-100 font-normal color-slate-600 hover:bg-stone-50 hover:color-slate-700 hover:shadow-lg"
               >
                 Custom button
               </Button>
@@ -446,13 +446,13 @@ export default function ButtonPage() {
               withSource
             >
               <IconButton
-                classes="border rounded text-slate-600"
+                classes="border rounded-md text-slate-600"
                 variant="custom"
                 title="Watch out!"
                 icon={CautionIcon}
               />
               <IconButton
-                classes="border rounded text-slate-800 bg-stone-100 border-slate-400"
+                classes="border rounded-md text-slate-800 bg-stone-100 border-slate-400"
                 variant="custom"
                 title="Watch out!"
                 icon={CautionIcon}
@@ -460,13 +460,13 @@ export default function ButtonPage() {
               />
               <IconButton
                 variant="custom"
-                classes="border rounded text-slate-800 bg-stone-100 border-slate-400"
+                classes="border rounded-md text-slate-800 bg-stone-100 border-slate-400"
                 title="Watch out!"
                 icon={CautionIcon}
                 expanded
               />
               <IconButton
-                classes="border rounded text-slate-400"
+                classes="border rounded-md text-slate-400"
                 variant="custom"
                 title="Watch out!"
                 icon={CautionIcon}

--- a/src/pattern-library/components/patterns/prototype/LMSContentSelectionPage.tsx
+++ b/src/pattern-library/components/patterns/prototype/LMSContentSelectionPage.tsx
@@ -117,11 +117,11 @@ function Button5({
   const Icon = icon ?? FilePdfFilledIcon;
   return (
     <Button
-      classes="w-full bg-stone-50 hover:bg-stone-100 rounded border border-stone-300 hover:border-stone-400 items-center"
+      classes="w-full bg-stone-50 hover:bg-stone-100 rounded-[4px] border border-stone-300 hover:border-stone-400 items-center"
       size="custom"
       variant="custom"
     >
-      <div className="p-1.5 bg-stone-200 rounded-l">
+      <div className="p-1.5 bg-stone-200 rounded-l-[4px]">
         <Icon className="text-stone-500" />
       </div>
       <div className="grow text-start pl-1">
@@ -151,7 +151,7 @@ function Button6({
   return (
     <Button
       classes={classnames(
-        'group bg-stone-50 hover:bg-slate-100 shadow hover:shadow-lg rounded border border-stone-300 hover:border-stone-400 justify-center',
+        'group bg-stone-50 hover:bg-slate-100 shadow hover:shadow-lg rounded-[4px] border border-stone-300 hover:border-stone-400 justify-center',
         {
           'shadow-inner': selected,
         }
@@ -171,7 +171,7 @@ function Button6({
         </div>
         <div
           className={classnames(
-            'group-hover:bg-slate-500 w-full p-0.5 rounded-b',
+            'group-hover:bg-slate-500 w-full p-0.5 rounded-b-[4px]',
             {
               'bg-stone-200': !selected,
               'bg-slate-500': selected,

--- a/src/pattern-library/components/patterns/prototype/LMSContentSelectionPage.tsx
+++ b/src/pattern-library/components/patterns/prototype/LMSContentSelectionPage.tsx
@@ -23,7 +23,7 @@ import Library from '../../Library';
 function Button1({ children }: { children: ComponentChildren }) {
   return (
     <Button
-      classes="bg-slate-0 rounded-sm border border-slate-3 gap-x-1 p-2"
+      classes="bg-slate-0 rounded border border-slate-3 gap-x-1 p-2"
       variant="custom"
       size="custom"
     >
@@ -41,7 +41,7 @@ function Button2({
 }) {
   return (
     <Button
-      classes="w-[15em] bg-slate-0 rounded-sm border border-slate-3 gap-x-2 items-center"
+      classes="w-[15em] bg-slate-0 rounded border border-slate-3 gap-x-2 items-center"
       variant="custom"
       size="custom"
     >
@@ -64,7 +64,7 @@ function Button3({
 }) {
   return (
     <Button
-      classes="w-[15em] rounded-sm gap-x-2 p-2 border border-stone-300 bg-stone-50"
+      classes="w-[15em] rounded gap-x-2 p-2 border border-stone-300 bg-stone-50"
       size="custom"
       variant="custom"
     >
@@ -89,7 +89,7 @@ function Button4({
 }) {
   return (
     <Button
-      classes="w-full bg-stone-50 rounded-sm border border-stone-300 gap-x-2 items-center"
+      classes="w-full bg-stone-50 rounded border border-stone-300 gap-x-2 items-center"
       size="custom"
       variant="custom"
     >

--- a/src/pattern-library/components/patterns/prototype/Menu.tsx
+++ b/src/pattern-library/components/patterns/prototype/Menu.tsx
@@ -193,7 +193,7 @@ export default function Menu({
         aria-haspopup={true}
         className={classnames(
           'focus-visible-ring',
-          'flex items-center justify-center rounded-sm transition-colors',
+          'flex items-center justify-center rounded transition-colors',
           {
             'text-grey-7 hover:text-grey-9': !isOpen,
             'text-brand': isOpen,

--- a/src/pattern-library/components/patterns/prototype/SharedAnnotationsPage.tsx
+++ b/src/pattern-library/components/patterns/prototype/SharedAnnotationsPage.tsx
@@ -52,12 +52,12 @@ function FakeAnnotation({
     <Card classes="relative">
       <div className="absolute right-full space-y-1 pt-1">
         {isPinned && (
-          <div className="bg-brand p-1.5 rounded-l">
+          <div className="bg-brand p-1.5 rounded-l-[4px]">
             <PinIcon className="text-white" />
           </div>
         )}
         {isShared && (
-          <div className="bg-sky-600 p-1.5 rounded-l">
+          <div className="bg-sky-600 p-1.5 rounded-l-[4px]">
             <GroupsFilledIcon className="text-white" />
           </div>
         )}

--- a/src/tailwind.preset.js
+++ b/src/tailwind.preset.js
@@ -13,6 +13,10 @@ export default /** @type {Partial<import('tailwindcss').Config>} */ ({
       borderColor: {
         DEFAULT: '#dbdbdb',
       },
+      borderRadius: {
+        // Equivalent to tailwind default `rounded-sm` size
+        DEFAULT: '0.125rem',
+      },
       boxShadow: {
         DEFAULT: '0 1px 1px rgba(0, 0, 0, 0.1)',
         md: '0px 2px 3px 0px rgba(0, 0, 0, 0.15)',

--- a/styles/library.scss
+++ b/styles/library.scss
@@ -10,7 +10,7 @@
     }
 
     :where(code):not(:where([class~='unstyled-text'] *)) {
-      @apply p-1 bg-stone-100 rounded-sm mx-0.5;
+      @apply p-1 bg-stone-100 rounded mx-0.5;
       font-size: 0.85em;
     }
 


### PR DESCRIPTION
This is the final PR of a set of PRs to update the use of border-radius styles in our apps.

See https://github.com/hypothesis/client/pull/5607

This PR:

* Replaces uses of unqualified `rounded` rules with their intent (e.g. `rounded-[4px]`)
* Replaces uses of `rounded-sm` with `rounded` (where it is used to imply the default rounding) and set a `DEFAULT` border-radius value in the tailwind configuration
* Clean up a few nits spotted when tweaking the `DEFAULT` border-radius setting to other values

After this lands, we can:

* Change the default border-radius of all package components by tweaking the `DEFAULT` border-radius value in the tailwind preset in this package
* Consuming apps control the default border radius for their local components AND shared components within their own local tailwind configurations, which now all have a `DEFAULT` border-radius value (which will override this package's setting).