### PR TITLE
Add feedback prop to input to support dynamic styling

### DIFF
--- a/src/components/input/Input.tsx
+++ b/src/components/input/Input.tsx
@@ -5,8 +5,13 @@ import { downcastRef } from '../../util/typing';
 import InputRoot from './InputRoot';
 
 type ComponentProps = {
-  hasError?: boolean;
   type?: 'email' | 'search' | 'text' | 'url';
+  feedback?: 'error' | 'warning';
+
+  /**
+   * @deprecated Use feedback="error" instead
+   */
+  hasError?: boolean;
 };
 
 export type InputProps = PresentationalProps &
@@ -18,8 +23,9 @@ export type InputProps = PresentationalProps &
  */
 const Input = function Input({
   elementRef,
-  hasError,
   type = 'text',
+  feedback,
+  hasError,
 
   ...htmlAttributes
 }: InputProps) {
@@ -28,6 +34,7 @@ const Input = function Input({
       data-component="Input"
       elementRef={downcastRef(elementRef)}
       type={type}
+      feedback={feedback}
       hasError={hasError}
       {...htmlAttributes}
     />

--- a/src/components/input/InputRoot.tsx
+++ b/src/components/input/InputRoot.tsx
@@ -7,6 +7,11 @@ import { inputGroupStyles } from './InputGroup';
 
 type RootComponentProps = {
   element?: 'input' | 'select';
+  feedback?: 'error' | 'warning';
+
+  /**
+   * @deprecated Use feedback="error" instead
+   */
   hasError?: boolean;
 };
 
@@ -27,9 +32,14 @@ const InputRoot = function InputRoot({
   classes,
   elementRef,
   hasError,
+  feedback,
 
   ...htmlAttributes
 }: InputRootProps) {
+  if (feedback === undefined && hasError) {
+    feedback = 'error';
+  }
+
   if (!htmlAttributes.id && !htmlAttributes['aria-label']) {
     console.warn(
       '`Input` component should have either an `id` or an `aria-label` attribute',
@@ -46,7 +56,11 @@ const InputRoot = function InputRoot({
         'focus-visible-ring ring-inset border rounded w-full p-2',
         'bg-grey-0 focus:bg-white disabled:bg-grey-1',
         'placeholder:text-color-grey-5 disabled:placeholder:color-grey-6',
-        { 'ring-inset ring-2 ring-red-error': hasError },
+        {
+          'ring-2': !!feedback,
+          'ring-red-error': feedback === 'error',
+          'ring-yellow-notice': feedback === 'warning',
+        },
         // Adapt styles when this component is inside an InputGroup
         inputGroupStyles,
         classes,

--- a/src/pattern-library/components/patterns/input/InputPage.tsx
+++ b/src/pattern-library/components/patterns/input/InputPage.tsx
@@ -69,11 +69,44 @@ export default function InputPage() {
             presentational component props
           </Library.Link>
           .
+          <Library.Example title="feedback">
+            <Library.Info>
+              <Library.InfoItem label="description">
+                Set <code>feedback</code> to indicate that there is an
+                associated error or warning for the <code>Input</code>.
+              </Library.InfoItem>
+              <Library.InfoItem label="type">
+                <code>
+                  {`"error"`} | {`"warning"`}
+                </code>
+              </Library.InfoItem>
+              <Library.InfoItem label="default">
+                <code>{`undefined`}</code>
+              </Library.InfoItem>
+            </Library.Info>
+
+            <Library.Demo withSource>
+              <div className="w-[350px]">
+                <Input
+                  aria-label="Input with error"
+                  feedback="error"
+                  value="something invalid"
+                />
+              </div>
+              <div className="w-[350px]">
+                <Input
+                  aria-label="Input with warning"
+                  feedback="warning"
+                  value="might be a problem"
+                />
+              </div>
+            </Library.Demo>
+          </Library.Example>
           <Library.Example title="hasError">
             <Library.Info>
               <Library.InfoItem label="description">
-                Set <code>hasError</code> to indicate that there is an
-                associated error for the <code>Input</code>.
+                <Library.StatusChip status="deprecated" />
+                Use <code>{`feedback="error"`}</code> instead.
               </Library.InfoItem>
               <Library.InfoItem label="type">
                 <code>{`boolean`}</code>


### PR DESCRIPTION
This PR adds a new `feedback` prop to `Input`, that can have values `error` or `warning`, and is used to dynamically style the input to provide extra feedback.

> **Note**
> I named it `feedback`, after checking how other UI libs treat this. Feedback is how it's named in bootstrap, and it sounds intuitive enough, and allows for more values to be eventually added (`success`, `info`, etc)

![image](https://github.com/hypothesis/frontend-shared/assets/2719332/97879e26-7a56-47d5-8478-a6e7443221e8)

It also deprecates and replaces `hasError`, recommending `feedback"error"` as a direct replacement. 

![image](https://github.com/hypothesis/frontend-shared/assets/2719332/9464cce3-7ec2-4b8a-a25e-951ec0cca524)

> **Note**
> The `Select` was left out of this PR and will be added afterwards, once we have discussed and agreed on the right contract.