### PR TITLE
Add overflow-hidden to Card component

### DIFF
--- a/src/components/layout/Card.tsx
+++ b/src/components/layout/Card.tsx
@@ -42,7 +42,7 @@ export default function Card({
       {...htmlAttributes}
       ref={downcastRef(elementRef)}
       className={classnames(
-        'rounded-lg border bg-white',
+        'rounded-lg border bg-white overflow-hidden',
         {
           'shadow hover:shadow-md': variant === 'raised', // default
           'shadow-md': active && variant === 'raised',


### PR DESCRIPTION
Add `overflow-hidden` class to `Card` component.

This is specially important when rounded corners are enabled, otherwise consuming code has to "work around it" by inheriting rounded corners or hiding overflow themselves.

At first I thought it would be better to not make assumptions and give as much control as possible to downstream projects, but during the implementation of https://github.com/hypothesis/client/pull/5938, I have realized that you always have to end up hiding the card's overflowing content.

And in fact, it makes sense. The card is an opinionated component to "wrap" content. It defines borders and background color, so you don't want content rendering out of it.

This has become more obvious with rounded corners though, so I'm adding the `overflow-hidden` class. 