### PR TITLE
Simplify export structure of components

### DIFF
--- a/src/components/data/AspectRatio.tsx
+++ b/src/components/data/AspectRatio.tsx
@@ -26,7 +26,7 @@ export type AspectRatioProps = {
  *
  * See https://www.smashingmagazine.com/2013/09/responsive-images-performance-problem-case-study/#the-padding-bottom-hack
  */
-const AspectRatio = function AspectRatio({
+export default function AspectRatio({
   children,
   objectFit = 'cover',
   ratio = '16/9',
@@ -77,6 +77,4 @@ const AspectRatio = function AspectRatio({
       {otherChildren}
     </div>
   );
-};
-
-export default AspectRatio;
+}

--- a/src/components/data/DataTable.tsx
+++ b/src/components/data/DataTable.tsx
@@ -49,7 +49,7 @@ export type DataTableProps<Row> = CompositeProps &
 /**
  * An interactive table of rows and columns with a sticky header.
  */
-const DataTable = function DataTable<Row>({
+export default function DataTable<Row>({
   children,
   elementRef,
 
@@ -178,6 +178,4 @@ const DataTable = function DataTable<Row>({
       {withFoot && <TableFoot />}
     </Table>
   );
-};
-
-export default DataTable;
+}

--- a/src/components/data/Scroll.tsx
+++ b/src/components/data/Scroll.tsx
@@ -15,7 +15,7 @@ export type ScrollProps = PresentationalProps & {
 /**
  * Render a fluid container that scrolls on overflow.
  */
-const Scroll = function Scroll({
+export default function Scroll({
   children,
   classes,
   elementRef,
@@ -49,6 +49,4 @@ const Scroll = function Scroll({
       </div>
     </ScrollContext.Provider>
   );
-};
-
-export default Scroll;
+}

--- a/src/components/data/ScrollBox.tsx
+++ b/src/components/data/ScrollBox.tsx
@@ -12,7 +12,7 @@ export type ScrollBoxProps = CompositeProps & {
  * Render an opinionated composition of Scroll components, making `children`
  * scrollable.
  */
-const ScrollBox = function ScrollBox({
+export default function ScrollBox({
   children,
   elementRef,
 
@@ -32,6 +32,4 @@ const ScrollBox = function ScrollBox({
       </Scroll>
     </ScrollContainer>
   );
-};
-
-export default ScrollBox;
+}

--- a/src/components/data/ScrollContainer.tsx
+++ b/src/components/data/ScrollContainer.tsx
@@ -12,10 +12,8 @@ export type ScrollContainerProps = PresentationalProps & {
 /**
  * Constrain children (which may include both scrollable and non-scrolling
  * content) to the dimensions of the immediate parent.
- *
- * @param {CommonProps & ScrollContainerProps & HTMLDivAttributes} props
  */
-const ScrollContainer = function ScrollContainer({
+export default function ScrollContainer({
   children,
   classes,
   elementRef,
@@ -41,6 +39,4 @@ const ScrollContainer = function ScrollContainer({
       {children}
     </div>
   );
-};
-
-export default ScrollContainer;
+}

--- a/src/components/data/ScrollContent.tsx
+++ b/src/components/data/ScrollContent.tsx
@@ -10,7 +10,7 @@ export type ScrollContentProps = PresentationalProps &
 /**
  * Apply consistent padding and spacing to content within a Scroll
  */
-const ScrollContent = function ScrollContent({
+export default function ScrollContent({
   children,
   classes,
   elementRef,
@@ -26,6 +26,4 @@ const ScrollContent = function ScrollContent({
       {children}
     </div>
   );
-};
-
-export default ScrollContent;
+}

--- a/src/components/data/Table.tsx
+++ b/src/components/data/Table.tsx
@@ -18,7 +18,7 @@ export type TableProps = PresentationalProps & {
 /**
  * Render table content
  */
-const Table = function Table({
+export default function Table({
   children,
   classes,
   elementRef,
@@ -65,6 +65,4 @@ const Table = function Table({
       </table>
     </TableContext.Provider>
   );
-};
-
-export default Table;
+}

--- a/src/components/data/TableBody.tsx
+++ b/src/components/data/TableBody.tsx
@@ -14,7 +14,7 @@ export type TableBodyProps = PresentationalProps &
 /**
  * Render a table body
  */
-const TableBody = function TableBody({
+export default function TableBody({
   children,
   classes,
   elementRef,
@@ -41,6 +41,4 @@ const TableBody = function TableBody({
       </tbody>
     </TableSectionContext.Provider>
   );
-};
-
-export default TableBody;
+}

--- a/src/components/data/TableCell.tsx
+++ b/src/components/data/TableCell.tsx
@@ -11,10 +11,8 @@ export type TableCellProps = PresentationalProps &
 
 /**
  * Render a single table cell
- *
- * @param {CommonProps & HTMLAttributes} props
  */
-const TableCell = function TableCell({
+export default function TableCell({
   children,
   classes,
   elementRef,
@@ -53,6 +51,4 @@ const TableCell = function TableCell({
       {children}
     </Cell>
   );
-};
-
-export default TableCell;
+}

--- a/src/components/data/TableFoot.tsx
+++ b/src/components/data/TableFoot.tsx
@@ -13,7 +13,7 @@ export type TableFootProps = PresentationalProps & HTMLAttributes;
 /**
  * Render a table footer section
  */
-const TableFoot = function TableFoot({
+export default function TableFoot({
   children,
   classes,
   elementRef,
@@ -42,6 +42,4 @@ const TableFoot = function TableFoot({
       </tfoot>
     </TableSectionContext.Provider>
   );
-};
-
-export default TableFoot;
+}

--- a/src/components/data/TableHead.tsx
+++ b/src/components/data/TableHead.tsx
@@ -13,10 +13,8 @@ export type TableHeadProps = PresentationalProps &
 
 /**
  * Render a table head section
- *
- * @param {CommonProps & HTMLAttributes} props
  */
-const TableHead = function TableHead({
+export default function TableHead({
   children,
   classes,
   elementRef,
@@ -47,6 +45,4 @@ const TableHead = function TableHead({
       </thead>
     </TableSectionContext.Provider>
   );
-};
-
-export default TableHead;
+}

--- a/src/components/data/TableRow.tsx
+++ b/src/components/data/TableRow.tsx
@@ -18,10 +18,8 @@ export type TableRowProps = PresentationalProps &
 
 /**
  * Render a table row
- *
- * @param {CommonProps & TableRowProps & HTMLAttributes} props
  */
-const TableRow = function TableRow({
+export default function TableRow({
   children,
   classes,
   elementRef,
@@ -61,6 +59,4 @@ const TableRow = function TableRow({
       {children}
     </tr>
   );
-};
-
-export default TableRow;
+}

--- a/src/components/data/Thumbnail.tsx
+++ b/src/components/data/Thumbnail.tsx
@@ -43,7 +43,7 @@ export type ThumbnailProps = CompositeProps &
  * Render embedded media (e.g. image), handling aspect ratio, loading state and
  * placeholder content.
  */
-const Thumbnail = function Thumbnail({
+export default function Thumbnail({
   children,
   elementRef,
 
@@ -96,6 +96,4 @@ const Thumbnail = function Thumbnail({
       </div>
     </div>
   );
-};
-
-export default Thumbnail;
+}

--- a/src/components/feedback/Callout.tsx
+++ b/src/components/feedback/Callout.tsx
@@ -24,7 +24,7 @@ export type CalloutProps = PresentationalProps &
 /**
  * Render a banner-like alert message with corresponding icon and coloring
  */
-const Callout = function Callout({
+export default function Callout({
   children,
   classes,
   elementRef,
@@ -117,6 +117,4 @@ const Callout = function Callout({
       </div>
     </div>
   );
-};
-
-export default Callout;
+}

--- a/src/components/feedback/Dialog.tsx
+++ b/src/components/feedback/Dialog.tsx
@@ -65,7 +65,7 @@ export type DialogProps = PresentationalProps &
 /**
  * Show a dialog
  */
-const Dialog = function Dialog({
+export default function Dialog({
   closeOnClickAway = false,
   closeOnEscape = false,
   closeOnFocusAway = false,
@@ -242,6 +242,4 @@ const Dialog = function Dialog({
       </Wrapper>
     </CloseableContext.Provider>
   );
-};
-
-export default Dialog;
+}

--- a/src/components/feedback/Modal.tsx
+++ b/src/components/feedback/Modal.tsx
@@ -38,7 +38,7 @@ const noop = () => {};
  * Show a modal
  * @deprecated - Use `ModalDialog` instead
  */
-const Modal = function Modal({
+export default function Modal({
   children,
   width = 'md',
 
@@ -154,6 +154,4 @@ const Modal = function Modal({
       </div>
     </Overlay>
   );
-};
-
-export default Modal;
+}

--- a/src/components/feedback/ModalDialog.tsx
+++ b/src/components/feedback/ModalDialog.tsx
@@ -47,7 +47,7 @@ export type ModalDialogProps = Omit<
 /**
  * Show a modal dialog
  */
-const ModalDialog = function ModalDialog({
+export default function ModalDialog({
   children,
   disableCloseOnEscape = false,
   disableFocusTrap = false,
@@ -112,6 +112,4 @@ const ModalDialog = function ModalDialog({
       </Dialog>
     </Overlay>
   );
-};
-
-export default ModalDialog;
+}

--- a/src/components/feedback/Spinner.tsx
+++ b/src/components/feedback/Spinner.tsx
@@ -10,7 +10,7 @@ export type SpinnerProps = {
 /**
  * Style a spinner icon.
  */
-const Spinner = function Spinner({
+export default function Spinner({
   size = 'sm',
   color = 'text-light',
 }: SpinnerProps) {
@@ -31,6 +31,4 @@ const Spinner = function Spinner({
       data-component="Spinner"
     />
   );
-};
-
-export default Spinner;
+}

--- a/src/components/feedback/SpinnerOverlay.tsx
+++ b/src/components/feedback/SpinnerOverlay.tsx
@@ -11,7 +11,7 @@ export type SpinnerOverlayProps = Omit<
 /**
  * Render a full-screen spinner atop a light-colored overlay
  */
-const SpinnerOverlay = function SpinnerOverlay({
+export default function SpinnerOverlay({
   ...htmlAttributes
 }: SpinnerOverlayProps) {
   return (
@@ -23,6 +23,4 @@ const SpinnerOverlay = function SpinnerOverlay({
       <Spinner size="lg" />
     </Overlay>
   );
-};
-
-export default SpinnerOverlay;
+}

--- a/src/components/input/Button.tsx
+++ b/src/components/input/Button.tsx
@@ -52,7 +52,7 @@ export type ButtonProps = PresentationalProps &
 /**
  * Render a button with optional icon
  */
-const Button = function Button({
+export default function Button({
   children,
   classes,
   elementRef,
@@ -121,6 +121,4 @@ const Button = function Button({
       {children}
     </button>
   );
-};
-
-export default Button;
+}

--- a/src/components/input/ButtonBase.tsx
+++ b/src/components/input/ButtonBase.tsx
@@ -51,7 +51,7 @@ export type ButtonBaseProps = BaseProps &
  *
  * @deprecated Use `Button` or `IconButton` with `unstyled` set instead
  */
-const ButtonBase = function ButtonBase({
+export default function ButtonBase({
   elementRef,
   children,
   classes,
@@ -103,6 +103,4 @@ const ButtonBase = function ButtonBase({
       {children}
     </button>
   );
-};
-
-export default ButtonBase;
+}

--- a/src/components/input/Checkbox.tsx
+++ b/src/components/input/Checkbox.tsx
@@ -32,7 +32,7 @@ export type CheckboxProps = CompositeProps &
  * one for the unchecked state and one for the checked state. The input itself
  * is positioned exactly on top of the icon, but is non-visible.
  */
-const Checkbox = function Checkbox({
+export default function Checkbox({
   children,
   elementRef,
 
@@ -108,6 +108,4 @@ const Checkbox = function Checkbox({
       {children}
     </label>
   );
-};
-
-export default Checkbox;
+}

--- a/src/components/input/IconButton.tsx
+++ b/src/components/input/IconButton.tsx
@@ -34,7 +34,7 @@ export type IconButtonProps = PresentationalProps &
 /**
  * Render a button that only contains an icon.
  */
-const IconButton = function IconButton({
+export default function IconButton({
   children,
   classes,
   elementRef,
@@ -98,6 +98,4 @@ const IconButton = function IconButton({
       {children}
     </Button>
   );
-};
-
-export default IconButton;
+}

--- a/src/components/input/Input.tsx
+++ b/src/components/input/Input.tsx
@@ -21,7 +21,7 @@ export type InputProps = PresentationalProps &
 /**
  * Render a text field input
  */
-const Input = function Input({
+export default function Input({
   elementRef,
   type = 'text',
   feedback,
@@ -39,6 +39,4 @@ const Input = function Input({
       {...htmlAttributes}
     />
   );
-};
-
-export default Input;
+}

--- a/src/components/input/InputGroup.tsx
+++ b/src/components/input/InputGroup.tsx
@@ -21,7 +21,7 @@ export type InputGroupProps = PresentationalProps &
 /**
  * Render a container that lays out a group of input components
  */
-const InputGroup = function InputGroup({
+export default function InputGroup({
   children,
   classes,
   elementRef,
@@ -44,6 +44,4 @@ const InputGroup = function InputGroup({
       {children}
     </div>
   );
-};
-
-export default InputGroup;
+}

--- a/src/components/input/InputRoot.tsx
+++ b/src/components/input/InputRoot.tsx
@@ -27,7 +27,7 @@ export type InputRootProps = PresentationalProps &
  * Root component for various input types that applies a consistent design
  * pattern.
  */
-const InputRoot = function InputRoot({
+export default function InputRoot({
   element: Element = 'input',
   children,
   classes,
@@ -71,6 +71,4 @@ const InputRoot = function InputRoot({
       {children}
     </Element>
   );
-};
-
-export default InputRoot;
+}

--- a/src/components/input/OptionButton.tsx
+++ b/src/components/input/OptionButton.tsx
@@ -16,7 +16,7 @@ export type OptionButtonProps = {
  * Render a button representing one of a set of options, with optional
  * right-aligned `details` content
  */
-const OptionButton = function OptionButton({
+export default function OptionButton({
   children,
   details,
   selected = false,
@@ -71,6 +71,4 @@ const OptionButton = function OptionButton({
       </div>
     </Button>
   );
-};
-
-export default OptionButton;
+}

--- a/src/components/input/Select.tsx
+++ b/src/components/input/Select.tsx
@@ -24,7 +24,7 @@ const arrowImage = `url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000
 /**
  * Style a native `<select>` element.
  */
-const Select = function Select({
+export default function Select({
   children,
   classes,
   type = 'text',
@@ -56,6 +56,4 @@ const Select = function Select({
       {children}
     </InputRoot>
   );
-};
-
-export default Select;
+}

--- a/src/components/input/Textarea.tsx
+++ b/src/components/input/Textarea.tsx
@@ -15,7 +15,7 @@ export type TextareaProps = PresentationalProps &
 /**
  * Render a textarea
  */
-const Textarea = function Textarea({
+export default function Textarea({
   elementRef,
   type = 'text',
   feedback,
@@ -32,6 +32,4 @@ const Textarea = function Textarea({
       {...htmlAttributes}
     />
   );
-};
-
-export default Textarea;
+}

--- a/src/components/layout/Card.tsx
+++ b/src/components/layout/Card.tsx
@@ -25,7 +25,7 @@ export type CardProps = PresentationalProps &
 /**
  * Render content in a card-like frame
  */
-const Card = function Card({
+export default function Card({
   children,
   classes,
   elementRef,
@@ -58,6 +58,4 @@ const Card = function Card({
       {children}
     </div>
   );
-};
-
-export default Card;
+}

--- a/src/components/layout/CardActions.tsx
+++ b/src/components/layout/CardActions.tsx
@@ -10,7 +10,7 @@ export type CardActionsProps = PresentationalProps &
 /**
  * Render a group of buttons or interactive elements inside a Card
  */
-const CardActions = function CardActions({
+export default function CardActions({
   children,
   classes,
   elementRef,
@@ -27,6 +27,4 @@ const CardActions = function CardActions({
       {children}
     </div>
   );
-};
-
-export default CardActions;
+}

--- a/src/components/layout/CardContent.tsx
+++ b/src/components/layout/CardContent.tsx
@@ -16,7 +16,7 @@ export type CardContentProps = PresentationalProps &
 /**
  * Apply consistent spacing and padding for actions content inside a Card
  */
-const CardContent = function CardContent({
+export default function CardContent({
   children,
   classes,
   elementRef,
@@ -42,6 +42,4 @@ const CardContent = function CardContent({
       {children}
     </div>
   );
-};
-
-export default CardContent;
+}

--- a/src/components/layout/CardHeader.tsx
+++ b/src/components/layout/CardHeader.tsx
@@ -34,7 +34,7 @@ export type CardHeaderProps = PresentationalProps &
 /**
  * Render a header area in a Card with optional title and/or close button
  */
-const CardHeader = function CardHeader({
+export default function CardHeader({
   children,
   classes,
   elementRef,
@@ -84,6 +84,4 @@ const CardHeader = function CardHeader({
       )}
     </div>
   );
-};
-
-export default CardHeader;
+}

--- a/src/components/layout/CardTitle.tsx
+++ b/src/components/layout/CardTitle.tsx
@@ -18,7 +18,7 @@ export type CardTitleProps = PresentationalProps &
 /**
  * Style a title for a Card
  */
-const CardTitle = function CardTitle({
+export default function CardTitle({
   children,
   classes,
   elementRef,
@@ -47,6 +47,4 @@ const CardTitle = function CardTitle({
       </WrapperElement>
     </div>
   );
-};
-
-export default CardTitle;
+}

--- a/src/components/layout/Overlay.tsx
+++ b/src/components/layout/Overlay.tsx
@@ -17,7 +17,7 @@ export type OverlayProps = PresentationalProps &
 /**
  * A full-screen fixed backdrop overlay
  */
-const Overlay = function Overlay({
+export default function Overlay({
   children,
   classes,
   elementRef,
@@ -48,6 +48,4 @@ const Overlay = function Overlay({
       {children}
     </div>
   );
-};
-
-export default Overlay;
+}

--- a/src/components/layout/Panel.tsx
+++ b/src/components/layout/Panel.tsx
@@ -54,7 +54,7 @@ export type PanelProps = CompositeProps &
  * Panel's immediate parent element, content (`children`) will scroll. The
  * header and any buttons will not scroll.
  */
-const Panel = function Panel({
+export default function Panel({
   children,
   elementRef,
 
@@ -104,6 +104,4 @@ const Panel = function Panel({
       )}
     </Card>
   );
-};
-
-export default Panel;
+}

--- a/src/components/navigation/Link.tsx
+++ b/src/components/navigation/Link.tsx
@@ -22,7 +22,7 @@ export type LinkProps = PresentationalProps &
 /**
  * Styled component for a link (`<a>` element).
  */
-const Link = function Link({
+export default function Link({
   children,
   classes,
   elementRef,
@@ -67,6 +67,4 @@ const Link = function Link({
       {children}
     </a>
   );
-};
-
-export default Link;
+}

--- a/src/components/navigation/LinkBase.tsx
+++ b/src/components/navigation/LinkBase.tsx
@@ -10,7 +10,7 @@ export type LinkBaseProps = BaseProps & JSX.HTMLAttributes<HTMLAnchorElement>;
  * Base component for Link components. Applies common attributes and styles.
  * @deprecated Use Link with styling API props instead
  */
-const LinkBase = function LinkBase({
+export default function LinkBase({
   children,
   classes,
   elementRef,
@@ -31,6 +31,4 @@ const LinkBase = function LinkBase({
       {children}
     </a>
   );
-};
-
-export default LinkBase;
+}

--- a/src/components/navigation/LinkButton.tsx
+++ b/src/components/navigation/LinkButton.tsx
@@ -25,7 +25,7 @@ export type LinkButtonProps = PresentationalProps &
 /**
  * Style a button as a link
  */
-const LinkButton = function LinkButton({
+export default function LinkButton({
   children,
   classes,
   elementRef,
@@ -76,6 +76,4 @@ const LinkButton = function LinkButton({
       {children}
     </Button>
   );
-};
-
-export default LinkButton;
+}

--- a/src/components/navigation/PointerButton.tsx
+++ b/src/components/navigation/PointerButton.tsx
@@ -31,7 +31,7 @@ export type PointerButtonProps = PresentationalProps &
  * The arrow-points are created by the combination of borders and positioning.
  * See https://css-tricks.com/snippets/css/css-triangle/
  */
-const PointerButton = function PointerButton({
+export default function PointerButton({
   children,
   classes,
   elementRef,
@@ -127,6 +127,4 @@ const PointerButton = function PointerButton({
       {children}
     </Button>
   );
-};
-
-export default PointerButton;
+}

--- a/src/components/navigation/Tab.tsx
+++ b/src/components/navigation/Tab.tsx
@@ -28,7 +28,7 @@ export type TabProps = PresentationalProps &
 /**
  * Render a button with appropriate ARIA tab affordances
  */
-const Tab = function Tab({
+export default function Tab({
   children,
   classes,
   elementRef,
@@ -103,6 +103,4 @@ const Tab = function Tab({
       </span>
     </Button>
   );
-};
-
-export default Tab;
+}

--- a/src/components/navigation/TabList.tsx
+++ b/src/components/navigation/TabList.tsx
@@ -24,7 +24,7 @@ export type TabListProps = PresentationalProps &
  * Render a tablist container for a set of tabs, with arrow key navigation per
  * https://www.w3.org/WAI/ARIA/apg/patterns/tabpanel/
  */
-const TabList = function TabList({
+export default function TabList({
   children,
   classes,
   elementRef,
@@ -57,6 +57,4 @@ const TabList = function TabList({
       {children}
     </div>
   );
-};
-
-export default TabList;
+}


### PR DESCRIPTION
Closes #1215 

This PR simplifies how components are exported, reducing symbol duplication.

It also takes the opportunity to remove some leftovers from the TypeScript migration.