### PR TITLE
Add feedback prop to Select to get it up to speed with Input

### DIFF
--- a/src/components/input/Select.tsx
+++ b/src/components/input/Select.tsx
@@ -6,6 +6,11 @@ import InputRoot from './InputRoot';
 
 type ComponentProps = {
   children?: ComponentChildren;
+  feedback?: 'error' | 'warning';
+
+  /**
+   * @deprecated Use feedback="error" instead
+   */
   hasError?: boolean;
 };
 export type SelectProps = PresentationalProps &
@@ -22,8 +27,9 @@ const arrowImage = `url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000
 const Select = function Select({
   children,
   classes,
-  hasError,
   type = 'text',
+  feedback,
+  hasError,
 
   ...htmlAttributes
 }: SelectProps) {
@@ -40,6 +46,7 @@ const Select = function Select({
       )}
       element="select"
       type={type}
+      feedback={feedback}
       hasError={hasError}
       style={{
         backgroundImage: arrowImage,

--- a/src/pattern-library/components/patterns/input/SelectPage.tsx
+++ b/src/pattern-library/components/patterns/input/SelectPage.tsx
@@ -65,7 +65,7 @@ export default function SelectPage() {
                     title="Previous student"
                     variant="dark"
                   />
-                  <SelectWrapper aria-label="Example input" />
+                  <SelectWrapper aria-label="Example select" />
                   <IconButton
                     icon={ArrowRightIcon}
                     title="Next student"
@@ -76,7 +76,7 @@ export default function SelectPage() {
             </Library.Demo>
             <Library.Demo title="Setting Select width" withSource>
               <div className="w-[250px]">
-                <SelectWrapper aria-label="Example input" />
+                <SelectWrapper aria-label="Example select" />
               </div>
             </Library.Demo>
           </Library.Example>
@@ -84,7 +84,7 @@ export default function SelectPage() {
           <Library.Example title="Disabled Selects">
             <Library.Demo title="disabled Select" withSource>
               <div className="w-[350px]">
-                <SelectWrapper aria-label="Example input" disabled />
+                <SelectWrapper aria-label="Example select" disabled />
               </div>
             </Library.Demo>
           </Library.Example>
@@ -96,11 +96,42 @@ export default function SelectPage() {
             presentational component props
           </Library.Link>
           .
+          <Library.Example title="feedback">
+            <Library.Info>
+              <Library.InfoItem label="description">
+                Set <code>feedback</code> to indicate that there is an
+                associated error or warning for the <code>Select</code>.
+              </Library.InfoItem>
+              <Library.InfoItem label="type">
+                <code>
+                  {`"error"`} | {`"warning"`}
+                </code>
+              </Library.InfoItem>
+              <Library.InfoItem label="default">
+                <code>{`undefined`}</code>
+              </Library.InfoItem>
+            </Library.Info>
+
+            <Library.Demo withSource>
+              <div className="w-[350px]">
+                <SelectWrapper
+                  aria-label="Select with error"
+                  feedback="error"
+                />
+              </div>
+              <div className="w-[350px]">
+                <SelectWrapper
+                  aria-label="Select with warning"
+                  feedback="warning"
+                />
+              </div>
+            </Library.Demo>
+          </Library.Example>
           <Library.Example title="hasError">
             <Library.Info>
               <Library.InfoItem label="description">
-                Set <code>hasError</code> to indicate that there is an
-                associated error for the <code>Select</code>.
+                <Library.StatusChip status="deprecated" />
+                Use <code>{`feedback="error"`}</code> instead.
               </Library.InfoItem>
               <Library.InfoItem label="type">
                 <code>{`boolean`}</code>
@@ -112,7 +143,7 @@ export default function SelectPage() {
 
             <Library.Demo withSource>
               <div className="w-[350px]">
-                <SelectWrapper aria-label="Example input" hasError />
+                <SelectWrapper aria-label="Example select" hasError />
               </div>
             </Library.Demo>
           </Library.Example>


### PR DESCRIPTION
This PR completes the work done in https://github.com/hypothesis/frontend-shared/pull/1196, adding `feedback` prop to the `Select`.

![image](https://github.com/hypothesis/frontend-shared/assets/2719332/5873aafe-4ec4-43a3-af60-eaa3568b263a)
