### PR TITLE
Fixes and improvements for SelectNext.Option

### DIFF
--- a/src/components/input/SelectNext.tsx
+++ b/src/components/input/SelectNext.tsx
@@ -64,9 +64,12 @@ function SelectOption<T>({
   return (
     <li
       className={classnames(
-        'w-full ring-inset focus:ring outline-none rounded-none',
+        'w-full ring-inset outline-none rounded-none',
         'border-t first:border-t-0 transition-colors whitespace-nowrap',
-        { 'cursor-pointer hover:bg-grey-1': !disabled },
+        {
+          'text-grey-4': disabled,
+          'cursor-pointer focus:ring hover:bg-grey-1': !disabled,
+        },
         classes,
       )}
       onClick={() => {
@@ -81,7 +84,7 @@ function SelectOption<T>({
         }
       }}
       role="option"
-      disabled={disabled}
+      aria-disabled={disabled}
       aria-selected={selected}
       // This is intended to be focused with arrow keys
       tabIndex={-1}
@@ -193,7 +196,7 @@ function SelectMain<T>({
     loop: false,
     autofocus: true,
     containerVisible: listboxOpen,
-    selector: '[role="option"]',
+    selector: '[role="option"]:not([aria-disabled="true"])',
   });
 
   useLayoutEffect(() => {

--- a/src/components/input/SelectNext.tsx
+++ b/src/components/input/SelectNext.tsx
@@ -28,9 +28,24 @@ export type SelectOptionStatus = {
 export type SelectOptionProps<T> = {
   value: T;
   disabled?: boolean;
-  children: (status: SelectOptionStatus) => ComponentChildren;
+  children:
+    | ComponentChildren
+    | ((status: SelectOptionStatus) => ComponentChildren);
   classes?: string | string[];
 };
+
+function optionChildren(
+  children:
+    | ComponentChildren
+    | ((status: SelectOptionStatus) => ComponentChildren),
+  status: SelectOptionStatus,
+): ComponentChildren {
+  if (typeof children === 'function') {
+    return children(status);
+  }
+
+  return children;
+}
 
 function SelectOption<T>({
   value,
@@ -49,14 +64,18 @@ function SelectOption<T>({
   return (
     <li
       className={classnames(
-        'w-full ring-inset focus:ring outline-none rounded-none cursor-pointer',
+        'w-full ring-inset focus:ring outline-none rounded-none',
         'border-t first:border-t-0 transition-colors whitespace-nowrap',
-        { 'hover:bg-grey-1': !disabled },
+        { 'cursor-pointer hover:bg-grey-1': !disabled },
         classes,
       )}
-      onClick={() => selectValue(value)}
+      onClick={() => {
+        if (!disabled) {
+          selectValue(value);
+        }
+      }}
       onKeyPress={e => {
-        if (e.code === 'Enter' || e.code === 'Space') {
+        if (!disabled && ['Enter', 'Space'].includes(e.code)) {
           e.preventDefault();
           selectValue(value);
         }
@@ -73,7 +92,7 @@ function SelectOption<T>({
           'border-l-brand font-medium': selected,
         })}
       >
-        {children({ selected, disabled })}
+        {optionChildren(children, { selected, disabled })}
       </div>
     </li>
   );

--- a/src/components/input/test/SelectNext-test.js
+++ b/src/components/input/test/SelectNext-test.js
@@ -81,6 +81,16 @@ describe('SelectNext', () => {
     assert.calledWith(onChange.lastCall, items[0]);
   });
 
+  it('does not change selected value when a disabled option is clicked', () => {
+    const onChange = sinon.stub();
+    const wrapper = createComponent({ onChange });
+    const clickDisabledOption = () =>
+      wrapper.find(`[data-testid="option-4"]`).simulate('click');
+
+    clickDisabledOption();
+    assert.notCalled(onChange);
+  });
+
   ['Enter', 'Space'].forEach(code => {
     it(`changes selected value when ${code} is pressed in option`, () => {
       const onChange = sinon.stub();
@@ -100,6 +110,20 @@ describe('SelectNext', () => {
 
       pressKeyInOption(1);
       assert.calledWith(onChange.lastCall, items[0]);
+    });
+
+    it(`does not change selected value when ${code} is pressed in a disabled option`, () => {
+      const onChange = sinon.stub();
+      const wrapper = createComponent({ onChange });
+      const pressKeyInDisabledOption = () =>
+        wrapper
+          .find(`[data-testid="option-4"]`)
+          .getDOMNode()
+          .closest('[role="option"]')
+          .dispatchEvent(new KeyboardEvent('keypress', { code }));
+
+      pressKeyInDisabledOption();
+      assert.notCalled(onChange);
     });
   });
 

--- a/src/components/input/test/SelectNext-test.js
+++ b/src/components/input/test/SelectNext-test.js
@@ -13,7 +13,17 @@ describe('SelectNext', () => {
     { id: '5', name: 'Doris Evanescence' },
   ];
 
-  const createComponent = (props = {}, paddingTop = 0) => {
+  /**
+   * @param {Object} [options]
+   * @param {number} [options.paddingTop] - Extra padding top for the container.
+   *                                        Defaults to 0.
+   * @param {boolean} [options.optionsChildrenAsCallback] -
+   *        Whether to renders SelectNext.Option children with callback notation.
+   *        Used primarily to test and cover both branches.
+   *        Defaults to true.
+   */
+  const createComponent = (props = {}, options = {}) => {
+    const { paddingTop = 0, optionsChildrenAsCallback = true } = options;
     const container = document.createElement('div');
     container.style.paddingTop = `${paddingTop}px`;
     document.body.append(container);
@@ -26,12 +36,16 @@ describe('SelectNext', () => {
             disabled={item.id === '4'}
             key={item.id}
           >
-            {({ selected, disabled }) => (
-              <span data-testid={`option-${item.id}`}>
-                {item.name}
-                {selected && <span data-testid="selected-option" />}
-                {disabled && <span data-testid="disabled-option" />}
-              </span>
+            {!optionsChildrenAsCallback ? (
+              <span data-testid={`option-${item.id}`}>{item.name}</span>
+            ) : (
+              ({ selected, disabled }) => (
+                <span data-testid={`option-${item.id}`}>
+                  {item.name}
+                  {selected && <span data-testid="selected-option" />}
+                  {disabled && <span data-testid="disabled-option" />}
+                </span>
+              )
             )}
           </SelectNext.Option>
         ))}
@@ -251,7 +265,7 @@ describe('SelectNext', () => {
     { containerPaddingTop: 1000, shouldDropUp: true },
   ].forEach(({ containerPaddingTop, shouldDropUp }) => {
     it('makes listbox drop up or down based on available space below', () => {
-      const wrapper = createComponent({}, containerPaddingTop);
+      const wrapper = createComponent({}, { paddingTop: containerPaddingTop });
       toggleListbox(wrapper);
 
       assert.equal(listboxDidDropUp(wrapper), shouldDropUp);
@@ -273,12 +287,19 @@ describe('SelectNext', () => {
     checkAccessibility([
       {
         name: 'Closed Select listbox',
-        content: () => createComponent({ buttonContent: 'Select' }),
+        content: () =>
+          createComponent(
+            { buttonContent: 'Select' },
+            { optionsChildrenAsCallback: false },
+          ),
       },
       {
         name: 'Open Select listbox',
         content: () => {
-          const wrapper = createComponent({ buttonContent: 'Select' });
+          const wrapper = createComponent(
+            { buttonContent: 'Select' },
+            { optionsChildrenAsCallback: false },
+          );
           toggleListbox(wrapper);
 
           return wrapper;

--- a/src/pattern-library/components/patterns/prototype/SelectNextPage.tsx
+++ b/src/pattern-library/components/patterns/prototype/SelectNextPage.tsx
@@ -6,7 +6,13 @@ import { IconButton, InputGroup } from '../../../../components/input';
 import SelectNext from '../../../../components/input/SelectNext';
 import Library from '../../Library';
 
-const defaultItems = [
+type ItemType = {
+  id: string;
+  name: string;
+  disabled?: boolean;
+};
+
+const defaultItems: ItemType[] = [
   { id: '1', name: 'All students' },
   { id: '2', name: 'Albert Banana' },
   { id: '3', name: 'Bernard California' },
@@ -25,13 +31,14 @@ function SelectExample({
   classes?: string;
   items?: typeof defaultItems;
 }) {
-  const [value, setValue] = useState<(typeof items)[number]>();
+  const [value, setValue] = useState<ItemType>();
 
   return (
     <SelectNext
       value={value}
       onChange={setValue}
       classes={classes}
+      disabled={disabled}
       buttonContent={
         value ? (
           <>
@@ -51,21 +58,27 @@ function SelectExample({
           <>Select one...</>
         )
       }
-      disabled={disabled}
     >
       {items.map(item => (
-        <SelectNext.Option value={item} key={item.id}>
-          {textOnly ? (
-            item.name
-          ) : (
-            <>
-              {item.name}
-              <div className="grow" />
-              <div className="rounded px-2 ml-2 bg-grey-7 text-white">
-                {item.id}
-              </div>
-            </>
-          )}
+        <SelectNext.Option value={item} key={item.id} disabled={item.disabled}>
+          {({ disabled }) =>
+            textOnly ? (
+              item.name
+            ) : (
+              <>
+                {item.name}
+                <div className="grow" />
+                <div
+                  className={classnames('rounded px-2 ml-2 text-white', {
+                    'bg-grey-7': !disabled,
+                    'bg-grey-4': disabled,
+                  })}
+                >
+                  {item.id}
+                </div>
+              </>
+            )
+          }
         </SelectNext.Option>
       ))}
     </SelectNext>
@@ -215,14 +228,6 @@ export default function SelectNextPage() {
             </Library.Demo>
           </Library.Example>
 
-          <Library.Example title="Disabled Select">
-            <Library.Demo title="Disabled Select">
-              <div className="w-96 mx-auto">
-                <SelectExample disabled />
-              </div>
-            </Library.Demo>
-          </Library.Example>
-
           <Library.Example title="Select with long content">
             <p>
               <code>SelectNext</code> makes sure the button content never
@@ -259,21 +264,11 @@ export default function SelectNextPage() {
           </Library.Example>
         </Library.Pattern>
 
-        <Library.Pattern title="Component API">
+        <Library.Pattern title="SelectNext component API">
           <code>SelectNext</code> accepts all standard{' '}
           <Library.Link href="/using-components#presentational-components-api">
             presentational component props
           </Library.Link>
-          <Library.Example title="buttonContent">
-            <Library.Info>
-              <Library.InfoItem label="description">
-                The content to be displayed in the toggle button.
-              </Library.InfoItem>
-              <Library.InfoItem label="type">
-                <code>ComponentChildren</code>
-              </Library.InfoItem>
-            </Library.Info>
-          </Library.Example>
           <Library.Example title="value">
             <Library.Info>
               <Library.InfoItem label="description">
@@ -294,16 +289,13 @@ export default function SelectNextPage() {
               </Library.InfoItem>
             </Library.Info>
           </Library.Example>
-          <Library.Example title="disabled">
+          <Library.Example title="buttonContent">
             <Library.Info>
               <Library.InfoItem label="description">
-                Whether the Select is disabled or not.
+                The content to be displayed in the toggle button.
               </Library.InfoItem>
               <Library.InfoItem label="type">
-                <code>boolean</code>
-              </Library.InfoItem>
-              <Library.InfoItem label="default">
-                <code>undefined</code>
+                <code>ComponentChildren</code>
               </Library.InfoItem>
             </Library.Info>
           </Library.Example>
@@ -320,9 +312,27 @@ export default function SelectNextPage() {
               </Library.InfoItem>
             </Library.Info>
           </Library.Example>
-          <p>
-            Every <code>SelectNext.Option</code> has its own set of props.
-          </p>
+          <Library.Example title="disabled">
+            <Library.Info>
+              <Library.InfoItem label="description">
+                Whether the Select is disabled or not.
+              </Library.InfoItem>
+              <Library.InfoItem label="type">
+                <code>boolean</code>
+              </Library.InfoItem>
+              <Library.InfoItem label="default">
+                <code>undefined</code>
+              </Library.InfoItem>
+            </Library.Info>
+            <Library.Demo title="Disabled Select">
+              <div className="w-96 mx-auto">
+                <SelectExample disabled />
+              </div>
+            </Library.Demo>
+          </Library.Example>
+        </Library.Pattern>
+
+        <Library.Pattern title="SelectNext.Option component API">
           <Library.Example title="children">
             <Library.Info>
               <Library.InfoItem label="description">
@@ -359,6 +369,15 @@ export default function SelectNextPage() {
                 <code>undefined</code>
               </Library.InfoItem>
             </Library.Info>
+            <Library.Demo title="Disabled options">
+              <div className="w-96 mx-auto">
+                <SelectExample
+                  items={defaultItems.map(item =>
+                    item.id !== '4' ? item : { ...item, disabled: true },
+                  )}
+                />
+              </div>
+            </Library.Demo>
           </Library.Example>
         </Library.Pattern>
 

--- a/src/pattern-library/components/patterns/prototype/SelectNextPage.tsx
+++ b/src/pattern-library/components/patterns/prototype/SelectNextPage.tsx
@@ -55,19 +55,17 @@ function SelectExample({
     >
       {items.map(item => (
         <SelectNext.Option value={item} key={item.id}>
-          {() =>
-            textOnly ? (
-              <>{item.name}</>
-            ) : (
-              <>
-                {item.name}
-                <div className="grow" />
-                <div className="rounded px-2 ml-2 bg-grey-7 text-white">
-                  {item.id}
-                </div>
-              </>
-            )
-          }
+          {textOnly ? (
+            item.name
+          ) : (
+            <>
+              {item.name}
+              <div className="grow" />
+              <div className="rounded px-2 ml-2 bg-grey-7 text-white">
+                {item.id}
+              </div>
+            </>
+          )}
         </SelectNext.Option>
       ))}
     </SelectNext>
@@ -117,19 +115,13 @@ function InputGroupSelectExample({ classes }: { classes?: string }) {
       >
         {defaultItems.map(item => (
           <SelectNext.Option value={item} key={item.id}>
-            {() => (
-              <>
-                {item.name}
-                <div className="grow" />
-                <div
-                  className={classnames(
-                    'rounded px-2 ml-2 text-white bg-grey-7',
-                  )}
-                >
-                  {item.id}
-                </div>
-              </>
-            )}
+            {item.name}
+            <div className="grow" />
+            <div
+              className={classnames('rounded px-2 ml-2 text-white bg-grey-7')}
+            >
+              {item.id}
+            </div>
           </SelectNext.Option>
         ))}
       </SelectNext>
@@ -322,6 +314,46 @@ export default function SelectNextPage() {
               </Library.InfoItem>
               <Library.InfoItem label="type">
                 <code>string</code>
+              </Library.InfoItem>
+              <Library.InfoItem label="default">
+                <code>undefined</code>
+              </Library.InfoItem>
+            </Library.Info>
+          </Library.Example>
+          <p>
+            Every <code>SelectNext.Option</code> has its own set of props.
+          </p>
+          <Library.Example title="children">
+            <Library.Info>
+              <Library.InfoItem label="description">
+                Content of the option. You can pass a callback to receive the
+                option status (<code>disabled</code> and <code>selected</code>).
+              </Library.InfoItem>
+              <Library.InfoItem label="type">
+                <code>
+                  ComponentChildren | (({'{'} disabled, selected {'}'}) {'=>'}{' '}
+                  ComponentChildren)
+                </code>
+              </Library.InfoItem>
+            </Library.Info>
+          </Library.Example>
+          <Library.Example title="value">
+            <Library.Info>
+              <Library.InfoItem label="description">
+                The value to set when this option is selected.
+              </Library.InfoItem>
+              <Library.InfoItem label="type">
+                <code>T</code>
+              </Library.InfoItem>
+            </Library.Info>
+          </Library.Example>
+          <Library.Example title="disabled">
+            <Library.Info>
+              <Library.InfoItem label="description">
+                Whether the option is disabled or not.
+              </Library.InfoItem>
+              <Library.InfoItem label="type">
+                <code>boolean</code>
               </Library.InfoItem>
               <Library.InfoItem label="default">
                 <code>undefined</code>


### PR DESCRIPTION
This PR introduces a couple of improvements and one fix for the `SelectNext.Option` components:

* It ensures `<SelectNext.Option disabled />` occurrences cannot be interacted with the mouse or keyboard.
  This was a regression introduced when moving from `Button` to `li`, as it worked out of the box for `<Button disabled />`.
* It adds some default style for disabled `SelectNext.Option`s.  
  
  ![image](https://github.com/hypothesis/frontend-shared/assets/2719332/9c7c45c6-33ef-4312-b890-01e62fcb67b4)

* It adds support for regular children.
  So far, children had to be a callback which receives the `disabled` and `selected` statuses, in case you need to apply some customization, but while using the `SelectNext` I have found that in most of the cases we are ignoring those, and being able to pass regular children is more convenient.
  So, instead of having to do this:
  ```tsx
  <SelectNext.Option>
    {() => 'Some value'}
  </SelectNext.Option>
  ```
  We can now also do this:
  ```tsx
  <SelectNext.Option>
    Some value
  </SelectNext.Option>
  ```
* It adds the missing documentation for `SelectNext.Option` props in the pattern library, as we were only documenting the main `SelectNext` props.
  
  ![image](https://github.com/hypothesis/frontend-shared/assets/2719332/1baaa9bc-2213-4f40-8e26-56defc15a0ce)
