### PR TITLE
Improve SelectNext arrow key navigation

### DIFF
--- a/src/components/input/SelectNext.tsx
+++ b/src/components/input/SelectNext.tsx
@@ -73,6 +73,8 @@ function SelectOption<T>({
   );
 }
 
+SelectOption.displayName = 'SelectNext.Option';
+
 function useShouldDropUp(
   buttonRef: RefObject<HTMLElement | undefined>,
   listboxRef: RefObject<HTMLElement | null>,
@@ -234,6 +236,8 @@ function SelectMain<T>({
     </div>
   );
 }
+
+SelectMain.displayName = 'SelectNext';
 
 const SelectNext = Object.assign(SelectMain, { Option: SelectOption });
 

--- a/src/hooks/test/use-arrow-key-navigation-test.js
+++ b/src/hooks/test/use-arrow-key-navigation-test.js
@@ -48,7 +48,6 @@ function ToolbarWithToggle({ navigationOptions = {} }) {
 
 describe('useArrowKeyNavigation', () => {
   let container;
-  let toolbar;
 
   beforeEach(() => {
     container = document.createElement('div');
@@ -56,7 +55,6 @@ describe('useArrowKeyNavigation', () => {
     button.setAttribute('data-testid', 'outside-button');
     container.append(button);
     document.body.append(container);
-    toolbar = renderToolbar();
   });
 
   afterEach(() => {
@@ -98,6 +96,7 @@ describe('useArrowKeyNavigation', () => {
     { forwardKey: 'ArrowDown', backKey: 'ArrowUp' },
   ].forEach(({ forwardKey, backKey }) => {
     it('should move focus and tab stop between elements when arrow keys are pressed', () => {
+      const toolbar = renderToolbar();
       const steps = [
         // Test navigating forwards.
         [forwardKey, 'Italic'],
@@ -381,12 +380,23 @@ describe('useArrowKeyNavigation', () => {
         container,
       ),
     );
+    const toggleToolbar = () => findElementByTestId('toggle').click();
 
     // No button should be initially focused
     assert.equal(document.activeElement, document.body);
 
-    // Once we toggle the list open, the first item will be focused
-    findElementByTestId('toggle').click();
+    // Once we open the toolbar, the first item will be focused
+    toggleToolbar();
     await waitFor(() => document.activeElement === findElementByTestId('bold'));
+
+    // If we then focus another toolbar item, then close the toolbar and open it
+    // again, that same element should be focused again
+    pressKey('ArrowDown'); // "italic" is focused
+    pressKey('ArrowDown'); // "underline" is focused
+    toggleToolbar(); // Close toolbar
+    toggleToolbar(); // Open toolbar again
+    await waitFor(
+      () => document.activeElement === findElementByTestId('underline'),
+    );
   });
 });

--- a/src/hooks/use-arrow-key-navigation.ts
+++ b/src/hooks/use-arrow-key-navigation.ts
@@ -77,7 +77,6 @@ export type UseArrowKeyNavigationOptions = {
  * [2] https://www.w3.org/TR/wai-aria-practices/#keyboard
  *
  */
-
 export function useArrowKeyNavigation(
   containerRef: RefObject<HTMLElement | undefined>,
   {
@@ -92,7 +91,7 @@ export function useArrowKeyNavigation(
   // Keep track of the element that was last focused by this hook such that
   // navigation can be restored if focus moves outside the container and then
   // back to/into it.
-  const lastFocusedItem = useRef<HTMLOrSVGElement | null>(null);
+  const lastFocusedItem = useRef<HTMLElement | null>(null);
 
   useEffect(() => {
     if (!containerRef.current) {
@@ -192,7 +191,16 @@ export function useArrowKeyNavigation(
       event.stopPropagation();
     };
 
-    updateTabIndexes(getNavigableElements(), 0, containerVisible && autofocus);
+    const navigableElements = getNavigableElements();
+    // Start focus sequence with previously focused element, if any
+    const initialIndex = lastFocusedItem.current
+      ? navigableElements.indexOf(lastFocusedItem.current)
+      : 0;
+    updateTabIndexes(
+      navigableElements,
+      initialIndex,
+      containerVisible && autofocus,
+    );
 
     const listeners = new ListenerCollection();
 


### PR DESCRIPTION
Part of https://github.com/hypothesis/frontend-shared/issues/1285
Depends on https://github.com/hypothesis/frontend-shared/pull/1288

This PR's primary focus is to improve arrow key navigation, making sure the active option is the focused one when the listbox is opened, falling back to the first option if none is active.

Additionally, we add explicit `displayName`s for `SelectNext` and `SelectOption`, which don't have the expected value by default due to the `Object.assign(...)` approach to expose the main component and its sub-components.

### Testing steps

1. Check out this branch and start dev server (`make dev`)
2. Go to http://localhost:4001/input-select-next
3. Focus one of the selects, and press <kbd>ArrowDown</kbd>. Notice the list is open and the first option is focused.
4. Select some other option. The list should close.
5. Repeat step 3. The active option should be the one selected this time.

In `main`, the first option is the one selected when the list is open, no matter if there's an active option or not.