### PR TITLE
Ensure `CloseButton` always rendered 16px square in panel/dialog headers

### DIFF
--- a/src/components/layout/CardHeader.tsx
+++ b/src/components/layout/CardHeader.tsx
@@ -74,7 +74,11 @@ const CardHeader = function CardHeader({
           classes={classnames(
             // Pull button right such that its icon right-aligns with the
             // header's bottom border
-            '-mr-2.5'
+            '-mr-2.5',
+            // Button icons render at 1em square. In this context, the icon
+            // should always be exactly 16px square, so set font size to make
+            // this happen.
+            'text-[16px]'
           )}
         />
       )}

--- a/src/pattern-library/components/patterns/layout/CardPage.tsx
+++ b/src/pattern-library/components/patterns/layout/CardPage.tsx
@@ -353,6 +353,26 @@ export default function CardPage() {
                 </CardContent>
               </Card>
             </Library.Demo>
+
+            <Library.Demo title="Close button sizing" withSource>
+              <div className="text-[13px] w-full">
+                <Card>
+                  <CardHeader onClose={() => alert('you clicked it')}>
+                    <h3 className="text-brand font-semibold">
+                      Custom title styling
+                    </h3>
+                  </CardHeader>
+                  <CardContent>
+                    <div>
+                      The close button will always have the same size,
+                      regardless of local font size. Here, font size is{' '}
+                      <code>13px</code>, echoing the client application base
+                      font size, but the close button remains the same size.
+                    </div>
+                  </CardContent>
+                </Card>
+              </div>
+            </Library.Demo>
           </Library.Example>
           <Library.Example title="fullWidth">
             <Library.Info>


### PR DESCRIPTION
The recent changes that included `CloseButton` caused a small visual regression in `SidebarPanel`s in the client, to wit, they are too small:

<img width="427" alt="image" src="https://github.com/hypothesis/frontend-shared/assets/439947/ec31edb6-4a4e-4056-b643-5416ea539602">

This is because `IconButton`s size their icons at 1em square, and the local font size here in the client is only `13px` (versus the pattern library's more sane 16px base font size).

Right now, the _intent_ is that any time we render a close button in a header (for a panel or dialog), it should always be exactly 16x16, and should not adapt to local font size.

I've made this the case, and also added a little example for `CardHeader` that would help us spot future regressions before they happen.

After these changes, `client` against build of this package:

<img width="427" alt="image" src="https://github.com/hypothesis/frontend-shared/assets/439947/ac1ed70f-3567-4ebf-81e6-0edee571190b">
