### PR TITLE
Make it easier to prevent unnecessary `DataTable` re-renders

### DIFF
--- a/src/components/data/Scroll.tsx
+++ b/src/components/data/Scroll.tsx
@@ -1,5 +1,6 @@
 import classnames from 'classnames';
 import type { JSX } from 'preact';
+import { useMemo } from 'preact/hooks';
 
 import { useSyncedRef } from '../../hooks/use-synced-ref';
 import type { PresentationalProps } from '../../types';
@@ -26,9 +27,12 @@ export default function Scroll({
 }: ScrollProps) {
   const ref = useSyncedRef(elementRef);
 
-  const scrollContext: ScrollInfo = {
-    scrollRef: ref,
-  };
+  const scrollContext: ScrollInfo = useMemo(
+    () => ({
+      scrollRef: ref,
+    }),
+    [ref],
+  );
 
   return (
     <ScrollContext.Provider value={scrollContext}>

--- a/src/components/data/Table.tsx
+++ b/src/components/data/Table.tsx
@@ -1,5 +1,6 @@
 import classnames from 'classnames';
 import type { JSX } from 'preact';
+import { useMemo } from 'preact/hooks';
 
 import { useSyncedRef } from '../../hooks/use-synced-ref';
 import type { PresentationalProps } from '../../types';
@@ -34,12 +35,15 @@ export default function Table({
 }: TableProps) {
   const ref = useSyncedRef(elementRef);
 
-  const tableContext: TableInfo = {
-    interactive,
-    stickyHeader,
-    borderless,
-    tableRef: ref,
-  };
+  const tableContext: TableInfo = useMemo(
+    () => ({
+      interactive,
+      stickyHeader,
+      borderless,
+      tableRef: ref,
+    }),
+    [borderless, interactive, stickyHeader, ref],
+  );
 
   return (
     <TableContext.Provider value={tableContext}>

--- a/src/components/data/TableBody.tsx
+++ b/src/components/data/TableBody.tsx
@@ -1,6 +1,6 @@
 import classnames from 'classnames';
 import type { JSX } from 'preact';
-import { useContext } from 'preact/hooks';
+import { useContext, useMemo } from 'preact/hooks';
 
 import type { PresentationalProps } from '../../types';
 import { downcastRef } from '../../util/typing';
@@ -22,9 +22,12 @@ export default function TableBody({
   ...htmlAttributes
 }: TableBodyProps) {
   const tableContext = useContext(TableContext);
-  const sectionContext: TableSection = {
-    section: 'body',
-  };
+  const sectionContext: TableSection = useMemo(
+    () => ({
+      section: 'body',
+    }),
+    [],
+  );
 
   return (
     <TableSectionContext.Provider value={sectionContext}>

--- a/src/components/data/TableFoot.tsx
+++ b/src/components/data/TableFoot.tsx
@@ -1,5 +1,6 @@
 import classnames from 'classnames';
 import type { JSX } from 'preact';
+import { useMemo } from 'preact/hooks';
 
 import type { PresentationalProps } from '../../types';
 import { downcastRef } from '../../util/typing';
@@ -20,9 +21,12 @@ export default function TableFoot({
 
   ...htmlAttributes
 }: TableFootProps) {
-  const sectionContext: TableSection = {
-    section: 'foot',
-  };
+  const sectionContext: TableSection = useMemo(
+    () => ({
+      section: 'foot',
+    }),
+    [],
+  );
 
   return (
     <TableSectionContext.Provider value={sectionContext}>

--- a/src/components/data/TableHead.tsx
+++ b/src/components/data/TableHead.tsx
@@ -1,6 +1,6 @@
 import classnames from 'classnames';
 import type { JSX } from 'preact';
-import { useContext } from 'preact/hooks';
+import { useContext, useMemo } from 'preact/hooks';
 
 import type { PresentationalProps } from '../../types';
 import { downcastRef } from '../../util/typing';
@@ -23,9 +23,12 @@ export default function TableHead({
 }: TableHeadProps) {
   const tableContext = useContext(TableContext);
 
-  const sectionContext: TableSection = {
-    section: 'head',
-  };
+  const sectionContext: TableSection = useMemo(
+    () => ({
+      section: 'head',
+    }),
+    [],
+  );
 
   return (
     <TableSectionContext.Provider value={sectionContext}>

--- a/src/hooks/test/use-stable-callback-test.js
+++ b/src/hooks/test/use-stable-callback-test.js
@@ -1,0 +1,39 @@
+// These tests use Preact directly, rather than via Enzyme, to simplify debugging.
+import { render } from 'preact';
+
+import { useStableCallback } from '../use-stable-callback';
+
+describe('useStableCallback', () => {
+  let container;
+  let stableCallbackValues;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    stableCallbackValues = [];
+  });
+
+  function Widget({ callback }) {
+    const stableCallback = useStableCallback(callback);
+    stableCallbackValues.push(stableCallback);
+    return <button onClick={stableCallback}>Test</button>;
+  }
+
+  it('returns a wrapper with a stable identity', () => {
+    render(<Widget callback={() => {}} />, container);
+    render(<Widget callback={() => {}} />, container);
+
+    assert.equal(stableCallbackValues.length, 2);
+    assert.equal(stableCallbackValues[0], stableCallbackValues[1]);
+  });
+
+  it('returned wrapper forwards to the latest callback', () => {
+    const stub = sinon.stub();
+    render(<Widget callback={() => {}} />, container);
+    render(<Widget callback={stub} />, container);
+
+    assert.equal(stableCallbackValues.length, 2);
+    stableCallbackValues.at(-1)('foo', 'bar', 'baz');
+
+    assert.calledWith(stub, 'foo', 'bar', 'baz');
+  });
+});

--- a/src/hooks/use-stable-callback.ts
+++ b/src/hooks/use-stable-callback.ts
@@ -1,0 +1,23 @@
+import { useRef } from 'preact/hooks';
+
+/**
+ * Return a function which wraps a callback to give it a stable value.
+ *
+ * The wrapper has a stable value across renders, but always forwards to the
+ * callback from the most recent render. This is useful if you want to use a
+ * callback inside a `useEffect` or `useMemo` hook without re-running the effect
+ * or re-computing the memoed value when the callback changes.
+ */
+export function useStableCallback<R, A extends any[], F extends (...a: A) => R>(
+  callback: F,
+): F {
+  const wrapper = useRef({
+    callback,
+    call: (...args: A) => wrapper.current.callback(...args),
+  });
+
+  // On each render, save the last callback value.
+  wrapper.current.callback = callback;
+
+  return wrapper.current.call as F;
+}


### PR DESCRIPTION
While adding some new UI to the VitalSource chapter/page selection dialog (see https://github.com/hypothesis/lms/issues/5808) I found that the UI got very slow when working with a book that had a large (> 1000) number of entries in the chapter list. Such a large chapter list could really use virtualization to limit rendering time, but memo-ing is much easier to add and still has a significant impact.

I tried memo-ing the `DataTable` but that initially had no effect, due to the parent `Scroll` triggering a re-render even if the `DataTable` was memoed. This PR fixes that issue, and adds a bunch of additional memo-ing inside `DataTable` to make it easier for downstream apps to prevent re-renders. They now need to just memo: 1) The rows, 2) the columns, 3) the selected item. For better results they can also memo the whole `DataTable`.

In the process I imported the [useStableCallback](https://github.com/hypothesis/via/pull/1129) hook from Via since it is generally useful for these kinds of optimizations and I expect it will be useful in other applications in future.