### PR TITLE
Close `SelectNext` listbox on focus away

### DIFF
--- a/src/components/input/SelectNext.tsx
+++ b/src/components/input/SelectNext.tsx
@@ -11,6 +11,7 @@ import {
 
 import { useArrowKeyNavigation } from '../../hooks/use-arrow-key-navigation';
 import { useClickAway } from '../../hooks/use-click-away';
+import { useFocusAway } from '../../hooks/use-focus-away';
 import { useKeyPress } from '../../hooks/use-key-press';
 import { useSyncedRef } from '../../hooks/use-synced-ref';
 import type { PresentationalProps } from '../../types';
@@ -105,8 +106,9 @@ function SelectMain<T>({
     [closeListbox, onChange],
   );
 
-  // When clicking away or pressing `Esc`, close the listbox
+  // When clicking away, focusing away or pressing `Esc`, close the listbox
   useClickAway(wrapperRef, closeListbox);
+  useFocusAway(wrapperRef, closeListbox);
   useKeyPress(['Escape'], closeListbox);
 
   // Vertical arrow key for options in the listbox
@@ -114,8 +116,12 @@ function SelectMain<T>({
 
   useLayoutEffect(() => {
     if (!listboxOpen) {
-      // Focus button after closing listbox
-      buttonRef.current!.focus();
+      // Focus toggle button after closing listbox, only if previously focused
+      // element was inside the listbox itself
+      if (listboxRef.current!.contains(document.activeElement)) {
+        buttonRef.current!.focus();
+      }
+
       // Reset shouldDropUp so that it does not affect calculations next time
       // it opens
       setShouldListboxDropUp(false);

--- a/src/components/input/test/SelectNext-test.js
+++ b/src/components/input/test/SelectNext-test.js
@@ -150,12 +150,35 @@ describe('SelectNext', () => {
     }
   });
 
+  it('closes listbox when focusing away', () => {
+    const wrapper = createComponent();
+    toggleListbox(wrapper);
+
+    // Focus an element which is outside the listbox itself
+    const outerButton = document.createElement('button');
+    document.body.append(outerButton);
+    outerButton.focus();
+    wrapper.update();
+
+    try {
+      assert.isTrue(isListboxClosed(wrapper));
+      // The button should still be focused after closing the listbox
+      assert.equal(document.activeElement, outerButton);
+    } finally {
+      outerButton.remove();
+    }
+  });
+
   it('restores focus to toggle button after closing listbox', () => {
     const wrapper = createComponent();
     toggleListbox(wrapper);
 
-    // Focus body before closing listbox
-    document.body.focus();
+    // Focus listbox option before closing listbox
+    wrapper
+      .find('[data-testid="option-3"]')
+      .getDOMNode()
+      .closest('button')
+      .focus();
     toggleListbox(wrapper);
     wrapper.update();
 


### PR DESCRIPTION
Closes #1253

This PR makes sure the `SelectNext` listbox is closed when focus moves to some other component in the page, without affecting the toggle button focus recover when the listbox is closed after an option is selected.

### Testing steps

1. Check out this branch and start dev server `make dev`
2. Go to http://localhost:4001/input-select-next
3. Press <kbd>Tab</kbd> until a select component is focused.
4. Press <kbd>Enter</kbd> to open the listbox. Navigate down or click on an option: The listbox should close and the focus should go back to the select toggle.
5. Press <kbd>Enter</kbd> again to open the list, then press <kbd>Tab</kbd> until some other external element is focused: The listbox should close but the external element should keep focused.