### PR TITLE
Use `event.composePath()` in `useClickAway` to determine if component is in container

### DIFF
--- a/src/hooks/use-click-away.ts
+++ b/src/hooks/use-click-away.ts
@@ -28,7 +28,12 @@ export function useClickAway(
     const handleAwayClick = (event: Event) => {
       if (
         container.current &&
-        !container.current.contains(event.target as Node)
+        // We test the composed path here to handle the case where the clicked
+        // element was in fact in the container, but is removed from the DOM
+        // (eg. by a re-render in a child component) before this callback is run.
+        // The composed path reflects the DOM hierarchy at the time the event was
+        // dispatched.
+        !event.composedPath().includes(container.current)
       ) {
         callback(event);
       }


### PR DESCRIPTION
This fixes a bug in which, if an element inside the container handled by `useClickAway` is clicked, and immediately removed from the DOM, the hook would think an element outside the container was clicked, and incorrectly call the callback.

In order to solve this, we check if the container is part of the event's `composePath()`, which is a list of the target element and all its parents at the moment of invoking the event. This will be true even if the target itself has been removed from the DOM before the event handler is invoked.