### PR TITLE
Add `rounded` prop to `OptionButton` to make it optionally consistent with rounded corners

### DIFF
--- a/src/components/input/OptionButton.tsx
+++ b/src/components/input/OptionButton.tsx
@@ -10,6 +10,12 @@ export type OptionButtonProps = {
   details?: ComponentChildren;
   /** alias for `pressed`: this option button is selected **/
   selected?: boolean;
+
+  /**
+   * Add rounded corners.
+   * @deprecated In next major version, OptionButtons will be rounded by default
+   */
+  rounded?: boolean;
 } & Omit<ButtonProps, 'size' | 'unstyled' | 'classes' | 'variant'>;
 
 /**
@@ -20,6 +26,7 @@ export default function OptionButton({
   children,
   details,
   selected = false,
+  rounded = false,
 
   pressed,
   ...buttonProps
@@ -35,6 +42,7 @@ export default function OptionButton({
         'disabled:border-stone-200',
         'aria-pressed:border-slate-5 aria-pressed:bg-slate-0 aria-pressed:shadow-inner',
         'aria-expanded:border-slate-5 aria-expanded:bg-slate-0 aria-expanded:shadow-inner',
+        { rounded },
       )}
       size="custom"
       variant="custom"

--- a/src/pattern-library/components/patterns/input/OptionButtonPage.tsx
+++ b/src/pattern-library/components/patterns/input/OptionButtonPage.tsx
@@ -110,6 +110,34 @@ export default function OptionButtonPage() {
             </Library.Demo>
           </Library.Example>
 
+          <Library.Example title="rounded">
+            <Library.Info>
+              <Library.InfoItem label="description">
+                <Library.StatusChip status="deprecated" />
+                Whether this button should render rounded corners.
+              </Library.InfoItem>
+              <Library.InfoItem label="type">
+                <code>boolean</code>
+              </Library.InfoItem>
+              <Library.InfoItem label="default">
+                <code>false</code>
+              </Library.InfoItem>
+            </Library.Info>
+
+            <Library.Demo title="Rounded OptionButton" withSource>
+              <div className="w-[250px]">
+                <OptionButton
+                  rounded
+                  details="PDF"
+                  title="Select a PDF from Google Drive"
+                  selected
+                >
+                  Google Drive
+                </OptionButton>
+              </div>
+            </Library.Demo>
+          </Library.Example>
+
           <Library.Example title="...buttonProps">
             <Library.Info>
               <Library.InfoItem label="description">


### PR DESCRIPTION
This was an overlook from https://github.com/hypothesis/frontend-shared/pull/1289

This PR adds a `rounded` property to `OptionButton`, so that we can optionally make it rounded.

The property defaults to `false` for backward compatibility, but is deprecated indicating the intention is to make all buttons rounded by default.

![image](https://github.com/hypothesis/frontend-shared/assets/2719332/81725734-ca10-40da-a9db-3df6dab9d1ef)
