### PR TITLE
Allow useArrowKeyNavigation consumers tell if container is visible

### DIFF
--- a/src/components/input/SelectNext.tsx
+++ b/src/components/input/SelectNext.tsx
@@ -150,7 +150,12 @@ function SelectMain<T>({
   useKeyPress(['Escape'], closeListbox);
 
   // Vertical arrow key for options in the listbox
-  useArrowKeyNavigation(wrapperRef, { horizontal: false, loop: false });
+  useArrowKeyNavigation(listboxRef, {
+    horizontal: false,
+    loop: false,
+    autofocus: true,
+    containerVisible: listboxOpen,
+  });
 
   useLayoutEffect(() => {
     // Focus toggle button after closing listbox, only if previously focused

--- a/src/hooks/use-arrow-key-navigation.ts
+++ b/src/hooks/use-arrow-key-navigation.ts
@@ -33,6 +33,15 @@ export type UseArrowKeyNavigationOptions = {
    * CSS selector which specifies the elements that navigation moves between
    */
   selector?: string;
+
+  /**
+   * Indicates if the container element is currently visible.
+   * This information is used to focus the current element when the container
+   * transitions from hidden to visible.
+   *
+   * Defaults to `true`.
+   */
+  containerVisible?: boolean;
 };
 
 /**
@@ -77,11 +86,12 @@ export function useArrowKeyNavigation(
     horizontal = true,
     vertical = true,
     selector = 'a,button',
+    containerVisible = true,
   }: UseArrowKeyNavigationOptions = {},
 ) {
   // Keep track of the element that was last focused by this hook such that
-  // navigation can be restored if focus moves outside of the container
-  // and then back to/into it.
+  // navigation can be restored if focus moves outside the container and then
+  // back to/into it.
   const lastFocusedItem = useRef<HTMLOrSVGElement | null>(null);
 
   useEffect(() => {
@@ -182,7 +192,7 @@ export function useArrowKeyNavigation(
       event.stopPropagation();
     };
 
-    updateTabIndexes(getNavigableElements(), 0, autofocus);
+    updateTabIndexes(getNavigableElements(), 0, containerVisible && autofocus);
 
     const listeners = new ListenerCollection();
 
@@ -222,5 +232,13 @@ export function useArrowKeyNavigation(
       listeners.removeAll();
       mo.disconnect();
     };
-  }, [autofocus, containerRef, horizontal, loop, selector, vertical]);
+  }, [
+    autofocus,
+    containerRef,
+    horizontal,
+    loop,
+    selector,
+    vertical,
+    containerVisible,
+  ]);
 }


### PR DESCRIPTION
Closes #1252
Depends on https://github.com/hypothesis/frontend-shared/pull/1276

This PR adds a new `containerVisible` flag option to `useArrowKeyNavigation` that can be used by consumers to more granularly control when to re-compute the hook's side effects.

This is needed if the arrow-key navigation is used on components which are initially not visible.

The PR also updates the logic in `SelectNext` to use this new option, allowing it to use the listbox as the container of `useArrowKeyNavigation`, and therefore preventing the toggle button to be included in the focus sequence.