### PR TITLE
Handle overflow in SelectNext

### DIFF
--- a/src/components/input/SelectNext.tsx
+++ b/src/components/input/SelectNext.tsx
@@ -194,7 +194,7 @@ function SelectMain<T>({
         id={buttonId ?? defaultButtonId}
         variant="custom"
         classes={classnames(
-          'w-full flex',
+          'w-full flex justify-between',
           'bg-grey-0 disabled:bg-grey-1 disabled:text-grey-6',
           // Add inherited rounded corners so that the toggle is consistent with
           // the wrapper, which is the element rendering borders.
@@ -217,8 +217,7 @@ function SelectMain<T>({
         }}
         data-testid="select-toggle-button"
       >
-        {buttonContent ?? label}
-        <div className="grow" />
+        <div className="truncate">{buttonContent ?? label}</div>
         <div className="text-grey-6">
           {listboxOpen ? <MenuCollapseIcon /> : <MenuExpandIcon />}
         </div>
@@ -226,7 +225,7 @@ function SelectMain<T>({
       <SelectContext.Provider value={{ selectValue, value }}>
         <ul
           className={classnames(
-            'absolute z-5 w-full max-h-80 overflow-y-auto',
+            'absolute z-5 min-w-full max-h-80 overflow-y-auto',
             'rounded border bg-white shadow hover:shadow-md focus-within:shadow-md',
             {
               'top-full mt-1': !shouldListboxDropUp,

--- a/src/pattern-library/components/patterns/prototype/SelectNextPage.tsx
+++ b/src/pattern-library/components/patterns/prototype/SelectNextPage.tsx
@@ -17,10 +17,12 @@ const defaultItems = [
 function SelectExample({
   disabled,
   textOnly,
+  classes,
   items = defaultItems,
 }: {
   disabled?: boolean;
   textOnly?: boolean;
+  classes?: string;
   items?: typeof defaultItems;
 }) {
   const [value, setValue] = useState<(typeof items)[number]>();
@@ -29,13 +31,17 @@ function SelectExample({
     <SelectNext
       value={value}
       onChange={setValue}
+      classes={classes}
       buttonContent={
         value ? (
           <>
-            {value.name}
+            {textOnly && value.name}
             {!textOnly && (
-              <div className="rounded px-2 bg-grey-7 text-white">
-                {value.id}
+              <div className="flex">
+                <div className="truncate">{value.name}</div>
+                <div className="rounded px-2 ml-2 bg-grey-7 text-white">
+                  {value.id}
+                </div>
               </div>
             )}
           </>
@@ -56,7 +62,7 @@ function SelectExample({
               <>
                 {item.name}
                 <div className="grow" />
-                <div className="rounded px-2 bg-grey-7 text-white">
+                <div className="rounded px-2 ml-2 bg-grey-7 text-white">
                   {item.id}
                 </div>
               </>
@@ -68,7 +74,7 @@ function SelectExample({
   );
 }
 
-function InputGroupSelectExample() {
+function InputGroupSelectExample({ classes }: { classes?: string }) {
   const [selected, setSelected] = useState<(typeof defaultItems)[number]>();
   const selectedIndex = useMemo(
     () => (!selected ? -1 : defaultItems.findIndex(item => item === selected)),
@@ -95,14 +101,15 @@ function InputGroupSelectExample() {
       <SelectNext
         value={selected}
         onChange={setSelected}
+        classes={classes}
         buttonContent={
           selected ? (
-            <>
-              {selected.name}
-              <div className="rounded px-2 bg-grey-7 text-white">
+            <div className="flex">
+              <div className="truncate">{selected.name}</div>
+              <div className="rounded px-2 ml-2 bg-grey-7 text-white">
                 {selected.id}
               </div>
-            </>
+            </div>
           ) : (
             <>Select one...</>
           )
@@ -115,7 +122,9 @@ function InputGroupSelectExample() {
                 {item.name}
                 <div className="grow" />
                 <div
-                  className={classnames('rounded px-2 text-white bg-grey-7')}
+                  className={classnames(
+                    'rounded px-2 ml-2 text-white bg-grey-7',
+                  )}
                 >
                   {item.id}
                 </div>
@@ -152,7 +161,7 @@ export default function SelectNextPage() {
 
           <Library.Example>
             <Library.Demo title="Basic Select">
-              <div className="w-[350px] mx-auto">
+              <div className="w-96 mx-auto">
                 <SelectExample textOnly />
               </div>
             </Library.Demo>
@@ -181,7 +190,7 @@ export default function SelectNextPage() {
 
           <Library.Example title="Select with many options">
             <Library.Demo title="Select with many options">
-              <div className="w-[350px] mx-auto">
+              <div className="w-96 mx-auto">
                 <SelectExample
                   items={[
                     ...defaultItems.map(({ id, name }) => ({
@@ -216,8 +225,43 @@ export default function SelectNextPage() {
 
           <Library.Example title="Disabled Select">
             <Library.Demo title="Disabled Select">
-              <div className="w-[350px] mx-auto">
+              <div className="w-96 mx-auto">
                 <SelectExample disabled />
+              </div>
+            </Library.Demo>
+          </Library.Example>
+
+          <Library.Example title="Select with long content">
+            <p>
+              <code>SelectNext</code> makes sure the button content never
+              overflows, and applies <code>text-overflow: ellipsis</code>.
+            </p>
+            <p>
+              If you provide more complex children to <code>buttonContent</code>
+              , and the default hidden overflow logic does not work for your use
+              case, it is up to you to handle the overflow logic in your
+              components.
+            </p>
+            <p>
+              On the other hand, the listbox will always grow to fit its
+              options.
+            </p>
+
+            <Library.Demo title="Plain text">
+              <div className="mx-auto">
+                <SelectExample textOnly classes="!w-36" />
+              </div>
+            </Library.Demo>
+
+            <Library.Demo title="Custom options">
+              <div className="mx-auto">
+                <SelectExample classes="!w-36" />
+              </div>
+            </Library.Demo>
+
+            <Library.Demo title="Input group">
+              <div className="mx-auto">
+                <InputGroupSelectExample classes="!w-36" />
               </div>
             </Library.Demo>
           </Library.Example>
@@ -303,7 +347,7 @@ export default function SelectNextPage() {
         value ? (
           <>
             {value.name}
-            <div className="rounded px-2 bg-grey-7 text-white">
+            <div className="rounded px-2 ml-2 bg-grey-7 text-white">
               {value.id}
             </div>
           </>


### PR DESCRIPTION
> Closes #1249 

This PR is trying to make `SelectNext` behave closer to the native `select` when the items overflow the size of the select itself.

For context, this is how a native select looks in that case:

![Captura desde 2023-10-16 15-33-07](https://github.com/hypothesis/frontend-shared/assets/2719332/106ff779-bd73-423c-adae-83fff7e09210)

* The content in the select itself is cropped, to make sure it does not overflow its container.
* The listbox grows to fit all options without cropping them. This is important, as there has to be a place where you can see the full content for every option.

Taking that into consideration, the next changes have been made.

1. The listbox has changed from `w-full` to `min-w-full`. That way it keeps looking the same as before in most of the cases, but it grows if the content is too long.

    ![image](https://github.com/hypothesis/frontend-shared/assets/2719332/e9ef6132-87d0-4ab3-bd96-5bc5771844d6)
    ![image](https://github.com/hypothesis/frontend-shared/assets/2719332/08647740-04ea-4fb3-8daf-37f9edd694a0)

2. The toggle button now truncates its content. That ensures there won't be content overflow, and displays ellipsis if the content is just plain text.
  When the content is not plain text, consumers might need to adapt their code in order to make it look nice. An example of this is included in the pattern library docs.

    ![image](https://github.com/hypothesis/frontend-shared/assets/2719332/b583b329-ace1-4aaa-8907-321f26be18c4)

### Testing steps.

You can check the new examples at the bottom of http://localhost:4001/input-select-next 