### PR TITLE
Export ToastMessages component and relevant types from main entry point

### DIFF
--- a/src/components/feedback/index.ts
+++ b/src/components/feedback/index.ts
@@ -4,6 +4,7 @@ export { default as Modal } from './Modal';
 export { default as ModalDialog } from './ModalDialog';
 export { default as Spinner } from './Spinner';
 export { default as SpinnerOverlay } from './SpinnerOverlay';
+export { default as ToastMessages } from './ToastMessages';
 
 export type { CalloutProps } from './Callout';
 export type { DialogProps } from './Dialog';
@@ -11,3 +12,8 @@ export type { ModalProps } from './Modal';
 export type { ModalDialogProps } from './ModalDialog';
 export type { SpinnerProps } from './Spinner';
 export type { SpinnerOverlayProps } from './SpinnerOverlay';
+export type {
+  ToastMessagesProps,
+  ToastMessage,
+  ToastMessageTransitionClasses,
+} from './ToastMessages';

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,6 +32,7 @@ export {
   ModalDialog,
   Spinner,
   SpinnerOverlay,
+  ToastMessages,
 } from './components/feedback';
 export {
   Button,
@@ -97,6 +98,9 @@ export type {
   ModalDialogProps,
   SpinnerProps,
   SpinnerOverlayProps,
+  ToastMessage,
+  ToastMessageTransitionClasses,
+  ToastMessagesProps,
 } from './components/feedback';
 
 export type {


### PR DESCRIPTION
This PR adds the `ToastMessages` component and the `ToastMessagesProps`, `ToastMessage` and `ToastMessageTransitionClasses` types to the main entry point exports, something that was overlooked on the original PR https://github.com/hypothesis/frontend-shared/pull/1272