### PR TITLE
Make Dialog API more strict depending on variation

### DIFF
--- a/src/components/feedback/ModalDialog.tsx
+++ b/src/components/feedback/ModalDialog.tsx
@@ -5,7 +5,7 @@ import { useTabKeyNavigation } from '../../hooks/use-tab-key-navigation';
 import { downcastRef } from '../../util/typing';
 import Overlay from '../layout/Overlay';
 import Dialog from './Dialog';
-import type { DialogProps } from './Dialog';
+import type { PanelDialogProps } from './Dialog';
 
 type ModalWidth = 'sm' | 'md' | 'lg' | 'custom';
 
@@ -39,7 +39,7 @@ type ComponentProps = {
 };
 
 export type ModalDialogProps = Omit<
-  DialogProps,
+  PanelDialogProps,
   'restoreFocus' | 'closeOnEscape'
 > &
   ComponentProps;

--- a/src/components/feedback/test/Dialog-test.js
+++ b/src/components/feedback/test/Dialog-test.js
@@ -302,9 +302,7 @@ describe('Dialog', () => {
 
     it('allows custom layout', () => {
       const wrapper = mount(
-        <Dialog title="My dialog" variant="custom">
-          This is my content
-        </Dialog>,
+        <Dialog variant="custom">This is my content</Dialog>,
       );
       assert.isFalse(wrapper.find('Panel').exists());
     });

--- a/src/pattern-library/components/patterns/feedback/DialogPage.tsx
+++ b/src/pattern-library/components/patterns/feedback/DialogPage.tsx
@@ -59,7 +59,6 @@ type Dialog_Props = DialogProps & {
  * multiple examples plausible and convenient.
  */
 function Dialog_({
-  buttons,
   _alwaysShowButton = false,
   _nonCloseable,
   children,
@@ -67,13 +66,15 @@ function Dialog_({
 }: Dialog_Props) {
   const [dialogOpen, setDialogOpen] = useState(false);
   const closeDialog = () => setDialogOpen(false);
-
   const closeHandler = _nonCloseable ? undefined : closeDialog;
-  const forwardedButtons = buttons ? (
-    buttons
-  ) : (
-    <Button onClick={closeDialog}>Escape!</Button>
-  );
+  const panelProps =
+    dialogProps.variant !== 'custom'
+      ? {
+          buttons: dialogProps.buttons ?? (
+            <Button onClick={closeDialog}>Escape!</Button>
+          ),
+        }
+      : undefined;
 
   const openButton = (
     <Button onClick={() => setDialogOpen(!dialogOpen)} variant="primary">
@@ -86,11 +87,7 @@ function Dialog_({
       {(!dialogOpen || _alwaysShowButton) && <div>{openButton}</div>}
       <div className="grow">
         {dialogOpen && (
-          <Dialog
-            buttons={forwardedButtons}
-            {...dialogProps}
-            onClose={closeHandler}
-          >
+          <Dialog {...panelProps} {...dialogProps} onClose={closeHandler}>
             {children}
           </Dialog>
         )}
@@ -238,7 +235,6 @@ export default function DialogPage() {
             </p>
             <Library.Demo title="Dialog with custom layout" withSource>
               <Dialog_
-                title="Custom layout"
                 onClose={() => {}}
                 variant="custom"
                 transitionComponent={Slider}

--- a/src/pattern-library/components/patterns/input/CloseButtonPage.tsx
+++ b/src/pattern-library/components/patterns/input/CloseButtonPage.tsx
@@ -69,7 +69,7 @@ export default function CloseButtonPage() {
               <code>onClick</code> prop in these cases.
             </p>
             <Library.Demo title="Dialog with CloseButton" withSource>
-              <Dialog_ variant="custom" title="Example Dialog">
+              <Dialog_ variant="custom">
                 <div className="flex gap-x-3">
                   <div className="grow">Example custom dialog</div>
                   <CloseButton />

--- a/src/pattern-library/components/patterns/prototype/TabbedDialogPage.tsx
+++ b/src/pattern-library/components/patterns/prototype/TabbedDialogPage.tsx
@@ -105,7 +105,6 @@ function TabbedDialog() {
         {panelOpen && (
           <Dialog
             variant="custom"
-            title="Panel with three tabs"
             onClose={() => setPanelOpen(false)}
             restoreFocus
           >
@@ -204,7 +203,6 @@ function TabbedSharePanel() {
         {panelOpen && (
           <Dialog
             variant="custom"
-            title="Share annotations"
             onClose={() => setPanelOpen(false)}
             transitionComponent={Slider}
             restoreFocus


### PR DESCRIPTION
This PR has been motivated by current requirement to pass some title (like `title=""`) when using `variant="custom"` in `Dialog`, even though that title is then ignored.

### Context

When the `Dialog` component was created, it was designed to wrap a `Panel`, and therefore, it extended some props from it that were later forwarded to the wrapped `Panel`.

Later, there was a use case to render a simpler `Dialog` where having to deal with a panel was inconvenient, and we introduced the `variant` prop, which could have values `'panel' | 'custom'`, being `panel` its default, and making provided children be rendered verbatim (not wrapped in a `Panel`) when value `custom` was provided.

However, the rest of the props API was the same, making some of the required `Panel` props still be required for `Dialog`, even when there's no `Panel` involved if `variant="custom"`.

### Actions taken

This PR updates the `Dialog` props so that its defined as a union type, where the `variant` prop is used to determine if the `Panel` props are required or not.

This way, we can continue defining panel dialogs, if no `variant` is provided, or it is provided with value `panel`:

```tsx
<Dialog title="Some dialog" buttons={...} icon={...} />

<Dialog variant="panel" title="Some dialog" buttons={...} icon={...} />
```

On the other hand, we can define custom dialogs where the panel props won't be required (in fact, they won't be allowed)

```tsx
<Dialog variant="custom" closeOnEscape restoreFocus />
```

### Considerations

The solution proposed here is the more resilient for consumers, as you will always be forced to provide a title as long as variation is `panel`, while you will be reminded no title can be used for `custom` dialogs.

However, it makes the `Dialog` implementation a bit complex, due to the mix of Panel props, Dialog props and HTML attributes, which requires a couple of type guard checks and multiple prop unpacking.

A more pragmatic solution would be to just define `title` as optional, and set a default fallback value when passing it down to the Panel. 

However, this solution is more prone to mistakes on consumers.