### PR TITLE
Refine tabbed-dialog prototype and define component composition

### DIFF
--- a/src/pattern-library/components/patterns/prototype/TabbedDialogPage.tsx
+++ b/src/pattern-library/components/patterns/prototype/TabbedDialogPage.tsx
@@ -1,23 +1,26 @@
 //import type { ComponentChildren } from 'preact';
 import classnames from 'classnames';
-import type { JSX } from 'preact';
+import type { ComponentChildren, JSX } from 'preact';
 import { useState } from 'preact/hooks';
 
 import {
   Button,
-  CopyIcon,
-  IconButton,
-  Input,
-  InputGroup,
-  TabList,
-  Tab,
-  CancelIcon,
   Card,
   CardActions,
   CardTitle,
+  IconButton,
+  Input,
+  InputGroup,
+  OptionButton,
+  TabList,
+  Tab,
+} from '../../../../';
+import {
+  CancelIcon,
+  CopyIcon,
+  EmailIcon,
   SocialTwitterIcon,
   SocialFacebookIcon,
-  EmailIcon,
 } from '../../../../';
 import type { PresentationalProps } from '../../../../types';
 import Library from '../../Library';
@@ -37,177 +40,279 @@ function Divider({ variant }: DividerProps) {
   );
 }
 
-export default function TabbedDialogPage() {
+type TabListHeaderProps = PresentationalProps & {
+  onClose?: () => void;
+};
+
+function TabListHeader({ children, onClose }: TabListHeaderProps) {
+  return (
+    <div data-testid="tabbed-header" className="flex items-center">
+      {onClose && (
+        // This might be extractable as, say, a CloseButton component
+        <IconButton
+          classes="text-[16px] text-grey-6 hover:text-grey-7 hover:bg-grey-3/50 order-last"
+          title="Close"
+          icon={CancelIcon}
+          onClick={onClose}
+          variant="custom"
+          size="sm"
+        />
+      )}
+      <TabList classes="grow gap-x-1 -mb-[1px] z-2">{children}</TabList>
+    </div>
+  );
+}
+
+type TabPanelProps = PresentationalProps & {
+  active?: boolean;
+  title?: ComponentChildren;
+} & JSX.HTMLAttributes<HTMLDivElement>;
+
+function TabPanel({
+  children,
+  active,
+  title,
+  ...htmlAttributes
+}: TabPanelProps) {
+  return (
+    <div
+      role="tabpanel"
+      className={classnames('p-3 focus-visible-ring ring-inset', {
+        hidden: !active,
+      })}
+      {...htmlAttributes}
+    >
+      {title && <CardTitle>{title}</CardTitle>}
+      <div className="space-y-3 pt-2">{children}</div>
+    </div>
+  );
+}
+
+function TabbedDialog() {
+  const [panelOpen, setPanelOpen] = useState(false);
+  const [selectedTab, setSelectedTab] = useState('one');
+  return (
+    <div className="w-full flex gap-x-4 h-[300px]">
+      <div>
+        <OptionButton
+          onClick={() => setPanelOpen(!panelOpen)}
+          selected={panelOpen}
+        >
+          Toggle dialog
+        </OptionButton>
+      </div>
+
+      <div className="w-[450px] mx-auto">
+        {panelOpen && (
+          <Dialog
+            variant="custom"
+            title="Panel with three tabs"
+            onClose={() => setPanelOpen(false)}
+            restoreFocus
+          >
+            <TabListHeader onClose={() => setPanelOpen(false)}>
+              <Tab
+                aria-controls="one-panel"
+                id="one-panel-tab"
+                variant="tab"
+                selected={selectedTab === 'one'}
+                textContent="One"
+                onClick={() => setSelectedTab('one')}
+              >
+                One
+              </Tab>
+              <Tab
+                aria-controls="two-panel"
+                id="two-panel-tab"
+                variant="tab"
+                selected={selectedTab === 'two'}
+                textContent="Two"
+                onClick={() => setSelectedTab('two')}
+              >
+                Two
+              </Tab>
+              <Tab
+                aria-controls="three-panel"
+                id="three-panel-tab"
+                variant="tab"
+                selected={selectedTab === 'three'}
+                textContent="Three"
+                onClick={() => setSelectedTab('three')}
+                disabled
+              >
+                Three
+              </Tab>
+            </TabListHeader>
+            <Card>
+              <TabPanel
+                id="one-panel"
+                active={selectedTab === 'one'}
+                aria-labelledby="one-panel-tab"
+                title="The first tab"
+                tabIndex={0}
+              >
+                <p>
+                  <strong>This tab panel has no focusable elements</strong>, so
+                  the tabpanel itself can take focus.
+                </p>
+              </TabPanel>
+              <TabPanel
+                id="two-panel"
+                active={selectedTab === 'two'}
+                aria-labelledby="two-panel-tab"
+                title="The second tab"
+              >
+                <p>
+                  This tab panel has focusable elements, so the tabpanel itself
+                  does not take focus.
+                </p>
+                <Input id="two-panel-input" />
+                <CardActions>
+                  <Button variant="primary">Save</Button>
+                </CardActions>
+              </TabPanel>
+              <TabPanel
+                aria-labelledby="three-panel-tab"
+                id="three-panel"
+                active={selectedTab === 'three'}
+                title="Tab number three"
+              >
+                <p>Nothing to see here.</p>
+              </TabPanel>
+            </Card>
+          </Dialog>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function TabbedSharePanel() {
   const [panelOpen, setPanelOpen] = useState(false);
   const [selectedTab, setSelectedTab] = useState('share');
   return (
+    <div className="w-full flex gap-x-4 bg-grey-2 p-4 h-[300px]">
+      <div>
+        <OptionButton
+          onClick={() => setPanelOpen(!panelOpen)}
+          selected={panelOpen}
+        >
+          Toggle dialog
+        </OptionButton>
+      </div>
+
+      <div className="w-[410px] mx-auto text-[13px] leading-normal">
+        {panelOpen && (
+          <Dialog
+            variant="custom"
+            title="Share annotations"
+            onClose={() => setPanelOpen(false)}
+            restoreFocus
+          >
+            <TabListHeader onClose={() => setPanelOpen(false)}>
+              <Tab
+                aria-controls="share-panel"
+                id="share-panel-tab"
+                variant="tab"
+                selected={selectedTab === 'share'}
+                textContent="Share"
+                onClick={() => setSelectedTab('share')}
+              >
+                Share
+              </Tab>
+              <Tab
+                aria-controls="export-panel"
+                id="export-panel-tab"
+                variant="tab"
+                selected={selectedTab === 'export'}
+                textContent="Export"
+                onClick={() => setSelectedTab('export')}
+              >
+                Export
+              </Tab>
+            </TabListHeader>
+            <Card>
+              <TabPanel
+                id="share-panel"
+                active={selectedTab === 'share'}
+                aria-labelledby="share-panel-tab"
+                title="Share annotations from GroupName"
+              >
+                <p>
+                  <strong>
+                    Use this link to share these annotations with anyone:
+                  </strong>
+                </p>
+                <InputGroup>
+                  <Input
+                    id="share-annotations-url"
+                    value="https://www.examle.com/fake"
+                  />
+                  <IconButton icon={CopyIcon} variant="dark" title="copy" />
+                </InputGroup>
+                <Divider variant="full" />
+                <ul className="flex flex-row gap-x-4 items-center justify-center text-grey-6">
+                  <li>
+                    <SocialTwitterIcon className="w-6 h-6" />
+                  </li>
+                  <li>
+                    <SocialFacebookIcon className="w-6 h-6" />
+                  </li>
+                  <li>
+                    <EmailIcon className="w-6 h-6" />
+                  </li>
+                </ul>
+              </TabPanel>
+              <TabPanel
+                id="export-panel"
+                active={selectedTab === 'export'}
+                aria-labelledby="export-panel-tab"
+                title="Export from GroupName"
+              >
+                <p>
+                  Export <strong>2 annotations</strong> in a file named:
+                </p>
+                <Input
+                  id="export-filename"
+                  value="2023-07-10-hypothesis-export.json"
+                />
+                <CardActions>
+                  <Button variant="primary">Export</Button>
+                </CardActions>
+              </TabPanel>
+            </Card>
+          </Dialog>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default function TabbedDialogPage() {
+  return (
     <Library.Page title="Export/Import Annotations">
       <Library.Section title="Tabbed Panel (Dialog) Pattern">
-        <p>TODO</p>
-      </Library.Section>
-      <Library.Section title="Import/Export UI prototyping">
-        <Library.Callout>
-          NB: This section is a work in progress.
-        </Library.Callout>
-        <Library.Pattern title="Adding Export to the Share Panel">
-          <Library.Callout>
-            NB: The disabled <em>Import</em> tab is rendered in the prototyped
-            dialog here to demonstrate what a disabled tab might look like, but
-            would not appear to users in this manner.
-          </Library.Callout>
+        <Library.Example title="General tabbed dialog pattern">
+          <p>
+            This design pattern extends the panel-like dialog layout with tabs
+            and an integrated close button. Tabs may be disabled.
+          </p>
           <Library.Demo>
-            <div className="w-full bg-grey-2 p-4">
-              <Button onClick={() => setPanelOpen(!panelOpen)}>
-                {panelOpen ? 'Close' : 'Show'} share panel
-              </Button>
-
-              <div className="w-[410px] mx-auto text-[13px] leading-normal">
-                {panelOpen && (
-                  <Dialog
-                    variant="custom"
-                    title="Share annotations"
-                    onClose={() => setPanelOpen(false)}
-                    restoreFocus
-                  >
-                    <div
-                      data-testid="tabbed-header"
-                      className="flex items-center"
-                    >
-                      <TabList classes="grow gap-x-1 -mb-[1px] z-2">
-                        <Tab
-                          aria-controls="share-panel"
-                          variant="tab"
-                          selected={selectedTab === 'share'}
-                          textContent="Share"
-                          onClick={() => setSelectedTab('share')}
-                        >
-                          Share
-                        </Tab>
-                        <Tab
-                          aria-controls="export-panel"
-                          variant="tab"
-                          selected={selectedTab === 'export'}
-                          textContent="Export"
-                          onClick={() => setSelectedTab('export')}
-                        >
-                          Export
-                        </Tab>
-                        <Tab
-                          aria-controls="import-panel"
-                          disabled
-                          variant="tab"
-                          selected={selectedTab === 'import'}
-                          textContent="Import"
-                          onClick={() => setSelectedTab('import')}
-                        >
-                          Import
-                        </Tab>
-                      </TabList>
-                      <IconButton
-                        classes="text-[16px] text-grey-6 hover:text-grey-7 hover:bg-grey-3/50"
-                        title="Close"
-                        icon={CancelIcon}
-                        onClick={() => setPanelOpen(false)}
-                        variant="custom"
-                        size="sm"
-                      />
-                    </div>
-                    <Card>
-                      <div
-                        id="share-panel"
-                        role="tabpanel"
-                        className={classnames(
-                          'p-3 focus-visible-ring ring-inset',
-                          {
-                            hidden: selectedTab !== 'share',
-                          }
-                        )}
-                        tabIndex={-1}
-                      >
-                        <CardTitle>Share annotations from GroupName</CardTitle>
-                        <div className="space-y-3 pt-2">
-                          <p>
-                            <strong>
-                              Use this link to share these annotations with
-                              anyone:
-                            </strong>
-                          </p>
-                          <InputGroup>
-                            <Input
-                              id="share-annotations-url"
-                              value="https://www.examle.com/fake"
-                            />
-                            <IconButton
-                              icon={CopyIcon}
-                              variant="dark"
-                              title="copy"
-                            />
-                          </InputGroup>
-                          <Divider variant="full" />
-                          <ul className="flex flex-row gap-x-4 items-center justify-center text-grey-6">
-                            <li>
-                              <SocialTwitterIcon className="w-6 h-6" />
-                            </li>
-                            <li>
-                              <SocialFacebookIcon className="w-6 h-6" />
-                            </li>
-                            <li>
-                              <EmailIcon className="w-6 h-6" />
-                            </li>
-                          </ul>
-                        </div>
-                      </div>
-                      <div
-                        id="export-panel"
-                        role="tabpanel"
-                        tabIndex={-1}
-                        className={classnames(
-                          'p-3 focus-visible-ring ring-inset',
-                          {
-                            hidden: selectedTab !== 'export',
-                          }
-                        )}
-                      >
-                        <CardTitle>Export from GroupName</CardTitle>
-                        <div className="space-y-3 pt-2">
-                          <p>
-                            <strong>2 annotations</strong> will be exported with
-                            the following file name:
-                          </p>
-                          <Input
-                            id="export-filename"
-                            value="2023-07-10-hypothesis-export"
-                          />
-                          <CardActions>
-                            <Button variant="primary">Export</Button>
-                          </CardActions>
-                        </div>
-                      </div>
-                      <div
-                        id="import-panel"
-                        role="tabpanel"
-                        tabIndex={-1}
-                        className={classnames(
-                          'p-3 focus-visible-ring ring-inset',
-                          {
-                            hidden: selectedTab !== 'import',
-                          }
-                        )}
-                      >
-                        <CardTitle>Import into GroupName</CardTitle>
-                        <div className="mt-2 space-y-3">
-                          <p>
-                            TODO: We will mock this up when we work on the
-                            import part of this project.
-                          </p>
-                        </div>
-                      </div>
-                    </Card>
-                  </Dialog>
-                )}
-              </div>
-            </div>
+            <TabbedDialog />
           </Library.Demo>
+        </Library.Example>
+      </Library.Section>
+      <Library.Section title="Import/Export">
+        <Library.Pattern title="Exporting">
+          <Library.Example title="Adding Export tab to existing share panel">
+            <p>
+              Client-specific font sizes and sidebar background color are
+              applied to this tabbed dialog to show how it would appear in situ.
+            </p>
+            <Library.Demo>
+              <TabbedSharePanel />
+            </Library.Demo>
+          </Library.Example>
         </Library.Pattern>
       </Library.Section>
     </Library.Page>


### PR DESCRIPTION
This PR extends the import/export project's tabbed-dialog prototype page and starts coalescing the composition of components. It also adjusts tab sequence/navigation in a way that might address https://github.com/hypothesis/frontend-shared/issues/1158 without the need for extra work.

The prototype is still loose, but these constituent components are bubbling up:

* `TabListHeader`: Bakes the design pattern layout of a horizontal set of tabs at the top of a panel/card
* `TabPanel`: At present, combines both the design pattern of tab-panel content within a card/panel and some a11y details.
* `CloseButton`: Proposed, a styled button that I'd like to make context-aware for its click handler.
* `Divider`: Ultra-simple component, cribbed from MUI, that I'd like to use in place of border-underlines and whatnot in components in the future. 

The needed changes to `Dialog` are also solidifying:

* `variant` prop, default to `panel` (supports current usage) with a `custom` option (so that `Dialog` is not concerned with the presentation of its contents). Inelegant, but seems to allow us what we need to do here without breaking the current API. The long-term direction would be to migrate usage to `custom` across apps and then get rid of `variant`. Still percolating on this.
* Proposed: Add a new `CloseableContext` or similar that could be used by `Dialog` and potentially other components that can be "closed". Put a close handler (that takes transitions into account as needed) into this context. Context-aware things such as the proposed `CloseButton` could take this into account.

This PR doesn't need deep review (beyond what the reviewer would like to review), as it's still all prototype.

Next steps: Start building extracted components, update `Dialog`.

Part of #1141