### PR TITLE
Fix slider transition event

### DIFF
--- a/plop-templates/transition-component-test.hbs
+++ b/plop-templates/transition-component-test.hbs
@@ -25,5 +25,5 @@ describe('{{name}}', () => {
     container.remove();
   });
 
-  testTransitionComponent(Slider);
+  testTransitionComponent({{name}});
 });

--- a/src/components/test/common-tests.js
+++ b/src/components/test/common-tests.js
@@ -336,7 +336,8 @@ export function testTransitionComponent(
 
         // Default to the main container as the `target` for the TransitionEvent,
         // as that would be the actual behavior at runtime.
-        // Callers can still override it in case that's not desired.
+        // If that's not desired, callers can still override it by providing
+        // event.target explicitly.
         const container = wrapper.find('div');
         container.prop('ontransitionend')({
           target: container.getDOMNode(),

--- a/src/components/test/common-tests.js
+++ b/src/components/test/common-tests.js
@@ -312,11 +312,11 @@ export function testSimpleComponent(Component) {
  * Common tests for simple design components
  *
  * @param {TransitionComponent} Component
- * @param {CommonTestOpts} opts
+ * @param {CommonTestOpts & { event?: Partial<TransitionEvent> }} opts
  */
 export function testTransitionComponent(
   Component,
-  { componentName, createContent = createComponent } = {}
+  { componentName, createContent = createComponent, event = {} } = {}
 ) {
   const displayName = componentName ?? Component.displayName ?? Component.name;
 
@@ -334,7 +334,14 @@ export function testTransitionComponent(
           onTransitionEnd,
         });
 
-        wrapper.find('div').prop('ontransitionend')();
+        // Default to the main container as the `target` for the TransitionEvent,
+        // as that would be the actual behavior at runtime.
+        // Callers can still override it in case that's not desired.
+        const container = wrapper.find('div');
+        container.prop('ontransitionend')({
+          target: container.getDOMNode(),
+          ...event,
+        });
 
         assert.calledWith(onTransitionEnd, direction);
       });

--- a/src/components/transition/Slider.tsx
+++ b/src/components/transition/Slider.tsx
@@ -53,17 +53,26 @@ const Slider: TransitionComponent = ({
     }
   }, [containerHeight, visible]);
 
-  const handleTransitionEnd = useCallback(() => {
-    if (visible) {
-      setContainerHeight('auto');
-    } else {
-      // When the collapse animation completes, stop rendering the content so
-      // that the browser has fewer nodes to render and the content is removed
-      // from keyboard navigation.
-      setContentVisible(false);
-    }
-    onTransitionEnd?.(direction);
-  }, [setContainerHeight, visible, onTransitionEnd, direction]);
+  const handleTransitionEnd = useCallback(
+    (e: TransitionEvent) => {
+      // Only transitions on the actual component and for the "height" property
+      // are relevant "in"/"out" transitions.
+      if (e.target !== containerRef.current || e.propertyName !== 'height') {
+        return;
+      }
+
+      if (visible) {
+        setContainerHeight('auto');
+      } else {
+        // When the collapse animation completes, stop rendering the content so
+        // that the browser has fewer nodes to render and the content is removed
+        // from keyboard navigation.
+        setContentVisible(false);
+      }
+      onTransitionEnd?.(direction);
+    },
+    [setContainerHeight, visible, onTransitionEnd, direction]
+  );
 
   const isFullyVisible = containerHeight === 'auto';
 


### PR DESCRIPTION
This PR fixes an oversight on how the `Slider` triggers `onTransitionEnd`, which was currently being called for any CSS transition event, either on it or any children (via event bubbling).

With these changes it now only invokes `onTransitionEnd` when the event was triggered on the Slider container itself, and it happened on the `height` property (the only one animated when "opening" or "closing").