### PR TITLE
Make Scroll within Panel inherit bottom rounded corners

### DIFF
--- a/src/components/layout/Panel.tsx
+++ b/src/components/layout/Panel.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames';
 import type { ComponentChildren, JSX } from 'preact';
 
 import type { IconComponent, CompositeProps } from '../../types';
@@ -96,7 +97,19 @@ export default function Panel({
         {Icon && <Icon className="w-em h-em" />}
         <CardTitle>{title}</CardTitle>
       </CardHeader>
-      {scrollable ? <Scroll>{panelContent}</Scroll> : <>{panelContent}</>}
+      {scrollable ? (
+        <Scroll
+          classes={classNames({
+            // When no buttons are provided (which means this is the last children),
+            // inherit the bottom border radius from Card.
+            'rounded-b-[inherit]': !buttons,
+          })}
+        >
+          {panelContent}
+        </Scroll>
+      ) : (
+        <>{panelContent}</>
+      )}
       {buttons && (
         <CardContent data-testid="panel-buttons">
           <CardActions>{buttons}</CardActions>

--- a/src/pattern-library/components/patterns/layout/PanelPage.tsx
+++ b/src/pattern-library/components/patterns/layout/PanelPage.tsx
@@ -42,17 +42,7 @@ export default function PanelPage() {
               withSource
             >
               <div className="h-[350px]">
-                <Panel
-                  title="Scrolling content"
-                  buttons={
-                    <>
-                      <Button>Buttons</Button>
-                      <Button>do not</Button>
-                      <Button variant="primary">Scroll</Button>
-                    </>
-                  }
-                  scrollable
-                >
+                <Panel title="Scrolling content" scrollable>
                   <LoremIpsum />
                 </Panel>
               </div>


### PR DESCRIPTION
This PR addresses a slight visual glitch happening when rendering `Panels` without buttons, in which the bottom corners were rendered without roundiness.

## Context

the `Panel` component is a wrapper around `Card`, which conditionally renders `<CardContent />` as the last children if some buttons have been provided, and can also wrap the panel content with `<Scroll />` if `scrollable` prop is true.

For simplicity, the default value for `scrollable` is true, so that you don't need to remember adding it and it just works if the content is too long.

During the development of https://github.com/hypothesis/client/pull/5938, we found some `Panels` and `Dialogs` where bottom corners were not rendered as rounded, because they didn't have buttons. It was worked aroundt by setting `scrollable={false}`, as this was not needed: https://github.com/hypothesis/client/pull/5938#discussion_r1383657231

With these changes, that workaround would not be needed anymore.

### Testing steps

The pattern library included two similar examples of scrollable panels. I have edited one of them so that it does not include buttons, in order to verify rounded corners work.

1. Check out this branch and go to http://localhost:4001/layout-panel.
2. Use the browser's search capabilities to search for "scrollable".
3. Check both examples render bottom corners as rounded.