### PR TITLE
Adjusted various UI elements `border-radius`

### DIFF
--- a/src/components/data/ScrollBox.tsx
+++ b/src/components/data/ScrollBox.tsx
@@ -6,6 +6,8 @@ import ScrollContent from './ScrollContent';
 export type ScrollBoxProps = CompositeProps & {
   /** Turn off borders on outer container */
   borderless?: boolean;
+  /** Add rounded corners to scrollable container */
+  rounded?: boolean;
 };
 
 /**
@@ -17,6 +19,7 @@ export default function ScrollBox({
   elementRef,
 
   borderless = false,
+  rounded = false,
 
   ...htmlAttributes
 }: ScrollBoxProps) {
@@ -25,6 +28,7 @@ export default function ScrollBox({
       data-composite-component="ScrollBox"
       {...htmlAttributes}
       borderless={borderless}
+      rounded={rounded}
       elementRef={elementRef}
     >
       <Scroll>

--- a/src/components/data/ScrollContainer.tsx
+++ b/src/components/data/ScrollContainer.tsx
@@ -7,6 +7,8 @@ import { downcastRef } from '../../util/typing';
 export type ScrollContainerProps = PresentationalProps & {
   /** Remove border around container */
   borderless?: boolean;
+  /** Add rounded corners to scrollable container */
+  rounded?: boolean;
 } & JSX.HTMLAttributes<HTMLDivElement>;
 
 /**
@@ -19,6 +21,7 @@ export default function ScrollContainer({
   elementRef,
 
   borderless = false,
+  rounded = false,
 
   ...htmlAttributes
 }: ScrollContainerProps) {
@@ -32,7 +35,10 @@ export default function ScrollContainer({
         // Prevent overflow by overriding `min-height: auto`.
         // See https://stackoverflow.com/a/66689926/434243.
         'min-h-0',
-        { border: !borderless },
+        {
+          border: !borderless,
+          'rounded-lg overflow-hidden': rounded,
+        },
         classes,
       )}
     >

--- a/src/components/data/Table.tsx
+++ b/src/components/data/Table.tsx
@@ -13,6 +13,8 @@ export type TableProps = PresentationalProps & {
   title: string;
   /** This table has rows that can be selected */
   interactive?: boolean;
+  /** Turn off outer table borders */
+  borderless?: boolean;
 } & Omit<JSX.HTMLAttributes<HTMLElement>, 'rows'>;
 
 /**
@@ -23,9 +25,10 @@ export default function Table({
   classes,
   elementRef,
 
-  interactive = false,
   title,
+  interactive = false,
   stickyHeader = false,
+  borderless = false,
 
   ...htmlAttributes
 }: TableProps) {
@@ -34,6 +37,7 @@ export default function Table({
   const tableContext: TableInfo = {
     interactive,
     stickyHeader,
+    borderless,
     tableRef: ref,
   };
 
@@ -56,9 +60,7 @@ export default function Table({
           // No top border is set here: that border is set by `TableCell`.
           // If it is set here, there will be a 1-pixel wiggle in the sticky
           // header on scroll
-          'border-x border-b',
-          // Making it feel more consistent with other UI
-          'rounded overflow-hidden',
+          { 'border-x border-b': !borderless },
           classes,
         )}
         ref={downcastRef(ref)}

--- a/src/components/data/Table.tsx
+++ b/src/components/data/Table.tsx
@@ -57,6 +57,8 @@ export default function Table({
           // If it is set here, there will be a 1-pixel wiggle in the sticky
           // header on scroll
           'border-x border-b',
+          // Making it feel more consistent with other UI
+          'rounded overflow-hidden',
           classes,
         )}
         ref={downcastRef(ref)}

--- a/src/components/data/TableCell.tsx
+++ b/src/components/data/TableCell.tsx
@@ -4,6 +4,7 @@ import { useContext } from 'preact/hooks';
 
 import type { PresentationalProps } from '../../types';
 import { downcastRef } from '../../util/typing';
+import TableContext from './TableContext';
 import TableSectionContext from './TableSectionContext';
 
 export type TableCellProps = PresentationalProps &
@@ -20,6 +21,7 @@ export default function TableCell({
   ...htmlAttributes
 }: TableCellProps) {
   const sectionContext = useContext(TableSectionContext);
+  const { borderless } = useContext(TableContext);
   const isHeadCell = sectionContext && sectionContext.section === 'head';
   const Cell = isHeadCell ? 'th' : 'td';
 
@@ -34,7 +36,8 @@ export default function TableCell({
           // Set horizontal borders here for table headers. This needs to be
           // done here (versus on the row or table) to prevent a 1-pixel wiggle
           // on scroll with sticky headers.
-          'text-left border-t border-b border-b-grey-5': isHeadCell,
+          'text-left border-b border-b-grey-5': isHeadCell,
+          'border-t': isHeadCell && !borderless,
           'border-none': !isHeadCell,
           // Apply a very subtle bottom border to the last row in the table (not
           // in the head). This can help delineate the end of data in tables

--- a/src/components/data/TableContext.ts
+++ b/src/components/data/TableContext.ts
@@ -6,6 +6,8 @@ export type TableInfo = {
   interactive: boolean;
   /** This table has a sticky header */
   stickyHeader: boolean;
+  /** Turn off outer table borders */
+  borderless: boolean;
   tableRef: RefObject<HTMLElement | undefined>;
 };
 

--- a/src/components/input/InputGroup.tsx
+++ b/src/components/input/InputGroup.tsx
@@ -10,7 +10,7 @@ export const inputGroupStyles = classnames(
   // All inputs within an InputGroup should have a border. Turn off border-radius
   'input-group:border input-group:rounded-none',
   // Restore border-radius on the leftmost and rightmost components in the group
-  'input-group:first:rounded-l-sm input-group:last:rounded-r-sm',
+  'input-group:first:rounded-l input-group:last:rounded-r',
   // "Collapse" borders between input components
   'input-group:border-l-0 input-group:first:border-l',
 );

--- a/src/components/layout/Card.tsx
+++ b/src/components/layout/Card.tsx
@@ -42,7 +42,7 @@ export default function Card({
       {...htmlAttributes}
       ref={downcastRef(elementRef)}
       className={classnames(
-        'rounded border bg-white',
+        'rounded-lg border bg-white',
         {
           'shadow hover:shadow-md': variant === 'raised', // default
           'shadow-md': active && variant === 'raised',

--- a/src/components/layout/CardHeader.tsx
+++ b/src/components/layout/CardHeader.tsx
@@ -57,7 +57,8 @@ export default function CardHeader({
       className={classnames(
         'flex items-center gap-x-2 border-b py-2',
         {
-          'bg-slate-0 border-slate-5': variant === 'secondary',
+          'bg-slate-0 border-slate-5 rounded-t-[inherit]':
+            variant === 'secondary',
           'mx-3': !fullWidth && variant === 'primary',
           'px-3': fullWidth || variant === 'secondary',
         },

--- a/src/components/navigation/Tab.tsx
+++ b/src/components/navigation/Tab.tsx
@@ -55,7 +55,7 @@ export default function Tab({
         sized && 'gap-x-1.5',
         themed && {
           'px-4 py-2': variant === 'tab' && sized,
-          'font-semibold text-grey-7 rounded-t border border-transparent border-b-0':
+          'font-semibold text-grey-7 rounded-t-lg border border-transparent border-b-0':
             variant === 'tab',
           'aria-selected:text-color-text aria-selected:bg-white':
             variant === 'tab',

--- a/src/pattern-library/components/patterns/data/TablePage.tsx
+++ b/src/pattern-library/components/patterns/data/TablePage.tsx
@@ -285,7 +285,7 @@ export default function TablePage() {
             <Library.Info>
               <Library.InfoItem label="description">
                 Set this boolean prop if you want to remove the table{"'"}s
-                outer borders, in case it is rendered on a container with its
+                outer borders, in case it is rendered in a container with its
                 own borders.
               </Library.InfoItem>
               <Library.InfoItem label="type">

--- a/src/pattern-library/components/patterns/data/TablePage.tsx
+++ b/src/pattern-library/components/patterns/data/TablePage.tsx
@@ -1,4 +1,5 @@
 import {
+  ScrollContainer,
   Scroll,
   Table,
   TableBody,
@@ -155,71 +156,76 @@ export default function TablePage() {
                 <code>false</code>
               </Library.InfoItem>
             </Library.Info>
-            <Library.Demo title="Table with stickyHeader and Scroll" withSource>
+            <Library.Demo
+              title="Table with stickyHeader and rounded Scroll"
+              withSource
+            >
               <div className="h-[250px]">
-                <Scroll>
-                  <Table title="Some sushi rolls" stickyHeader>
-                    <TableHead>
-                      <TableRow>
-                        <TableCell classes="w-[180px]">
-                          Sushi roll name
-                        </TableCell>
-                        <TableCell>Definition</TableCell>
-                      </TableRow>
-                    </TableHead>
-                    <TableBody>
-                      <TableRow>
-                        <TableCell>Alaskan roll</TableCell>
-                        <TableCell>
-                          A variant of the California roll with smoked salmon on
-                          the inside, or layered on the outside.
-                        </TableCell>
-                      </TableRow>
-                      <TableRow>
-                        <TableCell>Boston roll</TableCell>
-                        <TableCell>
-                          An uramaki California roll with poached shrimp instead
-                          of imitation crab.
-                        </TableCell>
-                      </TableRow>
-                      <TableRow>
-                        <TableCell>British Columbia roll</TableCell>
-                        <TableCell>
-                          A roll containing grilled or barbecued salmon skin,
-                          cucumber, sweet sauce, sometimes with roe. Also
-                          sometimes referred to as salmon skin rolls outside of
-                          British Columbia, Canada.
-                        </TableCell>
-                      </TableRow>
-                      <TableRow>
-                        <TableCell>California roll</TableCell>
-                        <TableCell>
-                          A roll consisting of avocado, kani kama (imitation
-                          crab/crab stick) (also can contain real crab in{' '}
-                          {'premium'} varieties), cucumber, and tobiko, often
-                          made as uramaki (with rice on the outside, nori on the
-                          inside).
-                        </TableCell>
-                      </TableRow>
-                      <TableRow>
-                        <TableCell>Dynamite roll</TableCell>
-                        <TableCell>
-                          A roll including yellowtail (hamachi) or prawn
-                          tempura, and fillings such as bean sprouts, carrots,
-                          avocado, cucumber, chili, spicy mayonnaise, and roe.
-                        </TableCell>
-                      </TableRow>
-                      <TableRow>
-                        <TableCell>Hawaiian roll</TableCell>
-                        <TableCell>
-                          A roll containing shōyu tuna (canned), tamago, kanpyō,
-                          kamaboko, and the distinctive red and green hana ebi
-                          (shrimp powder).
-                        </TableCell>
-                      </TableRow>
-                    </TableBody>
-                  </Table>
-                </Scroll>
+                <ScrollContainer rounded>
+                  <Scroll>
+                    <Table title="Some sushi rolls" stickyHeader borderless>
+                      <TableHead>
+                        <TableRow>
+                          <TableCell classes="w-[180px]">
+                            Sushi roll name
+                          </TableCell>
+                          <TableCell>Definition</TableCell>
+                        </TableRow>
+                      </TableHead>
+                      <TableBody>
+                        <TableRow>
+                          <TableCell>Alaskan roll</TableCell>
+                          <TableCell>
+                            A variant of the California roll with smoked salmon
+                            on the inside, or layered on the outside.
+                          </TableCell>
+                        </TableRow>
+                        <TableRow>
+                          <TableCell>Boston roll</TableCell>
+                          <TableCell>
+                            An uramaki California roll with poached shrimp
+                            instead of imitation crab.
+                          </TableCell>
+                        </TableRow>
+                        <TableRow>
+                          <TableCell>British Columbia roll</TableCell>
+                          <TableCell>
+                            A roll containing grilled or barbecued salmon skin,
+                            cucumber, sweet sauce, sometimes with roe. Also
+                            sometimes referred to as salmon skin rolls outside
+                            of British Columbia, Canada.
+                          </TableCell>
+                        </TableRow>
+                        <TableRow>
+                          <TableCell>California roll</TableCell>
+                          <TableCell>
+                            A roll consisting of avocado, kani kama (imitation
+                            crab/crab stick) (also can contain real crab in{' '}
+                            {'premium'} varieties), cucumber, and tobiko, often
+                            made as uramaki (with rice on the outside, nori on
+                            the inside).
+                          </TableCell>
+                        </TableRow>
+                        <TableRow>
+                          <TableCell>Dynamite roll</TableCell>
+                          <TableCell>
+                            A roll including yellowtail (hamachi) or prawn
+                            tempura, and fillings such as bean sprouts, carrots,
+                            avocado, cucumber, chili, spicy mayonnaise, and roe.
+                          </TableCell>
+                        </TableRow>
+                        <TableRow>
+                          <TableCell>Hawaiian roll</TableCell>
+                          <TableCell>
+                            A roll containing shōyu tuna (canned), tamago,
+                            kanpyō, kamaboko, and the distinctive red and green
+                            hana ebi (shrimp powder).
+                          </TableCell>
+                        </TableRow>
+                      </TableBody>
+                    </Table>
+                  </Scroll>
+                </ScrollContainer>
               </div>
             </Library.Demo>
           </Library.Example>
@@ -239,6 +245,59 @@ export default function TablePage() {
 
             <Library.Demo title="Table with interactive set" withSource>
               <Table title="Some sushi rolls" interactive>
+                <TableHead>
+                  <TableRow>
+                    <TableCell classes="w-[180px]">Sushi roll name</TableCell>
+                    <TableCell>Definition</TableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  <TableRow onClick={() => alert('Yum, Alaska roll!')}>
+                    <TableCell>Alaskan roll</TableCell>
+                    <TableCell>
+                      A variant of the California roll with smoked salmon on the
+                      inside, or layered on the outside.
+                    </TableCell>
+                  </TableRow>
+                  <TableRow onClick={() => alert('This is a new one!')}>
+                    <TableCell>Boston roll</TableCell>
+                    <TableCell>
+                      An uramaki California roll with poached shrimp instead of
+                      imitation crab.
+                    </TableCell>
+                  </TableRow>
+                  <TableRow
+                    onClick={() => alert('I call this a salmon-skin roll')}
+                  >
+                    <TableCell>British Columbia roll</TableCell>
+                    <TableCell>
+                      A roll containing grilled or barbecued salmon skin,
+                      cucumber, sweet sauce, sometimes with roe. Also sometimes
+                      referred to as salmon skin rolls outside of British
+                      Columbia, Canada.
+                    </TableCell>
+                  </TableRow>
+                </TableBody>
+              </Table>
+            </Library.Demo>
+          </Library.Example>
+          <Library.Example title="borderless">
+            <Library.Info>
+              <Library.InfoItem label="description">
+                Set this boolean prop if you want to remove the table{"'"}s
+                outer borders, in case it is rendered on a container with its
+                own borders.
+              </Library.InfoItem>
+              <Library.InfoItem label="type">
+                <code>boolean</code>
+              </Library.InfoItem>
+              <Library.InfoItem label="default">
+                <code>false</code>
+              </Library.InfoItem>
+            </Library.Info>
+
+            <Library.Demo title="Table without borders" withSource>
+              <Table title="Some sushi rolls" borderless>
                 <TableHead>
                   <TableRow>
                     <TableCell classes="w-[180px]">Sushi roll name</TableCell>

--- a/src/pattern-library/components/patterns/layout/CardPage.tsx
+++ b/src/pattern-library/components/patterns/layout/CardPage.tsx
@@ -51,7 +51,7 @@ export default function CardPage() {
             <Library.Demo title="Card with full-width image" withSource>
               <Card>
                 <img
-                  className="rounded-t-lg"
+                  className="rounded-t-[inherit]"
                   src="https://placekitten.com/1000/250"
                   alt="kitty"
                 />

--- a/src/pattern-library/components/patterns/layout/CardPage.tsx
+++ b/src/pattern-library/components/patterns/layout/CardPage.tsx
@@ -50,7 +50,11 @@ export default function CardPage() {
             </p>
             <Library.Demo title="Card with full-width image" withSource>
               <Card>
-                <img src="https://placekitten.com/1000/250" alt="kitty" />
+                <img
+                  className="rounded-t-lg"
+                  src="https://placekitten.com/1000/250"
+                  alt="kitty"
+                />
                 <CardContent>
                   <LoremIpsum size="xs" />
                 </CardContent>

--- a/src/pattern-library/components/patterns/prototype/TabbedDialogPage.tsx
+++ b/src/pattern-library/components/patterns/prototype/TabbedDialogPage.tsx
@@ -141,7 +141,9 @@ function TabbedDialog() {
                 Three
               </Tab>
             </TabListHeader>
-            <Card>
+            <Card
+              classes={selectedTab === 'one' ? 'rounded-tl-none' : undefined}
+            >
               <TabPanel
                 id="one-panel"
                 active={selectedTab === 'one'}
@@ -229,7 +231,9 @@ function TabbedSharePanel() {
                 Export
               </Tab>
             </TabListHeader>
-            <Card>
+            <Card
+              classes={selectedTab === 'share' ? 'rounded-tl-none' : undefined}
+            >
               <TabPanel
                 id="share-panel"
                 active={selectedTab === 'share'}

--- a/src/tailwind.preset.js
+++ b/src/tailwind.preset.js
@@ -17,6 +17,15 @@ export default /** @type {Partial<import('tailwindcss').Config>} */ ({
       borderColor: {
         DEFAULT: '#dbdbdb',
       },
+      borderRadius: {
+        // Equivalent to tailwind default `rounded-sm` size.
+        // These should be overwritten by downstream projects in order to
+        // "enable" rounded corners.
+        // Next major version will remove this config, effectively enabling
+        // rounded corners.
+        lg: 'var(--h-border-radius-lg, 0.125rem)',
+        DEFAULT: 'var(--h-border-radius, 0.125rem)',
+      },
       boxShadow: {
         DEFAULT: '0 1px 1px rgba(0, 0, 0, 0.1)',
         md: '0px 2px 3px 0px rgba(0, 0, 0, 0.15)',

--- a/src/tailwind.preset.js
+++ b/src/tailwind.preset.js
@@ -17,10 +17,6 @@ export default /** @type {Partial<import('tailwindcss').Config>} */ ({
       borderColor: {
         DEFAULT: '#dbdbdb',
       },
-      borderRadius: {
-        // Equivalent to tailwind default `rounded-sm` size
-        DEFAULT: '0.125rem',
-      },
       boxShadow: {
         DEFAULT: '0 1px 1px rgba(0, 0, 0, 0.1)',
         md: '0px 2px 3px 0px rgba(0, 0, 0, 0.15)',

--- a/styles/library.scss
+++ b/styles/library.scss
@@ -2,6 +2,15 @@
  * This stylesheet contains styles for pattern-library components (only).
  */
 
+@layer base {
+  :root {
+    // This is the same as default tailwind values
+    // Once our overwrites have been removed from the preset, this can be dropped
+    --h-border-radius: 0.25rem;
+    --h-border-radius-lg: 0.5rem;
+  }
+}
+
 @layer components {
   // Support some basic text styling in Library components
   .styled-text {


### PR DESCRIPTION
This PR increases the overall "roundness" of many elements in the UI, which rely on the `rounded` class from Tailwind. Primary changes made:
- Removed the overwrite of `DEFAULT` value for `border-radius` inside of `tailwind.preset.js` which reset the `rounded` class value to equal 4px.
- Adjusted a few elements which had behavior different than using `rounded` including `InputGroup`
- Increased the radius to 8px for `Card` and `Tab` using the `rounded-lg` class.
- Added roundness to `Table` which may need to reverted based on feedback.

> Part of https://github.com/hypothesis/frontend-shared/issues/1304