### PR TITLE
Add reusable ToastMessages component

### DIFF
--- a/src/components/feedback/ToastMessages.tsx
+++ b/src/components/feedback/ToastMessages.tsx
@@ -1,0 +1,221 @@
+import classnames from 'classnames';
+import type {
+  ComponentChildren,
+  ComponentProps,
+  FunctionComponent,
+} from 'preact';
+import {
+  useCallback,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'preact/hooks';
+
+import type { TransitionComponent } from '../../types';
+import Callout from './Callout';
+
+export type ToastMessage = {
+  id: string;
+  type: 'error' | 'success' | 'notice';
+  message: ComponentChildren;
+
+  /**
+   * Visually hidden messages are announced to screen readers but not visible.
+   * Defaults to false.
+   */
+  visuallyHidden?: boolean;
+
+  /**
+   * Determines if the toast message should be auto-dismissed.
+   * Defaults to true.
+   */
+  autoDismiss?: boolean;
+};
+
+export type ToastMessageTransitionClasses = {
+  /** Classes to apply to a toast message when appended. Defaults to 'animate-fade-in' */
+  transitionIn?: string;
+  /** Classes to apply to a toast message being dismissed. Defaults to 'animate-fade-out' */
+  transitionOut?: string;
+};
+
+type ToastMessageItemProps = {
+  message: ToastMessage;
+  onDismiss: (id: string) => void;
+};
+
+/**
+ * An individual toast message: a brief and transient success or error message.
+ * The message may be dismissed by clicking on it. `visuallyHidden` toast
+ * messages will not be visible but are still available to screen readers.
+ */
+function ToastMessageItem({ message, onDismiss }: ToastMessageItemProps) {
+  // Capitalize the message type for prepending; Don't prepend a message
+  // type for "notice" messages
+  const prefix =
+    message.type !== 'notice'
+      ? `${message.type.charAt(0).toUpperCase() + message.type.slice(1)}: `
+      : '';
+
+  return (
+    <Callout
+      classes={classnames({
+        'sr-only': message.visuallyHidden,
+      })}
+      status={message.type}
+      onClick={() => onDismiss(message.id)}
+      variant="raised"
+    >
+      <strong>{prefix}</strong>
+      {message.message}
+    </Callout>
+  );
+}
+
+type ToastMessageTransitionType = FunctionComponent<
+  ComponentProps<TransitionComponent> & {
+    transitionClasses?: ToastMessageTransitionClasses;
+  }
+>;
+
+const ToastMessageTransition: ToastMessageTransitionType = ({
+  direction,
+  onTransitionEnd,
+  children,
+  transitionClasses = {},
+}) => {
+  const isDismissed = direction === 'out';
+  const containerRef = useRef<HTMLDivElement>(null);
+  const handleAnimation = (e: AnimationEvent) => {
+    // Ignore animations happening on child elements
+    if (e.target !== containerRef.current) {
+      return;
+    }
+
+    onTransitionEnd?.(direction ?? 'in');
+  };
+  const classes = useMemo(() => {
+    const {
+      transitionIn = 'animate-fade-in',
+      transitionOut = 'animate-fade-out',
+    } = transitionClasses;
+
+    return {
+      [transitionIn]: !isDismissed,
+      [transitionOut]: isDismissed,
+    };
+  }, [isDismissed, transitionClasses]);
+
+  return (
+    <div
+      data-testid="animation-container"
+      onAnimationEnd={handleAnimation}
+      ref={containerRef}
+      className={classnames('relative w-full container', classes)}
+    >
+      {children}
+    </div>
+  );
+};
+
+export type ToastMessagesProps = {
+  messages: ToastMessage[];
+  onMessageDismiss: (id: string) => void;
+  transitionClasses?: ToastMessageTransitionClasses;
+  setTimeout_?: typeof setTimeout;
+};
+
+type TimeoutId = number;
+
+/**
+ * A collection of toast messages. These are rendered within an `aria-live`
+ * region for accessibility with screen readers.
+ */
+export default function ToastMessages({
+  messages,
+  onMessageDismiss,
+  transitionClasses,
+  /* istanbul ignore next - test seam */
+  setTimeout_ = setTimeout,
+}: ToastMessagesProps) {
+  // List of IDs of toast messages that have been dismissed and have an
+  // in-progress 'out' transition
+  const [dismissedMessages, setDismissedMessages] = useState<string[]>([]);
+  // Tracks not finished timeouts for auto-dismiss toast messages
+  const messageSchedules = useRef(new Map<string, TimeoutId>());
+
+  const dismissMessage = useCallback(
+    (id: string) => setDismissedMessages(ids => [...ids, id]),
+    [],
+  );
+  const scheduleMessageDismiss = useCallback(
+    (id: string) => {
+      const timeout = setTimeout_(() => {
+        dismissMessage(id);
+        messageSchedules.current.delete(id);
+      }, 5000);
+      messageSchedules.current.set(id, timeout);
+    },
+    [dismissMessage, setTimeout_],
+  );
+
+  const onTransitionEnd = useCallback(
+    (direction: 'in' | 'out', message: ToastMessage) => {
+      const autoDismiss = message.autoDismiss ?? true;
+      if (direction === 'in' && autoDismiss) {
+        scheduleMessageDismiss(message.id);
+      }
+
+      if (direction === 'out') {
+        onMessageDismiss(message.id);
+        setDismissedMessages(ids => ids.filter(id => id !== message.id));
+      }
+    },
+    [scheduleMessageDismiss, onMessageDismiss],
+  );
+
+  useLayoutEffect(() => {
+    // Clear all pending timeouts for not yet dismissed toast messages when the
+    // component is unmounted
+    const pendingTimeouts = messageSchedules.current;
+    return () => {
+      pendingTimeouts.forEach(timeout => clearTimeout(timeout));
+    };
+  }, []);
+
+  return (
+    <ul
+      aria-live="polite"
+      aria-relevant="additions"
+      className="w-full space-y-2"
+      data-component="ToastMessages"
+    >
+      {messages.map(message => {
+        const isDismissed = dismissedMessages.includes(message.id);
+        return (
+          <li
+            className={classnames({
+              // Add a bottom margin to visible messages only. Typically, we'd
+              // use a `space-y-2` class on the parent to space children.
+              // Doing that here could cause an undesired top margin on
+              // the first visible message in a list that contains (only)
+              // visually-hidden messages before it.
+              // See https://tailwindcss.com/docs/space#limitations
+              'mb-2': !message.visuallyHidden,
+            })}
+            key={message.id}
+          >
+            <ToastMessageTransition
+              direction={isDismissed ? 'out' : 'in'}
+              onTransitionEnd={direction => onTransitionEnd(direction, message)}
+              transitionClasses={transitionClasses}
+            >
+              <ToastMessageItem message={message} onDismiss={dismissMessage} />
+            </ToastMessageTransition>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}

--- a/src/components/feedback/test/ToastMessages-test.js
+++ b/src/components/feedback/test/ToastMessages-test.js
@@ -1,0 +1,168 @@
+import { mount } from 'enzyme';
+
+import ToastMessages from '../ToastMessages';
+
+describe('ToastMessages', () => {
+  let wrappers;
+  const toastMessages = [
+    {
+      id: '1',
+      type: 'success',
+      message: 'Hello world',
+    },
+    {
+      id: '2',
+      type: 'notice',
+      message: 'Foobar',
+    },
+    {
+      id: '3',
+      type: 'error',
+      message: 'Something failed',
+    },
+  ];
+  let fakeOnMessageDismiss;
+
+  beforeEach(() => {
+    wrappers = [];
+    fakeOnMessageDismiss = sinon.stub();
+  });
+
+  afterEach(() => {
+    wrappers.forEach(wrapper => wrapper.unmount());
+  });
+
+  function createToastMessages(toastMessages, setTimeout) {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+
+    const wrapper = mount(
+      <ToastMessages
+        messages={toastMessages}
+        onMessageDismiss={fakeOnMessageDismiss}
+        setTimeout_={setTimeout}
+      />,
+      { attachTo: container },
+    );
+    wrappers.push(wrapper);
+
+    return wrapper;
+  }
+
+  function triggerAnimationEnd(wrapper, index, direction = 'out') {
+    wrapper
+      .find('ToastMessageTransition')
+      .at(index)
+      .props()
+      .onTransitionEnd(direction);
+    wrapper.update();
+  }
+
+  it('renders a list of toast messages', () => {
+    const wrapper = createToastMessages(toastMessages);
+    assert.equal(wrapper.find('ToastMessageItem').length, toastMessages.length);
+  });
+
+  toastMessages.forEach((message, index) => {
+    it('dismisses messages when clicked', () => {
+      const wrapper = createToastMessages(toastMessages);
+
+      wrapper.find('Callout').at(index).props().onClick();
+      // onMessageDismiss is not immediately called. Transition has to finish
+      assert.notCalled(fakeOnMessageDismiss);
+
+      // Once dismiss animation has finished, onMessageDismiss is called
+      triggerAnimationEnd(wrapper, index);
+      assert.calledWith(fakeOnMessageDismiss, message.id);
+    });
+  });
+
+  it('dismisses messages automatically unless instructed otherwise', () => {
+    const messages = [
+      ...toastMessages,
+      {
+        id: 'foo',
+        type: 'success',
+        message: 'Not to be dismissed',
+        autoDismiss: false,
+      },
+    ];
+    const wrapper = createToastMessages(
+      messages,
+      // Fake internal setTimeout, to immediately call its callback
+      callback => callback(),
+    );
+
+    // Trigger "in" animation for all messages, which will schedule dismiss for
+    // appropriate messages
+    messages.forEach((_, index) => {
+      triggerAnimationEnd(wrapper, index, 'in');
+    });
+
+    // Trigger "out" animation on components whose "direction" prop is currently
+    // "out". That means they were scheduled for dismiss
+    wrapper
+      .find('ToastMessageTransition')
+      .forEach((transitionComponent, index) => {
+        if (transitionComponent.prop('direction') === 'out') {
+          triggerAnimationEnd(wrapper, index);
+        }
+      });
+
+    // Only one toast message will remain, as it was marked as `autoDismiss: false`
+    assert.equal(fakeOnMessageDismiss.callCount, 3);
+  });
+
+  it('schedules dismiss only once per message', () => {
+    const wrapper = createToastMessages(
+      toastMessages,
+      // Fake an immediate setTimeout which does not slow down the test, but
+      // keeps the async behavior
+      callback => setTimeout(callback, 0),
+    );
+    const scheduleFirstMessageDismiss = () =>
+      triggerAnimationEnd(wrapper, 0, 'in');
+
+    scheduleFirstMessageDismiss();
+    scheduleFirstMessageDismiss();
+    scheduleFirstMessageDismiss();
+
+    // Once dismiss animation has finished, onMessageDismiss is called
+    triggerAnimationEnd(wrapper, 0);
+    assert.equal(fakeOnMessageDismiss.callCount, 1);
+  });
+
+  it('invokes onTransitionEnd when animation happens on container', () => {
+    const wrapper = createToastMessages(toastMessages, callback => callback());
+    const animationContainer = wrapper
+      .find('[data-testid="animation-container"]')
+      .first();
+
+    // Trigger "in" animation for all messages, which will schedule dismiss
+    toastMessages.forEach((_, index) => {
+      triggerAnimationEnd(wrapper, index, 'in');
+    });
+
+    animationContainer
+      .getDOMNode()
+      .dispatchEvent(new AnimationEvent('animationend'));
+
+    assert.called(fakeOnMessageDismiss);
+  });
+
+  it('does not invoke onTransitionEnd for animation events bubbling from children', () => {
+    const wrapper = createToastMessages(toastMessages, callback => callback());
+    const child = wrapper.find('Callout').first();
+
+    // Trigger "in" animation for all messages, which will schedule dismiss
+    toastMessages.forEach((_, index) => {
+      triggerAnimationEnd(wrapper, index, 'in');
+    });
+
+    child
+      .getDOMNode()
+      .dispatchEvent(new AnimationEvent('animationend', { bubbles: true }));
+
+    assert.notCalled(fakeOnMessageDismiss);
+  });
+});

--- a/src/pattern-library/components/patterns/feedback/ToastMessagesPage.tsx
+++ b/src/pattern-library/components/patterns/feedback/ToastMessagesPage.tsx
@@ -1,0 +1,249 @@
+import { useCallback, useState } from 'preact/hooks';
+
+import type {
+  ToastMessagesProps,
+  ToastMessage,
+} from '../../../../components/feedback/ToastMessages';
+import ToastMessages from '../../../../components/feedback/ToastMessages';
+import Button from '../../../../components/input/Button';
+import Link from '../../../../components/navigation/Link';
+import Library from '../../Library';
+
+type BaseToastMessage = Omit<ToastMessage, 'id'>;
+
+const toastMessages: BaseToastMessage[] = [
+  {
+    message: 'Success toast message',
+    type: 'success',
+    autoDismiss: false,
+  },
+  {
+    message: 'Warning toast message',
+    type: 'notice',
+    autoDismiss: false,
+  },
+  {
+    message: 'Error toast message',
+    type: 'error',
+    autoDismiss: false,
+  },
+];
+
+type ToastMessages_Props = Omit<ToastMessagesProps, 'messages'> & {
+  messages: BaseToastMessage[];
+  _printOnDismiss?: boolean;
+  _allowAppending?: boolean;
+};
+
+function ToastMessages_({
+  messages: initialMessages,
+  transitionClasses,
+  _printOnDismiss = false,
+  _allowAppending = false,
+}: ToastMessages_Props) {
+  const [messages, setMessages] = useState(
+    initialMessages.map((message, index) => ({
+      id: `${index}`,
+      ...message,
+    })),
+  );
+  const [lastDismissedMessage, setLastDismissedMessage] =
+    useState<BaseToastMessage>();
+  const onMessageDismiss = useCallback(
+    (id: string) => {
+      setLastDismissedMessage(messages.find(message => message.id === id));
+      setMessages(prev => prev.filter(message => message.id !== id));
+    },
+    [messages],
+  );
+  const appendMessage = useCallback(
+    ({ autoDismiss }: { autoDismiss: boolean }) => {
+      const newId =
+        messages.length === 0
+          ? 1
+          : Number(messages[messages.length - 1].id) + 1;
+      const newMessage: ToastMessage = {
+        id: `${newId}`,
+        message: autoDismiss
+          ? 'Dismissing in 5 seconds...'
+          : 'Click me to dismiss',
+        type: 'success',
+        autoDismiss,
+      };
+      setMessages(prev => [...prev, newMessage]);
+    },
+    [messages],
+  );
+
+  return (
+    <div className="w-full">
+      {_allowAppending && (
+        <div className="flex gap-x-2 mb-3">
+          <Button
+            onClick={() => appendMessage({ autoDismiss: false })}
+            classes="mb-2"
+            variant="primary"
+          >
+            Append message
+          </Button>
+          <Button
+            onClick={() => appendMessage({ autoDismiss: true })}
+            classes="mb-2"
+            variant="primary"
+          >
+            Append auto-dismiss message
+          </Button>
+        </div>
+      )}
+      <div className="w-1/2 mx-auto flex flex-col gap-y-4">
+        <ToastMessages
+          messages={messages}
+          onMessageDismiss={onMessageDismiss}
+          transitionClasses={transitionClasses}
+        />
+        {_printOnDismiss && lastDismissedMessage && (
+          <div>
+            Just dismissed message {'"'}
+            {lastDismissedMessage.message}
+            {'"'}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default function ToastMessagesPage() {
+  return (
+    <Library.Page
+      title="ToastMessages"
+      intro={
+        <p>
+          ToastMessages is a component that wraps{' '}
+          <Library.Link href="/feedback-callout">Callout</Library.Link> with out
+          of the box accessibility, message auto-dismiss, dismiss-on-click,
+          transitions and message positioning.
+        </p>
+      }
+    >
+      <Library.Section>
+        <Library.Pattern>
+          <Library.Usage componentName="ToastMessages" />
+          <Library.Example>
+            <Library.Demo withSource title="Basic ToastMessages">
+              <ToastMessages_
+                messages={toastMessages}
+                onMessageDismiss={() => {}}
+              />
+            </Library.Demo>
+          </Library.Example>
+        </Library.Pattern>
+
+        <Library.Pattern title="Working with ToastMessages">
+          <Library.Example title="Accessibility">
+            <p>
+              <code>ToastMessages</code> includes an{' '}
+              <Link href="https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions">
+                <code>
+                  aria-live={'"'}polite{'"'}
+                </code>
+              </Link>{' '}
+              wrapper which will announce added toast messages to screen
+              readers.
+            </p>
+            <p>
+              Additionally, it is possible to append hidden messages that are
+              only announced by screen readers, via{' '}
+              <code>{'{ visuallyHidden: true }'}</code>
+            </p>
+          </Library.Example>
+          <Library.Example title="Positioning">
+            <p>
+              By default, every message rendered by <code>ToastMessages</code>{' '}
+              will be relative positioned. It{"'"}s up to consumers to wrap it
+              in an absolute-positioned container if desired.
+            </p>
+          </Library.Example>
+          <Library.Example title="Auto-dismiss">
+            <p>
+              All messages will be auto-dismissed after 5 seconds. Pass
+              <code>{'{ autoDismiss: false }'}</code> for those messages where
+              you want this to be prevented.
+            </p>
+          </Library.Example>
+          <Library.Example title="Transitions">
+            <p>
+              All messages will fade-in when appended and fade-out when
+              dismissed, but you can provide your own transition classes via{' '}
+              <code>transitionClasses</code> prop.
+            </p>
+          </Library.Example>
+        </Library.Pattern>
+
+        <Library.Pattern title="Component API">
+          <Library.Example title="messages">
+            <Library.Info>
+              <Library.InfoItem label="description">
+                The list of toast messages to display at a given point.
+              </Library.InfoItem>
+              <Library.InfoItem label="type">
+                <code>{`ToastMessage[]`}</code>
+              </Library.InfoItem>
+            </Library.Info>
+
+            <Library.Demo title="ToastMessages with one message" withSource>
+              <ToastMessages_
+                messages={[toastMessages[0]]}
+                onMessageDismiss={() => {}}
+              />
+            </Library.Demo>
+          </Library.Example>
+          <Library.Example title="onMessageDismiss">
+            <Library.Info>
+              <Library.InfoItem label="description">
+                Callback invoked with the toast message id, when it ends its
+                dismiss transition. The message with that id can then be removed
+                from the list.
+              </Library.InfoItem>
+              <Library.InfoItem label="type">
+                <code>{`(toastMessageId: string) => void`}</code>
+              </Library.InfoItem>
+            </Library.Info>
+
+            <Library.Demo title="Click a message to dismiss it" withSource>
+              <ToastMessages_
+                messages={toastMessages}
+                onMessageDismiss={() => {}}
+                _printOnDismiss
+              />
+            </Library.Demo>
+          </Library.Example>
+          <Library.Example title="transitionClasses">
+            <Library.Info>
+              <Library.InfoItem label="description">
+                Custom CSS classes to apply to toast messages when appended
+                and/or dismissed. By default they get{' '}
+                <code>animate-fade-in</code> and <code>animate-fade-out</code>
+              </Library.InfoItem>
+              <Library.InfoItem label="type">
+                <code>{`{ transitionIn?: string; transitionOut?: string; }`}</code>
+              </Library.InfoItem>
+            </Library.Info>
+
+            <Library.Demo title="Custom transitions" withSource>
+              <ToastMessages_
+                messages={toastMessages}
+                onMessageDismiss={() => {}}
+                transitionClasses={{
+                  transitionIn: 'animate-slide-in-from-right',
+                  transitionOut: 'animate-slide-out-to-right',
+                }}
+                _allowAppending
+              />
+            </Library.Demo>
+          </Library.Example>
+        </Library.Pattern>
+      </Library.Section>
+    </Library.Page>
+  );
+}

--- a/src/pattern-library/routes.ts
+++ b/src/pattern-library/routes.ts
@@ -15,6 +15,7 @@ import CalloutPage from './components/patterns/feedback/CalloutPage';
 import DialogPage from './components/patterns/feedback/DialogPage';
 import ModalPage from './components/patterns/feedback/ModalPage';
 import SpinnerPage from './components/patterns/feedback/SpinnerPage';
+import ToastMessagesPage from './components/patterns/feedback/ToastMessagesPage';
 import ButtonsPage from './components/patterns/input/ButtonPage';
 import CheckboxPage from './components/patterns/input/CheckboxPage';
 import CloseButtonPage from './components/patterns/input/CloseButtonPage';
@@ -159,6 +160,12 @@ const routes: PlaygroundRoute[] = [
     group: 'feedback',
     component: SpinnerPage,
     route: '/feedback-spinner',
+  },
+  {
+    title: 'ToastMessages',
+    group: 'feedback',
+    component: ToastMessagesPage,
+    route: '/feedback-toast-messages',
   },
   {
     title: 'Button',

--- a/src/tailwind.preset.js
+++ b/src/tailwind.preset.js
@@ -10,6 +10,10 @@ const minimumTouchDimension = '44px';
 export default /** @type {Partial<import('tailwindcss').Config>} */ ({
   theme: {
     extend: {
+      animation: {
+        'fade-in': 'fade-in 0.3s forwards',
+        'fade-out': 'fade-out 0.3s forwards',
+      },
       borderColor: {
         DEFAULT: '#dbdbdb',
       },
@@ -68,6 +72,24 @@ export default /** @type {Partial<import('tailwindcss').Config>} */ ({
           DEFAULT: '#202020',
           light: '#737373',
           inverted: '#f2f2f2',
+        },
+      },
+      keyframes: {
+        'fade-in': {
+          '0%': {
+            opacity: '0',
+          },
+          '100%': {
+            opacity: '1',
+          },
+        },
+        'fade-out': {
+          '0%': {
+            opacity: '1',
+          },
+          '100%': {
+            opacity: '0',
+          },
         },
       },
       minHeight: {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -6,4 +6,42 @@ import tailwindPreset from './src/tailwind.preset.js';
 export default {
   presets: [tailwindPreset],
   content: ['./src/**/*.{js,ts,tsx}', './templates/**/*.html'],
+
+  // Pattern library specific config
+  theme: {
+    extend: {
+      animation: {
+        'slide-in-from-right': 'slide-in-from-right 0.3s forwards ease-in-out',
+        'slide-out-to-right': 'slide-out-to-right 0.3s forwards ease-in-out',
+      },
+      keyframes: {
+        'slide-in-from-right': {
+          '0%': {
+            opacity: '0',
+            left: '100%',
+          },
+          '80%': {
+            left: '-10px',
+          },
+          '100%': {
+            left: '0',
+            opacity: '1',
+          },
+        },
+        'slide-out-to-right': {
+          '0%': {
+            left: '0',
+            opacity: '1',
+          },
+          '20%': {
+            left: '-10px',
+          },
+          '100%': {
+            opacity: '0',
+            left: '100%',
+          },
+        },
+      },
+    },
+  },
 };


### PR DESCRIPTION
Closes #1075 

This PR brings the `ToastMessages` component from client/via, and adds the corresponding documentation to the pattern library.

![image](https://github.com/hypothesis/frontend-shared/assets/2719332/a2c62f8f-1f24-4b7a-9e49-b7a654368c1d)

Once this is merged, we can start using it in frontend apps and remove duplicated code.

### Testing steps

1. Check out this branch.
2. Start dev server (`make dev`)
3. Go to http://localhost:4001/feedback-toast-messages