### PR TITLE
Exclude irrelevant mutations from useArrowKeyNavigation's MutationObserver

### DIFF
--- a/src/components/input/SelectNext.tsx
+++ b/src/components/input/SelectNext.tsx
@@ -112,7 +112,11 @@ function SelectMain<T>({
   useKeyPress(['Escape'], closeListbox);
 
   // Vertical arrow key for options in the listbox
-  useArrowKeyNavigation(wrapperRef, { horizontal: false, loop: false });
+  useArrowKeyNavigation(wrapperRef, {
+    horizontal: false,
+    loop: false,
+    selector: '[role="option"]',
+  });
 
   useLayoutEffect(() => {
     if (!listboxOpen) {

--- a/src/hooks/use-arrow-key-navigation.ts
+++ b/src/hooks/use-arrow-key-navigation.ts
@@ -80,8 +80,8 @@ export function useArrowKeyNavigation(
   }: UseArrowKeyNavigationOptions = {},
 ) {
   // Keep track of the element that was last focused by this hook such that
-  // navigation can be restored if focus moves outside of the container
-  // and then back to/into it.
+  // navigation can be restored if focus moves outside the container and then
+  // back to/into it.
   const lastFocusedItem = useRef<HTMLOrSVGElement | null>(null);
 
   useEffect(() => {
@@ -208,8 +208,16 @@ export function useArrowKeyNavigation(
 
     // Update the tab indexes of elements as they are added, removed, enabled
     // or disabled.
-    const mo = new MutationObserver(() => {
-      updateTabIndexes();
+    const mo = new MutationObserver(mutations => {
+      const mutationsAreRelevant = mutations.some(mutation => {
+        const element = mutation.target as Element;
+        // Relevant mutations are those affecting elements matching selector or
+        // containing elements matching selector
+        return element.matches(selector) || !!element.querySelector(selector);
+      });
+      if (mutationsAreRelevant) {
+        updateTabIndexes();
+      }
     });
     mo.observe(container, {
       subtree: true,


### PR DESCRIPTION
Closes #1252

This PR excludes `SelectNext`'s main toggle button from arrow key navigation, so that once the listbox is open, you can navigate through its options exclusively.

This has been achieved by providing `selector: '[role="option"]` to `useArrowKeyNavigation`.

However, this was already attempted, but resulted in the second option in the listbox to be the first focused item.

The reason was that the chevron toggling (from chevron pointing down to chevron pointing up) was triggering a mutation from `useArrowKeyNavigation`'s internal MutationObserver, which resulted in the side effect being triggered twice when opened.

This PR also updates that so that the MutationObserver triggers the side effect only if any of the mutations happened on items matching `useArrowKeyNavigation`'s `selector`, or containing children that match `selector`.