### PR TITLE
Create SelectNext component replacing Select

### DIFF
--- a/src/components/input/Select.tsx
+++ b/src/components/input/Select.tsx
@@ -23,6 +23,7 @@ const arrowImage = `url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000
 
 /**
  * Style a native `<select>` element.
+ * @deprecated Use SelectNext instead
  */
 export default function Select({
   children,

--- a/src/components/input/SelectContext.ts
+++ b/src/components/input/SelectContext.ts
@@ -1,0 +1,10 @@
+import { createContext } from 'preact';
+
+export type SelectContextType<T = unknown> = {
+  selectValue: (newValue: T) => void;
+  value: T;
+};
+
+const SelectContext = createContext<SelectContextType | null>(null);
+
+export default SelectContext;

--- a/src/components/input/SelectNext.tsx
+++ b/src/components/input/SelectNext.tsx
@@ -1,0 +1,198 @@
+import classnames from 'classnames';
+import type { ComponentChildren } from 'preact';
+import {
+  useCallback,
+  useContext,
+  useId,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from 'preact/hooks';
+
+import { useArrowKeyNavigation } from '../../hooks/use-arrow-key-navigation';
+import { useClickAway } from '../../hooks/use-click-away';
+import { useKeyPress } from '../../hooks/use-key-press';
+import { useSyncedRef } from '../../hooks/use-synced-ref';
+import type { PresentationalProps } from '../../types';
+import { MenuCollapseIcon, MenuExpandIcon } from '../icons';
+import Button from './Button';
+import SelectContext from './SelectContext';
+
+export type SelectOptionStatus = {
+  selected: boolean;
+  disabled: boolean;
+};
+
+export type SelectOptionProps<T> = {
+  value: T;
+  disabled?: boolean;
+  children: (status: SelectOptionStatus) => ComponentChildren;
+  classes?: string | string[];
+};
+
+function SelectOption<T>({
+  value,
+  children,
+  disabled = false,
+  classes,
+}: SelectOptionProps<T>) {
+  const selectContext = useContext(SelectContext);
+  if (!selectContext) {
+    throw new Error('Select.Option can only be used as Select child');
+  }
+
+  const { selectValue, value: currentValue } = selectContext;
+  const selected = !disabled && currentValue === value;
+
+  return (
+    <Button
+      variant="custom"
+      classes={classnames(
+        'w-full ring-inset rounded-none !p-0',
+        'border-t first:border-t-0 bg-transparent',
+        { 'hover:bg-grey-1': !disabled },
+        classes,
+      )}
+      onClick={() => selectValue(value)}
+      role="option"
+      disabled={disabled}
+      aria-selected={selected}
+      // This is intended to be focused with arrow keys
+      tabIndex={-1}
+    >
+      <div
+        className={classnames('flex w-full p-1.5 border-l-4', {
+          'border-l-transparent': !selected,
+          'border-l-brand font-medium': selected,
+        })}
+      >
+        {children({ selected, disabled })}
+      </div>
+    </Button>
+  );
+}
+
+export type SelectProps<T> = PresentationalProps & {
+  value: T;
+  onChange: (newValue: T) => void;
+  label: ComponentChildren;
+  disabled?: boolean;
+};
+
+function SelectMain<T>({
+  label,
+  value,
+  onChange,
+  children,
+  disabled,
+  classes,
+  elementRef,
+}: SelectProps<T>) {
+  const [listboxOpen, setListboxOpen] = useState(false);
+  const [shouldListboxDropUp, setShouldListboxDropUp] = useState(false);
+  const closeListbox = useCallback(() => setListboxOpen(false), []);
+  const wrapperRef = useRef<HTMLDivElement | null>(null);
+  const listboxRef = useRef<HTMLDivElement | null>(null);
+  const listboxId = useId();
+  const buttonRef = useSyncedRef(elementRef);
+  const buttonId = useId();
+
+  const selectValue = useCallback(
+    (newValue: unknown) => {
+      onChange(newValue as T);
+      closeListbox();
+    },
+    [closeListbox, onChange],
+  );
+
+  // When clicking away or pressing `Esc`, close the listbox
+  useClickAway(wrapperRef, closeListbox);
+  useKeyPress(['Escape'], closeListbox);
+
+  // Vertical arrow key for options in the listbox
+  useArrowKeyNavigation(wrapperRef, { horizontal: false });
+
+  useLayoutEffect(() => {
+    if (!listboxOpen) {
+      // Focus button after closing listbox
+      buttonRef.current!.focus();
+      // Reset shouldDropUp so that it does not affect calculations next time
+      // it opens
+      setShouldListboxDropUp(false);
+    } else {
+      const viewportHeight = window.innerHeight;
+      const { top: buttonDistanceToTop, bottom: buttonBottom } =
+        buttonRef.current!.getBoundingClientRect();
+      const buttonDistanceToBottom = viewportHeight - buttonBottom;
+      const { bottom: listboxBottom } =
+        listboxRef.current!.getBoundingClientRect();
+      const listboxDistanceToBottom = viewportHeight - listboxBottom;
+
+      // The listbox should drop up only if there's not enough space below to
+      // fit it, and there's also more absolute space above than below
+      setShouldListboxDropUp(
+        listboxDistanceToBottom < 0 &&
+          buttonDistanceToTop > buttonDistanceToBottom,
+      );
+    }
+  }, [buttonRef, listboxOpen]);
+
+  return (
+    <div className="relative" ref={wrapperRef}>
+      <Button
+        id={buttonId}
+        variant="custom"
+        classes={classnames(
+          'w-full flex border',
+          'bg-grey-0 disabled:bg-grey-1 disabled:text-grey-6',
+          classes,
+        )}
+        expanded={listboxOpen}
+        disabled={disabled}
+        aria-haspopup="listbox"
+        aria-controls={listboxId}
+        elementRef={buttonRef}
+        onClick={() => setListboxOpen(prev => !prev)}
+        onKeyDown={e => {
+          if (e.key === 'ArrowDown' && !listboxOpen) {
+            setListboxOpen(true);
+          }
+        }}
+        data-testid="select-toggle-button"
+      >
+        {label}
+        <div className="grow" />
+        {listboxOpen ? <MenuCollapseIcon /> : <MenuExpandIcon />}
+      </Button>
+      <SelectContext.Provider value={{ selectValue, value }}>
+        <div
+          className={classnames(
+            'absolute z-5 w-full max-h-80 overflow-y-auto',
+            'rounded border bg-white shadow hover:shadow-md focus-within:shadow-md',
+            {
+              'top-full mt-1': !shouldListboxDropUp,
+              'bottom-full mb-1': shouldListboxDropUp,
+
+              // Hiding instead of unmounting to
+              // * Ensure screen readers detect button as a listbox handler
+              // * Listbox size can be computed to correctly drop up or down
+              hidden: !listboxOpen,
+            },
+          )}
+          role="listbox"
+          ref={listboxRef}
+          id={listboxId}
+          aria-labelledby={buttonId}
+          aria-orientation="vertical"
+          data-testid="select-listbox"
+        >
+          {children}
+        </div>
+      </SelectContext.Provider>
+    </div>
+  );
+}
+
+const SelectNext = Object.assign(SelectMain, { Option: SelectOption });
+
+export default SelectNext;

--- a/src/components/input/index.ts
+++ b/src/components/input/index.ts
@@ -7,6 +7,7 @@ export { default as Input } from './Input';
 export { default as InputGroup } from './InputGroup';
 export { default as OptionButton } from './OptionButton';
 export { default as Select } from './Select';
+export { default as SelectNext } from './SelectNext';
 export { default as Textarea } from './Textarea';
 
 export type { ButtonProps } from './Button';
@@ -18,4 +19,5 @@ export type { InputProps } from './Input';
 export type { InputGroupProps } from './InputGroup';
 export type { OptionButtonProps } from './OptionButton';
 export type { SelectProps } from './Select';
+export type { SelectProps as SelectNextProps } from './SelectNext';
 export type { TextareaProps } from './Textarea';

--- a/src/components/input/test/SelectNext-test.js
+++ b/src/components/input/test/SelectNext-test.js
@@ -1,0 +1,218 @@
+import { mount } from 'enzyme';
+
+import { checkAccessibility } from '../../../../test/util/accessibility.js';
+import SelectNext from '../SelectNext';
+
+describe('SelectNext', () => {
+  let wrappers;
+  const items = [
+    { id: '1', name: 'All students' },
+    { id: '2', name: 'Albert Banana' },
+    { id: '3', name: 'Bernard California' },
+    { id: '4', name: 'Cecelia Davenport' },
+    { id: '5', name: 'Doris Evanescence' },
+  ];
+
+  const createComponent = (props = {}, paddingTop = 0) => {
+    const container = document.createElement('div');
+    container.style.paddingTop = `${paddingTop}px`;
+    document.body.append(container);
+
+    const wrapper = mount(
+      <SelectNext value={undefined} onChange={sinon.stub()} label="" {...props}>
+        {items.map(item => (
+          <SelectNext.Option
+            value={item}
+            disabled={item.id === '4'}
+            key={item.id}
+          >
+            {({ selected, disabled }) => (
+              <span data-testid={`option-${item.id}`}>
+                {item.name}
+                {selected && <span data-testid="selected-option" />}
+                {disabled && <span data-testid="disabled-option" />}
+              </span>
+            )}
+          </SelectNext.Option>
+        ))}
+      </SelectNext>,
+      { attachTo: container },
+    );
+
+    wrappers.push(wrapper);
+
+    return wrapper;
+  };
+
+  beforeEach(() => {
+    wrappers = [];
+  });
+
+  afterEach(() => {
+    wrappers.forEach(wrapper => wrapper.unmount());
+  });
+
+  const getToggleButton = wrapper =>
+    wrapper.find('button[data-testid="select-toggle-button"]');
+
+  const toggleListbox = wrapper => getToggleButton(wrapper).simulate('click');
+
+  const getListbox = wrapper => wrapper.find('[data-testid="select-listbox"]');
+
+  const isListboxClosed = wrapper =>
+    getListbox(wrapper).prop('className').includes('hidden');
+
+  const listboxDidDropUp = wrapper =>
+    getListbox(wrapper).prop('className').includes('bottom-full');
+
+  it('changes selected value when an option is clicked', () => {
+    const onChange = sinon.stub();
+    const wrapper = createComponent({ onChange });
+
+    wrapper.find('[data-testid="option-3"]').simulate('click');
+    assert.calledWith(onChange.lastCall, items[2]);
+
+    wrapper.find('[data-testid="option-5"]').simulate('click');
+    assert.calledWith(onChange.lastCall, items[4]);
+
+    wrapper.find('[data-testid="option-1"]').simulate('click');
+    assert.calledWith(onChange.lastCall, items[0]);
+  });
+
+  it('marks the right item as selected', () => {
+    const wrapper = createComponent({ value: items[2] });
+    const isOptionSelected = id =>
+      wrapper
+        .find(`[data-testid="option-${id}"]`)
+        .exists('[data-testid="selected-option"]');
+
+    assert.isFalse(isOptionSelected(1));
+    assert.isFalse(isOptionSelected(2));
+    assert.isTrue(isOptionSelected(3));
+    assert.isFalse(isOptionSelected(4));
+    assert.isFalse(isOptionSelected(5));
+  });
+
+  it('marks the right item as disabled', () => {
+    const wrapper = createComponent();
+    const isOptionDisabled = id =>
+      wrapper
+        .find(`[data-testid="option-${id}"]`)
+        .exists('[data-testid="disabled-option"]');
+
+    assert.isFalse(isOptionDisabled(1));
+    assert.isFalse(isOptionDisabled(2));
+    assert.isFalse(isOptionDisabled(3));
+    assert.isTrue(isOptionDisabled(4));
+    assert.isFalse(isOptionDisabled(5));
+  });
+
+  it('toggles listbox when button is clicked', () => {
+    const wrapper = createComponent();
+
+    assert.isTrue(isListboxClosed(wrapper));
+    toggleListbox(wrapper);
+    assert.isFalse(isListboxClosed(wrapper));
+  });
+
+  it('closes listbox when Escape is pressed', () => {
+    const wrapper = createComponent();
+
+    toggleListbox(wrapper);
+    assert.isFalse(isListboxClosed(wrapper));
+
+    document.body.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'Escape' }),
+    );
+    wrapper.update();
+
+    // Listbox is closed after `Escape` is pressed
+    assert.isTrue(isListboxClosed(wrapper));
+  });
+
+  it('closes listbox when clicking away', () => {
+    const wrapper = createComponent();
+
+    toggleListbox(wrapper);
+    assert.isFalse(isListboxClosed(wrapper));
+
+    const externalButton = document.createElement('button');
+    document.body.append(externalButton);
+
+    externalButton.click();
+    wrapper.update();
+
+    try {
+      // Listbox is closed after other element is clicked
+      assert.isTrue(isListboxClosed(wrapper));
+    } finally {
+      externalButton.remove();
+    }
+  });
+
+  it('restores focus to toggle button after closing listbox', () => {
+    const wrapper = createComponent();
+    toggleListbox(wrapper);
+
+    // Focus body before closing listbox
+    document.body.focus();
+    toggleListbox(wrapper);
+    wrapper.update();
+
+    assert.equal(document.activeElement, getToggleButton(wrapper).getDOMNode());
+  });
+
+  it('displays listbox when ArrowDown is pressed on toggle', () => {
+    const wrapper = createComponent();
+
+    assert.isTrue(isListboxClosed(wrapper));
+
+    getToggleButton(wrapper)
+      .getDOMNode()
+      .dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+    wrapper.update();
+
+    assert.isFalse(isListboxClosed(wrapper));
+  });
+
+  [
+    { containerPaddingTop: 0, shouldDropUp: false },
+    { containerPaddingTop: 1000, shouldDropUp: true },
+  ].forEach(({ containerPaddingTop, shouldDropUp }) => {
+    it('makes listbox drop up or down based on available space below', () => {
+      const wrapper = createComponent({}, containerPaddingTop);
+      toggleListbox(wrapper);
+
+      assert.equal(listboxDidDropUp(wrapper), shouldDropUp);
+    });
+  });
+
+  context('when Option is rendered outside of SelectNext', () => {
+    it('throws an error', () => {
+      assert.throws(
+        () =>
+          mount(<SelectNext.Option value="1">{() => '1'}</SelectNext.Option>),
+        'Select.Option can only be used as Select child',
+      );
+    });
+  });
+
+  it(
+    'should pass a11y checks',
+    checkAccessibility([
+      {
+        name: 'Closed Select listbox',
+        content: () => createComponent({ label: 'Select' }),
+      },
+      {
+        name: 'Open Select listbox',
+        content: () => {
+          const wrapper = createComponent({ label: 'Select' });
+          toggleListbox(wrapper);
+
+          return wrapper;
+        },
+      },
+    ]),
+  );
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,6 +43,7 @@ export {
   InputGroup,
   OptionButton,
   Select,
+  SelectNext,
   Textarea,
 } from './components/input';
 export {
@@ -108,6 +109,7 @@ export type {
   InputGroupProps,
   OptionButtonProps,
   SelectProps,
+  SelectNextProps,
   TextareaProps,
 } from './components/input';
 

--- a/src/pattern-library/components/patterns/input/SelectPage.tsx
+++ b/src/pattern-library/components/patterns/input/SelectPage.tsx
@@ -26,10 +26,18 @@ export default function SelectPage() {
     <Library.Page
       title="Select"
       intro={
-        <p>
-          <code>Select</code> is a presentational component that styles native{' '}
-          <code>{'<select>'}</code> elements.
-        </p>
+        <>
+          <p>
+            <code>Select</code> is a presentational component that styles native{' '}
+            <code>{'<select>'}</code> elements.
+          </p>
+          <p>
+            <code>Select</code> is <Library.StatusChip status="deprecated" />,
+            use{' '}
+            <Library.Link href="/input-select-next">SelectNext</Library.Link>{' '}
+            instead.
+          </p>
+        </>
       }
     >
       <Library.Section>

--- a/src/pattern-library/components/patterns/prototype/SelectNextPage.tsx
+++ b/src/pattern-library/components/patterns/prototype/SelectNextPage.tsx
@@ -1,0 +1,325 @@
+import classnames from 'classnames';
+import { useCallback, useMemo, useState } from 'preact/hooks';
+
+import { ArrowLeftIcon, ArrowRightIcon } from '../../../../components/icons';
+import { IconButton, InputGroup } from '../../../../components/input';
+import Select from '../../../../components/input/SelectNext';
+import Library from '../../Library';
+
+const defaultItems = [
+  { id: '1', name: 'All students' },
+  { id: '2', name: 'Albert Banana' },
+  { id: '3', name: 'Bernard California' },
+  { id: '4', name: 'Cecelia Davenport' },
+  { id: '5', name: 'Doris Evanescence' },
+];
+
+function SelectExample({
+  disabled,
+  textOnly,
+  items = defaultItems,
+}: {
+  disabled?: boolean;
+  textOnly?: boolean;
+  items?: typeof defaultItems;
+}) {
+  const [value, setValue] = useState<(typeof items)[number]>();
+
+  return (
+    <Select
+      value={value}
+      onChange={setValue}
+      label={
+        value ? (
+          <>
+            {value.name}
+            {!textOnly && (
+              <div className="rounded px-2 bg-grey-7 text-white">
+                {value.id}
+              </div>
+            )}
+          </>
+        ) : disabled ? (
+          <>This is disabled</>
+        ) : (
+          <>Select one...</>
+        )
+      }
+      disabled={disabled}
+    >
+      {items.map(item => (
+        <Select.Option value={item} key={item.id}>
+          {() =>
+            textOnly ? (
+              <>{item.name}</>
+            ) : (
+              <>
+                {item.name}
+                <div className="grow" />
+                <div className="rounded px-2 bg-grey-7 text-white">
+                  {item.id}
+                </div>
+              </>
+            )
+          }
+        </Select.Option>
+      ))}
+    </Select>
+  );
+}
+
+function InputGroupSelectExample() {
+  const [selected, setSelected] = useState<(typeof defaultItems)[number]>();
+  const selectedIndex = useMemo(
+    () => (!selected ? -1 : defaultItems.findIndex(item => item === selected)),
+    [selected],
+  );
+  const next = useCallback(() => {
+    const newIndex = selectedIndex + 1;
+    setSelected(defaultItems[newIndex] ?? selected);
+  }, [selected, selectedIndex]);
+  const previous = useCallback(() => {
+    const newIndex = selectedIndex - 1;
+    setSelected(defaultItems[newIndex] ?? selected);
+  }, [selected, selectedIndex]);
+
+  return (
+    <InputGroup>
+      <IconButton
+        icon={ArrowLeftIcon}
+        title="Previous student"
+        variant="dark"
+        onClick={previous}
+        disabled={selectedIndex <= 0}
+      />
+      <div className="w-full">
+        <Select
+          value={selected}
+          onChange={setSelected}
+          label={
+            selected ? (
+              <>
+                {selected.name}
+                <div className="rounded px-2 bg-grey-7 text-white">
+                  {selected.id}
+                </div>
+              </>
+            ) : (
+              <>Select one...</>
+            )
+          }
+        >
+          {defaultItems.map(item => (
+            <Select.Option value={item} key={item.id}>
+              {() => (
+                <>
+                  {item.name}
+                  <div className="grow" />
+                  <div
+                    className={classnames('rounded px-2 text-white bg-grey-7')}
+                  >
+                    {item.id}
+                  </div>
+                </>
+              )}
+            </Select.Option>
+          ))}
+        </Select>
+      </div>
+      <IconButton
+        icon={ArrowRightIcon}
+        title="Next student"
+        variant="dark"
+        onClick={next}
+        disabled={selectedIndex >= defaultItems.length - 1}
+      />
+    </InputGroup>
+  );
+}
+
+export default function SelectNextPage() {
+  return (
+    <Library.Page
+      title="SelectNext"
+      intro={
+        <p>
+          <code>SelectNext</code> is a presentational component which behaves
+          like the native <code>{'<select>'}</code> element.
+        </p>
+      }
+    >
+      <Library.Section>
+        <Library.Pattern>
+          <Library.Usage componentName="SelectNext" />
+
+          <Library.Example>
+            <Library.Demo title="Basic Select">
+              <div className="w-[350px] mx-auto">
+                <SelectExample textOnly />
+              </div>
+            </Library.Demo>
+          </Library.Example>
+        </Library.Pattern>
+
+        <Library.Pattern title="Working with SelectNext">
+          <p>
+            <code>SelectNext</code> toggles a listbox where <code>Options</code>
+            {"'"} UI can be customized and values can be objects.
+          </p>
+
+          <Library.Example title="Composing and styling Selects">
+            <Library.Demo title="Select with custom Options">
+              <div className="w-96">
+                <SelectExample />
+              </div>
+            </Library.Demo>
+
+            <Library.Demo title="Select in InputGroup">
+              <div className="w-96">
+                <InputGroupSelectExample />
+              </div>
+            </Library.Demo>
+          </Library.Example>
+
+          <Library.Example title="Select with many options">
+            <Library.Demo title="Select with many options">
+              <div className="w-[350px] mx-auto">
+                <SelectExample
+                  items={[
+                    ...defaultItems.map(({ id, name }) => ({
+                      id: `1${id}`,
+                      name: `1 ${name}`,
+                    })),
+                    ...defaultItems.map(({ id, name }) => ({
+                      id: `2${id}`,
+                      name: `2 ${name}`,
+                    })),
+                    ...defaultItems.map(({ id, name }) => ({
+                      id: `3${id}`,
+                      name: `3 ${name}`,
+                    })),
+                    ...defaultItems.map(({ id, name }) => ({
+                      id: `4${id}`,
+                      name: `4 ${name}`,
+                    })),
+                    ...defaultItems.map(({ id, name }) => ({
+                      id: `5${id}`,
+                      name: `5 ${name}`,
+                    })),
+                    ...defaultItems.map(({ id, name }) => ({
+                      id: `6${id}`,
+                      name: `6 ${name}`,
+                    })),
+                  ]}
+                />
+              </div>
+            </Library.Demo>
+          </Library.Example>
+
+          <Library.Example title="Disabled Select">
+            <Library.Demo title="Disabled Select">
+              <div className="w-[350px] mx-auto">
+                <SelectExample disabled />
+              </div>
+            </Library.Demo>
+          </Library.Example>
+        </Library.Pattern>
+
+        <Library.Pattern title="Component API">
+          <code>SelectNext</code> accepts all standard{' '}
+          <Library.Link href="/using-components#presentational-components-api">
+            presentational component props
+          </Library.Link>
+          <Library.Example title="label">
+            <Library.Info>
+              <Library.InfoItem label="description">
+                The content to be displayed in the toggle button.
+              </Library.InfoItem>
+              <Library.InfoItem label="type">
+                <code>ComponentChildren</code>
+              </Library.InfoItem>
+            </Library.Info>
+          </Library.Example>
+          <Library.Example title="value">
+            <Library.Info>
+              <Library.InfoItem label="description">
+                Represents currently selected Option.
+              </Library.InfoItem>
+              <Library.InfoItem label="type">
+                <code>T</code>
+              </Library.InfoItem>
+            </Library.Info>
+          </Library.Example>
+          <Library.Example title="onChange">
+            <Library.Info>
+              <Library.InfoItem label="description">
+                A callback invoked every time selected value changes.
+              </Library.InfoItem>
+              <Library.InfoItem label="type">
+                <code>(newValue: T) =&gt; void</code>
+              </Library.InfoItem>
+            </Library.Info>
+          </Library.Example>
+          <Library.Example title="disabled">
+            <Library.Info>
+              <Library.InfoItem label="description">
+                Whether the Select is disabled or not.
+              </Library.InfoItem>
+              <Library.InfoItem label="type">
+                <code>boolean</code>
+              </Library.InfoItem>
+              <Library.InfoItem label="default">
+                <code>undefined</code>
+              </Library.InfoItem>
+            </Library.Info>
+          </Library.Example>
+        </Library.Pattern>
+
+        <Library.Pattern title="How to use it">
+          <p>
+            <code>SelectNext</code> is meant to be used as a controlled
+            component.
+          </p>
+
+          <Library.Code
+            content={`function App() {
+  const [value, setSelected] = useState<{ id: string; name: string }>();
+  return (
+    <SelectNext
+      value={value}
+      onChange={setSelected}
+      label={
+        value ? (
+          <>
+            {value.name}
+            <div className="rounded px-2 bg-grey-7 text-white">
+              {value.id}
+            </div>
+          </>
+        ) : (
+          <>Select one...</>
+        )
+      }
+    >
+      {items.map(item => (
+        <SelectNext.Option value={item} key={item.id}>
+          {() => (
+            <>
+              {item.name}
+              <div className="grow" />
+              <div className="rounded px-2 bg-grey-7 text-white">
+                {item.id}
+              </div>
+            </>
+          )}
+        </SelectNext.Option>
+      ))}
+    </SelectNext>
+  );
+}`}
+          />
+        </Library.Pattern>
+      </Library.Section>
+    </Library.Page>
+  );
+}

--- a/src/pattern-library/routes.ts
+++ b/src/pattern-library/routes.ts
@@ -32,6 +32,7 @@ import PointerButtonPage from './components/patterns/navigation/PointerButtonPag
 import TabPage from './components/patterns/navigation/TabPage';
 import LMSContentButtonPage from './components/patterns/prototype/LMSContentButtonPage';
 import LMSContentSelectionPage from './components/patterns/prototype/LMSContentSelectionPage';
+import SelectNextPage from './components/patterns/prototype/SelectNextPage';
 import SharedAnnotationsPage from './components/patterns/prototype/SharedAnnotationsPage';
 import TabbedDialogPage from './components/patterns/prototype/TabbedDialogPage';
 import SliderPage from './components/patterns/transition/SliderPage';
@@ -194,6 +195,12 @@ const routes: PlaygroundRoute[] = [
     group: 'input',
     component: OptionButtonPage,
     route: '/input-option-button',
+  },
+  {
+    title: 'SelectNext',
+    group: 'input',
+    component: SelectNextPage,
+    route: '/input-select-next',
   },
   {
     title: 'Select',


### PR DESCRIPTION
Create a new `SelectNext` component, which is meant to replace existing `Select` one.

The benefits it presents include being able to customize the listbox UI, and supporting complex objects as values.

`SelectNext` is a controlled component designed to be used like this:

```tsx
import { SelectNext } from '@hypothesis/frontend-shared';

const items = [
  { id: 1, name: 'All students' },
  { id: 2, name: 'Albert Banana' },
  { id: 3, name: 'Bernard California' },
  { id: 4, name: 'Cecelia Davenport' },
  { id: 5, name: 'Doris Evanescence' },
];

function App() {
  const [value, setValue] = useState<(typeof items)[number]>();

  return (
    <SelectNext
      selected={value}
      onChange={setValue}
      label={
        value ? (
          <>{value.name} ({value.id})</>
        ) : (
          <>Select one...</>
        )
      }
    >
      {items.map(item => (
        <SelectNext.Option value={item} key={item.id}>
          {({ disabled, isSelected }) => <>{item.name} ({item.id})</>}
        </SelectNext.Option>
      ))}
    </SelectNext>
  )
}
```

Existing `Select` is now marked as deprecated, and the plan is to remove it on next major release, while we also rename `SelectNext` to plain `Select`.

### TODO

- [x] Add test
- [x] Fix a11y issues highlighted when testing Select

### Follow up improvements

There are a couple of things we can improve, but it would be better to tackle separately to avoid a PR bigger than it already is:

- Handle too long content in options or select (overflow ellipsis?).
- Prevent looping back to top/bottom in arrow keys navigation when reaching the end of the list. [See comment](https://github.com/hypothesis/frontend-shared/pull/1237#discussion_r1331767946).
- Exclude the select toggle button from the arrow key navigation sequence. [See comment](https://github.com/hypothesis/frontend-shared/pull/1237#discussion_r1332634012).
- Close listbox when focus moves to some other component (make sure the toggle button is not focused in this case).

Nice to have:

- Support searching/filtering: See technical proposal https://github.com/hypothesis/frontend-shared/pull/1237#issuecomment-1723436418
- Support `feedback="error"` and `feedback="warning"` like the existing Select does.

> A big chunk of this PR is the new pattern library documentation page that you can see by checking out this branch and going to http://localhost:4001/input-select-next

Closes https://github.com/hypothesis/frontend-shared/issues/1223