### PR TITLE
Add `tab` variant to `Tab` and support styling API

### DIFF
--- a/src/components/navigation/Tab.tsx
+++ b/src/components/navigation/Tab.tsx
@@ -14,7 +14,11 @@ type ComponentProps = {
    */
   textContent?: string;
   selected?: boolean;
-  variant?: 'basic';
+
+  // Styling API
+  size?: 'md' | 'custom';
+  variant?: 'text' | 'tab' | 'custom';
+  unstyled?: boolean;
 };
 
 export type TabProps = PresentationalProps &
@@ -32,18 +36,35 @@ const Tab = function Tab({
   icon: Icon,
   textContent,
   selected = false,
-  variant = 'basic',
+  size = 'md',
+  variant = 'text',
+  unstyled = false,
 
   ...htmlAttributes
 }: TabProps) {
+  const styled = !unstyled;
+  const themed = styled && variant !== 'custom';
+  const sized = styled && size !== 'custom';
+
   return (
     <Button
       data-component="Tab"
       {...htmlAttributes}
       classes={classnames(
-        'gap-x-1.5 enabled:hover:text-brand-dark',
-        {
-          'font-bold': selected && variant === 'basic',
+        // Buttons have a flex layout. Add a horizontal gap.
+        sized && 'gap-x-1.5',
+        themed && {
+          'px-4 py-2': variant === 'tab' && sized,
+          'font-semibold text-grey-7 rounded-t border border-transparent border-b-0':
+            variant === 'tab',
+          'aria-selected:text-color-text aria-selected:bg-white':
+            variant === 'tab',
+          'aria-selected:border aria-selected:border-grey-3 aria-selected:border-b-0':
+            variant === 'tab',
+          'enabled:hover:text-color-text disabled:text-grey-7/50':
+            variant === 'tab',
+          'enabled:hover:text-brand-dark': variant === 'text',
+          'aria-selected:font-bold': variant === 'text',
         },
         classes
       )}
@@ -52,6 +73,7 @@ const Tab = function Tab({
       role="tab"
       variant="custom"
       size="custom"
+      unstyled={unstyled}
     >
       {Icon && (
         <Icon

--- a/src/components/navigation/test/Tab-test.js
+++ b/src/components/navigation/test/Tab-test.js
@@ -1,7 +1,10 @@
 import { mount } from 'enzyme';
 
 import { ProfileIcon } from '../../icons';
-import { testPresentationalComponent } from '../../test/common-tests';
+import {
+  testPresentationalComponent,
+  testStyledComponent,
+} from '../../test/common-tests';
 import Tab from '../Tab';
 
 const contentFn = (Component, props = {}) => {
@@ -17,6 +20,7 @@ describe('Tab', () => {
     createContent: contentFn,
     elementSelector: 'button[data-component="Tab"]',
   });
+  testStyledComponent(Tab);
 
   it('sets `aria-selected` when selected', () => {
     const tab1 = contentFn(Tab, { selected: true });

--- a/src/pattern-library/components/patterns/navigation/TabPage.tsx
+++ b/src/pattern-library/components/patterns/navigation/TabPage.tsx
@@ -283,6 +283,70 @@ export default function TabPage() {
             </Library.Info>
           </Library.Example>
         </Library.Pattern>
+
+        <Library.Pattern title="Styling API">
+          <p>
+            <code>Tab</code> accepts the following props from the{' '}
+            <Library.Link href="/using-components#presentational-components-styling-api">
+              presentational component styling API
+            </Library.Link>
+            .
+          </p>
+          <Library.Example title="variant">
+            <Library.Info>
+              <Library.InfoItem label="description">
+                Set to <code>custom</code> to remove theming styles and provide
+                your own styling with <code>classes</code>.
+              </Library.InfoItem>
+              <Library.InfoItem label="type">
+                <code>{`'text' | 'tab' | 'custom'`}</code>
+              </Library.InfoItem>
+              <Library.InfoItem label="default">
+                <code>{"'text'"}</code>
+              </Library.InfoItem>
+            </Library.Info>
+
+            <Library.Demo title="variant: 'tab'" withSource>
+              <div role="tablist" className="flex">
+                <Tab variant="tab">Share</Tab>
+                <Tab selected variant="tab">
+                  Import
+                </Tab>
+                <Tab variant="tab">Export</Tab>
+              </div>
+            </Library.Demo>
+          </Library.Example>
+
+          <Library.Example title="size">
+            <Library.Info>
+              <Library.InfoItem label="description">
+                Set relative internal spacing and padding. Set to{' '}
+                <code>{`'custom'`}</code> to provide your own sizing styles with{' '}
+                <code>classes</code>.
+              </Library.InfoItem>
+              <Library.InfoItem label="type">
+                <code>{`'md' | 'custom'`}</code>
+              </Library.InfoItem>
+              <Library.InfoItem label="default">
+                <code>{`'md'`}</code>
+              </Library.InfoItem>
+            </Library.Info>
+          </Library.Example>
+
+          <Library.Example title="unstyled">
+            <Library.Info>
+              <Library.InfoItem label="description">
+                Set to remove all styling.
+              </Library.InfoItem>
+              <Library.InfoItem label="type">
+                <code>boolean</code>
+              </Library.InfoItem>
+              <Library.InfoItem label="default">
+                <code>false</code>
+              </Library.InfoItem>
+            </Library.Info>
+          </Library.Example>
+        </Library.Pattern>
       </Library.Section>
       <Library.Section
         title="TabList"


### PR DESCRIPTION
This PR adds some support we pretty much know we'll need for the import/export project by adding a new variant to `Tab` (called `tab`) and extending `Tab` to support the styling API. 

See the local [Tabs pattern library page](http://localhost:4001/navigation-tab) for details.

![image](https://github.com/hypothesis/frontend-shared/assets/439947/8538abad-0f14-4d02-bca2-3afa9f2645c2)

Part of #1141