### PR TITLE
Extract hook with logic to determine SelectNext listbox location

### DIFF
--- a/src/hooks/use-should-be-positioned-above.ts
+++ b/src/hooks/use-should-be-positioned-above.ts
@@ -1,0 +1,49 @@
+import { useLayoutEffect, useState } from 'preact/hooks';
+
+/**
+ * Determines if a popping element (typically a dialog/popover of some sort)
+ * should be positioned above another reference component, based on the sizes of
+ * those two components, and the available viewport space above and below the
+ * reference component.
+ *
+ * By default, we prefer the popping component to be positioned below the
+ * reference component, and only if there's enough space above, and not enough
+ * space below, we will prefer it to be positioned above.
+ */
+export function useShouldBePositionedAbove(
+  referenceComponent: HTMLElement | null,
+  poppingComponent: HTMLElement | null,
+  isPoppingComponentOpen: boolean,
+) {
+  const [shouldBePositionedAbove, setShouldBePositionedAbove] = useState(false);
+
+  useLayoutEffect(() => {
+    // Reset shouldPositionAbove so that it does not affect calculations next
+    // time popping component opens
+    if (!referenceComponent || !poppingComponent || !isPoppingComponentOpen) {
+      setShouldBePositionedAbove(false);
+      return;
+    }
+
+    const viewportHeight = window.innerHeight;
+    const {
+      top: referenceComponentDistanceToTop,
+      bottom: referenceComponentBottom,
+    } = referenceComponent.getBoundingClientRect();
+    const referenceComponentDistanceToBottom =
+      viewportHeight - referenceComponentBottom;
+    const { bottom: poppingComponentBottom } =
+      poppingComponent.getBoundingClientRect();
+    const poppingComponentDistanceToBottom =
+      viewportHeight - poppingComponentBottom;
+
+    // The popping component should drop up only if there's not enough space
+    // below to fit it, and there's more absolute space above than below
+    setShouldBePositionedAbove(
+      poppingComponentDistanceToBottom < 0 &&
+        referenceComponentDistanceToTop > referenceComponentDistanceToBottom,
+    );
+  }, [referenceComponent, poppingComponent, isPoppingComponentOpen]);
+
+  return shouldBePositionedAbove;
+}


### PR DESCRIPTION
This creates a new `useShouldBePositionedAbove` hook that wraps the logic originally defined in `SelectNext` to determine if the listbox should be rendered above or below the toggle button.

There could be other use-cases for this hook, but for now I have opted to not expose it until we really see a case for it.

The main motivation to extract this is to simplify the code in `SelectNext` while trying to tackle https://github.com/hypothesis/frontend-shared/pull/1269 and is proving a bit confusing otherwise.

Due to the reasons explained above, I have also decided not to extract individual tests for this new hook for now. Its logic is covered by `SelectNext`'s hook anyway.

We can extract tests in a follow-up PR or if we decide to expose it and use it in other cases.