### PR TITLE
Add arrow key navigation `loop` option and use it in `SelectNext`

### DIFF
--- a/src/components/input/SelectNext.tsx
+++ b/src/components/input/SelectNext.tsx
@@ -110,7 +110,7 @@ function SelectMain<T>({
   useKeyPress(['Escape'], closeListbox);
 
   // Vertical arrow key for options in the listbox
-  useArrowKeyNavigation(wrapperRef, { horizontal: false });
+  useArrowKeyNavigation(wrapperRef, { horizontal: false, loop: false });
 
   useLayoutEffect(() => {
     if (!listboxOpen) {

--- a/src/hooks/test/use-arrow-key-navigation-test.js
+++ b/src/hooks/test/use-arrow-key-navigation-test.js
@@ -329,4 +329,24 @@ describe('useArrowKeyNavigation', () => {
     // nb. tabIndex update is async because it uses MutationObserver
     await waitFor(() => italicButton.tabIndex === 0);
   });
+
+  it('should not loop if disabled', () => {
+    renderToolbar({ loop: false });
+
+    // Focus last element
+    findElementByTestId('help').focus();
+
+    // Clicking down or right should not move focus back to the first element
+    pressKey('ArrowDown');
+    pressKey('ArrowRight');
+    assert.equal(currentItem(), 'Help');
+
+    // Focus first element
+    findElementByTestId('bold').focus();
+
+    // Clicking up or left should not move focus back to the last element
+    pressKey('ArrowUp');
+    pressKey('ArrowLeft');
+    assert.equal(currentItem(), 'Bold');
+  });
 });

--- a/src/hooks/use-arrow-key-navigation.ts
+++ b/src/hooks/use-arrow-key-navigation.ts
@@ -18,6 +18,12 @@ export type UseArrowKeyNavigationOptions = {
    */
   autofocus?: boolean;
 
+  /**
+   * Whether focus should loop back to the first element once the end of the
+   * list is reached. Defaults to `true`.
+   */
+  loop?: boolean;
+
   /** Enable navigating elements using left/right arrow keys  */
   horizontal?: boolean;
   /** Enable navigating elements using up/down arrow keys */
@@ -67,6 +73,7 @@ export function useArrowKeyNavigation(
   containerRef: RefObject<HTMLElement | undefined>,
   {
     autofocus = false,
+    loop = true,
     horizontal = true,
     vertical = true,
     selector = 'a,button',
@@ -142,7 +149,7 @@ export function useArrowKeyNavigation(
         (vertical && event.key === 'ArrowUp')
       ) {
         if (currentIndex === 0) {
-          currentIndex = elements.length - 1;
+          currentIndex = loop ? elements.length - 1 : currentIndex;
         } else {
           --currentIndex;
         }
@@ -152,7 +159,7 @@ export function useArrowKeyNavigation(
         (vertical && event.key === 'ArrowDown')
       ) {
         if (currentIndex === elements.length - 1) {
-          currentIndex = 0;
+          currentIndex = loop ? 0 : currentIndex;
         } else {
           ++currentIndex;
         }
@@ -215,5 +222,5 @@ export function useArrowKeyNavigation(
       listeners.removeAll();
       mo.disconnect();
     };
-  }, [autofocus, containerRef, horizontal, selector, vertical]);
+  }, [autofocus, containerRef, horizontal, loop, selector, vertical]);
 }


### PR DESCRIPTION
Closes #1251 

Add a new `loop` option to `useArrowKeyNavigation` hook, which allows to check if focus should loop back to the first element once the end of the list is reached. It defaults to `true`, as that was its previous behavior.

Additionally, this PR disables `loop` in `SelectNext`, so that it behaves closer to native selects.

### Testing steps

1. Check out this branch and start dev server (`make dev`)
2. Go to http://localhost:4001/input-select-next
3. Arrow key navigation on the select dropdown should stop once reaching the first or last items.

On `main` branch, the navigation would loop back to the first item once the end is reached.