### PR TITLE
Prompts confirm

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,9 @@ export { useFocusAway } from './hooks/use-focus-away';
 export { useKeyPress } from './hooks/use-key-press';
 export { useSyncedRef } from './hooks/use-synced-ref';
 
+// Utils
+export { confirm } from './util/prompts';
+
 // Components
 export * from './components/icons';
 export {
@@ -126,6 +129,8 @@ export type {
   TabProps,
   TabListProps,
 } from './components/navigation/';
+
+export type { ConfirmModalProps } from './util/prompts';
 
 // Deprecated
 export { useElementShouldClose } from './hooks/use-element-should-close';

--- a/src/pattern-library/components/patterns/feedback/DialogPage.tsx
+++ b/src/pattern-library/components/patterns/feedback/DialogPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef } from 'preact/hooks';
+import { useState, useRef, useCallback } from 'preact/hooks';
 
 import type { DialogProps } from '../../../../';
 import {
@@ -19,6 +19,7 @@ import {
 } from '../../../../';
 import { ModalDialog } from '../../../../components/feedback';
 import type { ModalDialogProps } from '../../../../components/feedback/ModalDialog';
+import { confirm } from '../../../../util/prompts';
 import Library from '../../Library';
 import { LoremIpsum, nabokovNovels } from '../samples';
 import type { NabokovNovel } from '../samples';
@@ -95,6 +96,30 @@ function Dialog_({
         )}
       </div>
     </div>
+  );
+}
+
+function Confirm() {
+  const [result, setResult] = useState<boolean | null>(null);
+  const showConfirm = useCallback(async () => {
+    const answer = await confirm({
+      message: 'This is a confirm dialog',
+
+      // Optional options
+      title: 'Your title',
+      confirmAction: 'Yes please',
+      cancelAction: 'I changed my mind',
+    });
+    setResult(answer);
+  }, []);
+
+  return (
+    <>
+      <Button variant="primary" onClick={showConfirm}>
+        Show confirm
+      </Button>
+      {result !== null && <>You clicked {result ? 'Yes' : 'Cancel'}</>}
+    </>
   );
 }
 
@@ -918,6 +943,38 @@ export default function DialogPage() {
               </Library.InfoItem>
             </Library.Info>
           </Library.Example>
+        </Library.Pattern>
+      </Library.Section>
+
+      <Library.Section
+        id="confirmprompt"
+        title="confirm"
+        intro={
+          <p>
+            <code>confirm</code> is a utility function that renders a{' '}
+            <code>ModalDialog</code> with two action buttons. It returns a{' '}
+            <code>Promise</code> resolving a <code>boolean</code>.
+          </p>
+        }
+      >
+        <Library.Pattern>
+          <Library.Usage componentName="confirm" />
+          <Library.Demo title="Basic confirm">
+            <Confirm />
+          </Library.Demo>
+
+          <Library.Demo title="Usage">
+            <Library.Code
+              content={`const answer = await confirm({
+  message: 'This is a confirm dialog',
+
+  // Optional options
+  title: 'Your title',
+  confirmAction: 'Yes please',
+  cancelAction: 'I changed my mind'
+});`}
+            />
+          </Library.Demo>
         </Library.Pattern>
       </Library.Section>
     </Library.Page>

--- a/src/util/prompts.tsx
+++ b/src/util/prompts.tsx
@@ -1,0 +1,81 @@
+import { render } from 'preact';
+import { createRef } from 'preact';
+import type { RefObject } from 'preact';
+import type { ComponentChildren } from 'preact';
+
+import ModalDialog from '../components/feedback/ModalDialog';
+import Button from '../components/input/Button';
+
+export type ConfirmModalProps = {
+  title?: string;
+  message: ComponentChildren;
+  confirmAction?: string;
+  cancelAction?: string;
+};
+
+/**
+ * Show the user a prompt asking them to confirm an action.
+ *
+ * This is like an async version of `window.confirm` except that:
+ *
+ *  - It can be used inside iframes (browsers are starting to prevent this for
+ *    the native `window.confirm` dialog)
+ *  - The visual style of the dialog matches the Hypothesis design system
+ *
+ * @return - Promise that resolves with `true` if the user confirmed the action
+ *   or `false` if they canceled it.
+ */
+export async function confirm({
+  title = 'Confirm',
+  message,
+  confirmAction = 'Yes',
+  cancelAction = 'Cancel',
+}: ConfirmModalProps): Promise<boolean> {
+  const cancelButton = createRef<HTMLElement | undefined>();
+  const container = document.createElement('div');
+  container.setAttribute('data-testid', 'confirm-container');
+
+  // Ensure dialog appears above any existing content. The Z-index value here
+  // is Good Enough™ for current usage.
+  container.style.position = 'relative';
+  container.style.zIndex = '10';
+
+  document.body.appendChild(container);
+
+  return new Promise(resolve => {
+    const close = (result: boolean) => {
+      render(null, container);
+      container.remove();
+      resolve(result);
+    };
+
+    render(
+      <ModalDialog
+        buttons={
+          <>
+            <Button
+              elementRef={cancelButton}
+              data-testid="cancel-button"
+              onClick={() => close(false)}
+            >
+              {cancelAction}
+            </Button>
+            <Button
+              data-testid="confirm-button"
+              variant="primary"
+              onClick={() => close(true)}
+            >
+              {confirmAction}
+            </Button>
+          </>
+        }
+        initialFocus={cancelButton as RefObject<HTMLElement>}
+        title={title}
+        onClose={() => close(false)}
+      >
+        {message}
+      </ModalDialog>,
+      container,
+    );
+  });
+}

--- a/src/util/test/prompts-test.js
+++ b/src/util/test/prompts-test.js
@@ -1,0 +1,71 @@
+import { confirm } from '../prompts';
+
+describe('confirm', () => {
+  function clickClose() {
+    const closeButton = getCustomDialog().querySelector('[aria-label="Close"]');
+    closeButton.click();
+  }
+
+  function getCancelButton() {
+    return getCustomDialog().querySelector('[data-testid="cancel-button"]');
+  }
+
+  function clickCancel() {
+    getCancelButton().click();
+  }
+
+  function getConfirmButton() {
+    return getCustomDialog().querySelector('[data-testid="confirm-button"]');
+  }
+
+  function clickConfirm() {
+    getConfirmButton().click();
+  }
+
+  function getCustomDialog() {
+    return document.querySelector('[data-testid="confirm-container"]');
+  }
+
+  it('renders a custom dialog', async () => {
+    const result = confirm({
+      title: 'Confirm action?',
+      message: 'Do the thing?',
+      confirmAction: 'Yeah!',
+    });
+    const dialog = getCustomDialog();
+
+    assert.ok(dialog);
+
+    clickClose();
+
+    assert.notOk(getCustomDialog());
+    assert.isFalse(await result);
+  });
+
+  it('renders provided actions', async () => {
+    const result = confirm({
+      title: 'Confirm action?',
+      message: 'Do the thing?',
+      confirmAction: 'Do it!',
+      cancelAction: "Don't do it!",
+    });
+
+    assert.equal(getConfirmButton().innerText, 'Do it!');
+    assert.equal(getCancelButton().innerText, "Don't do it!");
+
+    clickClose();
+    await result;
+  });
+
+  it('returns true if "Confirm" button is clicked', async () => {
+    const result = confirm({ message: 'Do the thing?' });
+    clickConfirm();
+    assert.isTrue(await result);
+  });
+
+  it('returns false if "Cancel" button is clicked', async () => {
+    const result = confirm({ message: 'Do the thing?' });
+    clickCancel();
+    assert.isFalse(await result);
+  });
+});


### PR DESCRIPTION
Bringing the `confirm` helper function from client to this library, as we have use cases for it in other projects.

I brought it almost verbatim, with the only addition of a customizable cancel action text.

I also added a simple documentation piece in the patterns library, under `Dialogs`.

![Captura desde 2023-09-07 10-30-45](https://github.com/hypothesis/frontend-shared/assets/2719332/e091978d-e461-43ea-b8e9-c95444ce4c8c)
