### PR TITLE
Do not unmount SelectNext chevron when toggling listbox

### DIFF
--- a/src/components/input/SelectNext.tsx
+++ b/src/components/input/SelectNext.tsx
@@ -215,7 +215,14 @@ function SelectMain<T>({
         {buttonContent ?? label}
         <div className="grow" />
         <div className="text-grey-6">
-          {listboxOpen ? <MenuCollapseIcon /> : <MenuExpandIcon />}
+          <MenuCollapseIcon
+            className={classnames({
+              // Hide instead of unmount to avoid `onClickAway` from thinking a
+              // foreign component was clicked and close the listbox
+              hidden: !listboxOpen,
+            })}
+          />
+          <MenuExpandIcon className={classnames({ hidden: listboxOpen })} />
         </div>
       </Button>
       <SelectContext.Provider value={{ selectValue, value }}>


### PR DESCRIPTION
This PR fixes a bug on `SelectNext`, where clicking exactly over the chevron would not open the list.

The reason is that we were mounting only one chevron icon depending if the list is open or closed. This was causing `onClickAway` to think a foreign element was clicked, as it is no longer in the DOM by the time the event bubbles.

In order to fix that behavior, this PR makes sure both chevrons are always mounted in the DOM, but hides the non-relevant one via CSS.