### PR TITLE
Update exports in plop templates

### DIFF
--- a/plop-templates/composite-component.hbs
+++ b/plop-templates/composite-component.hbs
@@ -18,7 +18,7 @@ export type {{name}}Props = CompositeProps &
 /**
  * TODO
  */
-const {{name}} = function {{name}}({
+export default function {{name}}({
   children,
   elementRef,
 
@@ -48,6 +48,4 @@ const {{name}} = function {{name}}({
       {children}
     </div>
   );
-};
-
-export default {{name}};
+}

--- a/plop-templates/presentational-component.hbs
+++ b/plop-templates/presentational-component.hbs
@@ -16,7 +16,7 @@ export type {{name}}Props = PresentationalProps & ComponentProps & HTMLAttribute
 /**
  * TODO
  */
-const {{name}} = function {{name}}({
+export default function {{name}}({
   children,
   classes,
   elementRef,
@@ -48,6 +48,4 @@ const {{name}} = function {{name}}({
       {children}
     </div>
   );
-};
-
-export default {{name}};
+}

--- a/plop-templates/simple-component.hbs
+++ b/plop-templates/simple-component.hbs
@@ -7,7 +7,7 @@ export type {{name}}Props = {
 /**
  * TODO
  */
-const {{name}} = function {{name}}({ size = 'md' }: {{name}}Props) {
+export default function {{name}}({ size = 'md' }: {{name}}Props) {
   return (
     <div
       className={classnames({
@@ -18,6 +18,4 @@ const {{name}} = function {{name}}({ size = 'md' }: {{name}}Props) {
       data-component="{{name}}"
     />
   );
-};
-
-export default {{name}};
+}


### PR DESCRIPTION
Use `export default`: previous export syntax was a holdover from when there could be multiple components with the same module name.

Leaving the `Transition` exports alone, as they are different.