### PR TITLE
Use grey-6 color for SelectNext chevron

### DIFF
--- a/src/components/input/SelectNext.tsx
+++ b/src/components/input/SelectNext.tsx
@@ -162,7 +162,9 @@ function SelectMain<T>({
       >
         {label}
         <div className="grow" />
-        {listboxOpen ? <MenuCollapseIcon /> : <MenuExpandIcon />}
+        <div className="text-grey-6">
+          {listboxOpen ? <MenuCollapseIcon /> : <MenuExpandIcon />}
+        </div>
       </Button>
       <SelectContext.Provider value={{ selectValue, value }}>
         <div


### PR DESCRIPTION
Closes #1250 

While experimenting with `SelectNext` in client, I realized the chevron didn't have a fixed color, but instead it was inheriting default page color.

That was less obvious in the pattern library, as it uses a lighter color, but in client it was rendering on a too dark color.

This PR sets a fixed `text-grey-6` on the chevron for a more predictable result.

Before:

![image](https://github.com/hypothesis/frontend-shared/assets/2719332/d575ce3f-44df-435f-a389-5db25d8f6973)

After:

![image](https://github.com/hypothesis/frontend-shared/assets/2719332/5904c0c4-32be-4a08-9ef1-7c0650a1ffe0)
