### PR TITLE
Add rounded class to SelectNext

### DIFF
--- a/src/components/input/SelectNext.tsx
+++ b/src/components/input/SelectNext.tsx
@@ -143,7 +143,7 @@ function SelectMain<T>({
         id={buttonId}
         variant="custom"
         classes={classnames(
-          'w-full flex border',
+          'w-full flex border rounded',
           'bg-grey-0 disabled:bg-grey-1 disabled:text-grey-6',
           classes,
         )}


### PR DESCRIPTION
On previous work I forgot to add `rounded` class to the `SelectNext` toggle. This PR adds it.

Since our rounded corners are currently subtle, this passed unnoticed.