### PR TITLE
Add Textarea component

### DIFF
--- a/src/components/input/InputRoot.tsx
+++ b/src/components/input/InputRoot.tsx
@@ -6,7 +6,7 @@ import { downcastRef } from '../../util/typing';
 import { inputGroupStyles } from './InputGroup';
 
 type RootComponentProps = {
-  element?: 'input' | 'select';
+  element?: 'input' | 'select' | 'textarea';
   feedback?: 'error' | 'warning';
 
   /**
@@ -20,6 +20,7 @@ export type InputRootProps = PresentationalProps &
   (
     | Omit<JSX.HTMLAttributes<HTMLInputElement>, 'size' | 'icon'>
     | Omit<JSX.HTMLAttributes<HTMLSelectElement>, 'size' | 'icon'>
+    | Omit<JSX.HTMLAttributes<HTMLTextAreaElement>, 'size' | 'icon'>
   );
 
 /**

--- a/src/components/input/Textarea.tsx
+++ b/src/components/input/Textarea.tsx
@@ -1,0 +1,37 @@
+import type { JSX } from 'preact';
+
+import type { PresentationalProps } from '../../types';
+import { downcastRef } from '../../util/typing';
+import InputRoot from './InputRoot';
+
+type ComponentProps = {
+  feedback?: 'error' | 'warning';
+};
+
+export type TextareaProps = PresentationalProps &
+  ComponentProps &
+  JSX.HTMLAttributes<HTMLTextAreaElement>;
+
+/**
+ * Render a textarea
+ */
+const Textarea = function Textarea({
+  elementRef,
+  type = 'text',
+  feedback,
+
+  ...htmlAttributes
+}: TextareaProps) {
+  return (
+    <InputRoot
+      data-component="Textarea"
+      element="textarea"
+      elementRef={downcastRef(elementRef)}
+      type={type}
+      feedback={feedback}
+      {...htmlAttributes}
+    />
+  );
+};
+
+export default Textarea;

--- a/src/components/input/index.ts
+++ b/src/components/input/index.ts
@@ -7,6 +7,7 @@ export { default as Input } from './Input';
 export { default as InputGroup } from './InputGroup';
 export { default as OptionButton } from './OptionButton';
 export { default as Select } from './Select';
+export { default as Textarea } from './Textarea';
 
 export type { ButtonProps } from './Button';
 export type { ButtonBaseProps } from './ButtonBase';
@@ -17,3 +18,4 @@ export type { InputProps } from './Input';
 export type { InputGroupProps } from './InputGroup';
 export type { OptionButtonProps } from './OptionButton';
 export type { SelectProps } from './Select';
+export type { TextareaProps } from './Textarea';

--- a/src/components/input/test/Textarea-test.js
+++ b/src/components/input/test/Textarea-test.js
@@ -1,0 +1,12 @@
+import { mount } from 'enzyme';
+
+import { testPresentationalComponent } from '../../test/common-tests';
+import Textarea from '../Textarea';
+
+const contentFn = (Component, props = {}) => {
+  return mount(<Component aria-label="Test textarea" {...props} />);
+};
+
+describe('Textarea', () => {
+  testPresentationalComponent(Textarea, { createContent: contentFn });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,6 +40,7 @@ export {
   InputGroup,
   OptionButton,
   Select,
+  Textarea,
 } from './components/input';
 export {
   Card,
@@ -104,6 +105,7 @@ export type {
   InputGroupProps,
   OptionButtonProps,
   SelectProps,
+  TextareaProps,
 } from './components/input';
 
 export type {

--- a/src/pattern-library/components/patterns/input/TextareaPage.tsx
+++ b/src/pattern-library/components/patterns/input/TextareaPage.tsx
@@ -1,0 +1,123 @@
+import { Textarea } from '../../../../';
+import Library from '../../Library';
+
+export default function TextareaPage() {
+  return (
+    <Library.Page
+      title="Textarea"
+      intro={
+        <p>
+          <code>Textarea</code> is a presentational component for styling{' '}
+          <code>textarea</code> elements.
+        </p>
+      }
+    >
+      <Library.Section>
+        <Library.Pattern>
+          <Library.Usage componentName="Textarea" />
+
+          <Library.Example>
+            <Library.Demo title="Basic Textarea" withSource>
+              <div className="w-[350px]">
+                <Textarea
+                  aria-label="Textarea example"
+                  placeholder="Placeholder..."
+                />
+              </div>
+            </Library.Demo>
+          </Library.Example>
+        </Library.Pattern>
+
+        <Library.Pattern title="Working with Textareas">
+          <Library.Example title="Accessibility">
+            <p>
+              Hypothesis does not currently have a design pattern for labeling
+              textareas. However, for accessibility, it is critical that a{' '}
+              <code>Textarea</code> have either an associated <code>label</code>{' '}
+              element or an <code>aria-label</code> attribute.
+            </p>
+
+            <Library.Demo title="Textarea with label" withSource>
+              <div className="w-[350px]">
+                <label htmlFor="textarea-with-label" className="font-semibold">
+                  Label
+                </label>
+                <Textarea
+                  id="textarea-with-label"
+                  placeholder="Placeholder..."
+                />
+              </div>
+            </Library.Demo>
+          </Library.Example>
+          <Library.Example title="Disabled Textareas">
+            <p>
+              <code>Textarea</code>s can be disabled by applying the HTML{' '}
+              <code>disabled</code> attribute.
+            </p>
+            <Library.Demo withSource>
+              <div className="w-[350px]">
+                <Textarea
+                  aria-label="Example textarea"
+                  placeholder="Placeholder..."
+                  disabled
+                />
+              </div>
+            </Library.Demo>
+          </Library.Example>
+        </Library.Pattern>
+
+        <Library.Pattern title="Component API">
+          <code>Textarea</code> accepts all standard{' '}
+          <Library.Link href="/using-components#presentational-components-api">
+            presentational component props
+          </Library.Link>
+          .
+          <Library.Example title="feedback">
+            <Library.Info>
+              <Library.InfoItem label="description">
+                Set <code>feedback</code> to indicate that there is an
+                associated error or warning for the <code>Textarea</code>.
+              </Library.InfoItem>
+              <Library.InfoItem label="type">
+                <code>
+                  {`"error"`} | {`"warning"`}
+                </code>
+              </Library.InfoItem>
+              <Library.InfoItem label="default">
+                <code>{`undefined`}</code>
+              </Library.InfoItem>
+            </Library.Info>
+
+            <Library.Demo withSource>
+              <div className="w-[350px]">
+                <Textarea
+                  aria-label="Textarea with error"
+                  feedback="error"
+                  value="something invalid"
+                />
+              </div>
+              <div className="w-[350px]">
+                <Textarea
+                  aria-label="Textarea with warning"
+                  feedback="warning"
+                  value="might be a problem"
+                />
+              </div>
+            </Library.Demo>
+          </Library.Example>
+          <Library.Example title="...htmlAttributes">
+            <Library.Info>
+              <Library.InfoItem label="description">
+                <code>Textarea</code> accepts HTML attributes for textarea
+                elements.
+              </Library.InfoItem>
+              <Library.InfoItem label="type">
+                <code>{`JSX.HTMLAttributes<HTMLTextareaElement>`}</code>
+              </Library.InfoItem>
+            </Library.Info>
+          </Library.Example>
+        </Library.Pattern>
+      </Library.Section>
+    </Library.Page>
+  );
+}

--- a/src/pattern-library/routes.ts
+++ b/src/pattern-library/routes.ts
@@ -22,6 +22,7 @@ import InputGroupPage from './components/patterns/input/InputGroupPage';
 import InputPage from './components/patterns/input/InputPage';
 import OptionButtonPage from './components/patterns/input/OptionButtonPage';
 import SelectPage from './components/patterns/input/SelectPage';
+import TextareaPage from './components/patterns/input/TextareaPage';
 import CardPage from './components/patterns/layout/CardPage';
 import OverlayPage from './components/patterns/layout/OverlayPage';
 import PanelPage from './components/patterns/layout/PanelPage';
@@ -199,6 +200,12 @@ const routes: PlaygroundRoute[] = [
     group: 'input',
     component: SelectPage,
     route: '/input-select',
+  },
+  {
+    title: 'Textarea',
+    group: 'input',
+    component: TextareaPage,
+    route: '/input-textarea',
   },
   {
     title: 'Card',


### PR DESCRIPTION
This PR depends on https://github.com/hypothesis/frontend-shared/pull/1196

Add a new `Textarea` component that renders consistently with `Input` and `Select`.

![image](https://github.com/hypothesis/frontend-shared/assets/2719332/a52d9895-51c4-4f53-8281-511f6951368e)

You can see how it looks by checking out this branch, running `make dev` and going to http://localhost:4001/input-textarea