### PR TITLE
Add props to SelectNext to granularly pass classess

### DIFF
--- a/src/components/input/SelectNext.tsx
+++ b/src/components/input/SelectNext.tsx
@@ -14,7 +14,7 @@ import { useClickAway } from '../../hooks/use-click-away';
 import { useFocusAway } from '../../hooks/use-focus-away';
 import { useKeyPress } from '../../hooks/use-key-press';
 import { useSyncedRef } from '../../hooks/use-synced-ref';
-import type { PresentationalProps } from '../../types';
+import type { CompositeProps } from '../../types';
 import { downcastRef } from '../../util/typing';
 import { MenuCollapseIcon, MenuExpandIcon } from '../icons';
 import { inputGroupStyles } from './InputGroup';
@@ -137,7 +137,7 @@ function useShouldDropUp(
   return shouldListboxDropUp;
 }
 
-export type SelectProps<T> = PresentationalProps & {
+export type SelectProps<T> = CompositeProps & {
   value: T;
   onChange: (newValue: T) => void;
   buttonContent?: ComponentChildren;
@@ -149,25 +149,37 @@ export type SelectProps<T> = PresentationalProps & {
    */
   buttonId?: string;
 
+  /** Additional classes to pass to container */
+  containerClasses?: string | string[];
+  /** Additional classes to pass to toggle button */
+  buttonClasses?: string | string[];
+  /** Additional classes to pass to listbox */
+  listboxClasses?: string | string[];
+
   'aria-label'?: string;
   'aria-labelledby'?: string;
 
   /** @deprecated Use buttonContent instead */
   label?: ComponentChildren;
+  /** @deprecated. Use buttonClasses instead */
+  classes?: string | string[];
 };
 
 function SelectMain<T>({
   buttonContent,
-  label,
   value,
   onChange,
   children,
   disabled,
   elementRef,
-  classes,
   buttonId,
+  buttonClasses,
+  listboxClasses,
+  containerClasses,
   'aria-label': ariaLabel,
   'aria-labelledby': ariaLabelledBy,
+  label,
+  classes,
 }: SelectProps<T>) {
   const [listboxOpen, setListboxOpen] = useState(false);
   const closeListbox = useCallback(() => setListboxOpen(false), []);
@@ -214,7 +226,11 @@ function SelectMain<T>({
 
   return (
     <div
-      className={classnames('relative w-full border rounded', inputGroupStyles)}
+      className={classnames(
+        'relative w-full border rounded',
+        inputGroupStyles,
+        containerClasses,
+      )}
       ref={wrapperRef}
     >
       <button
@@ -228,7 +244,7 @@ function SelectMain<T>({
           // Using overflow-hidden in the parent is not an option here, because
           // that would hide the listbox
           'rounded-[inherit]',
-          classes,
+          buttonClasses ?? classes,
         )}
         type="button"
         role="combobox"
@@ -267,6 +283,7 @@ function SelectMain<T>({
               // * Listbox size can be computed to correctly drop up or down
               hidden: !listboxOpen,
             },
+            listboxClasses,
           )}
           role="listbox"
           ref={listboxRef}

--- a/src/pattern-library/components/patterns/prototype/SelectNextPage.tsx
+++ b/src/pattern-library/components/patterns/prototype/SelectNextPage.tsx
@@ -28,7 +28,12 @@ function SelectExample({
   ...rest
 }: Pick<
   SelectNextProps<ItemType>,
-  'aria-label' | 'aria-labelledby' | 'classes' | 'disabled'
+  | 'aria-label'
+  | 'aria-labelledby'
+  | 'buttonClasses'
+  | 'containerClasses'
+  | 'listboxClasses'
+  | 'disabled'
 > & {
   textOnly?: boolean;
   items?: ItemType[];
@@ -98,7 +103,11 @@ function SelectExample({
   );
 }
 
-function InputGroupSelectExample({ classes }: { classes?: string }) {
+function InputGroupSelectExample({
+  buttonClasses,
+}: {
+  buttonClasses?: string;
+}) {
   const [selected, setSelected] = useState<(typeof defaultItems)[number]>();
   const selectedIndex = useMemo(
     () => (!selected ? -1 : defaultItems.findIndex(item => item === selected)),
@@ -129,7 +138,7 @@ function InputGroupSelectExample({ classes }: { classes?: string }) {
           buttonId={buttonId}
           value={selected}
           onChange={setSelected}
-          classes={classes}
+          buttonClasses={buttonClasses}
           buttonContent={
             selected ? (
               <div className="flex">
@@ -173,8 +182,8 @@ export default function SelectNextPage() {
       title="SelectNext"
       intro={
         <p>
-          <code>SelectNext</code> is a presentational component which behaves
-          like the native <code>{'<select>'}</code> element.
+          <code>SelectNext</code> is a composite component which behaves like
+          the native <code>{'<select>'}</code> element.
         </p>
       }
     >
@@ -302,19 +311,19 @@ export default function SelectNextPage() {
 
             <Library.Demo title="Plain text">
               <div className="mx-auto">
-                <SelectExample textOnly classes="!w-36" />
+                <SelectExample textOnly buttonClasses="!w-36" />
               </div>
             </Library.Demo>
 
             <Library.Demo title="Custom options">
               <div className="mx-auto">
-                <SelectExample classes="!w-36" />
+                <SelectExample buttonClasses="!w-36" />
               </div>
             </Library.Demo>
 
             <Library.Demo title="Input group">
               <div className="mx-auto">
-                <InputGroupSelectExample classes="!w-36" />
+                <InputGroupSelectExample buttonClasses="!w-36" />
               </div>
             </Library.Demo>
           </Library.Example>
@@ -322,8 +331,8 @@ export default function SelectNextPage() {
 
         <Library.Pattern title="SelectNext component API">
           <code>SelectNext</code> accepts all standard{' '}
-          <Library.Link href="/using-components#presentational-components-api">
-            presentational component props
+          <Library.Link href="/using-components#composite-components-api">
+            composite component props
           </Library.Link>
           <Library.Example title="value">
             <Library.Info>
@@ -383,6 +392,60 @@ export default function SelectNextPage() {
             <Library.Demo title="Disabled Select">
               <div className="w-96 mx-auto">
                 <SelectExample disabled />
+              </div>
+            </Library.Demo>
+          </Library.Example>
+          <Library.Example title="buttonClasses">
+            <Library.Info>
+              <Library.InfoItem label="description">
+                Additional classes to pass to toggle button.
+              </Library.InfoItem>
+              <Library.InfoItem label="type">
+                <code>string | string[]</code>
+              </Library.InfoItem>
+              <Library.InfoItem label="default">
+                <code>undefined</code>
+              </Library.InfoItem>
+            </Library.Info>
+            <Library.Demo title="Custom button">
+              <div className="w-96 mx-auto">
+                <SelectExample buttonClasses="!bg-yellow-notice" />
+              </div>
+            </Library.Demo>
+          </Library.Example>
+          <Library.Example title="containerClasses">
+            <Library.Info>
+              <Library.InfoItem label="description">
+                Additional classes to pass to container.
+              </Library.InfoItem>
+              <Library.InfoItem label="type">
+                <code>string | string[]</code>
+              </Library.InfoItem>
+              <Library.InfoItem label="default">
+                <code>undefined</code>
+              </Library.InfoItem>
+            </Library.Info>
+            <Library.Demo title="Custom container">
+              <div className="w-96 mx-auto">
+                <SelectExample containerClasses="border-4 border-yellow-notice" />
+              </div>
+            </Library.Demo>
+          </Library.Example>
+          <Library.Example title="listboxClasses">
+            <Library.Info>
+              <Library.InfoItem label="description">
+                Additional classes to pass to listbox.
+              </Library.InfoItem>
+              <Library.InfoItem label="type">
+                <code>string | string[]</code>
+              </Library.InfoItem>
+              <Library.InfoItem label="default">
+                <code>undefined</code>
+              </Library.InfoItem>
+            </Library.Info>
+            <Library.Demo title="Custom listbox">
+              <div className="w-96 mx-auto">
+                <SelectExample listboxClasses="border-4 border-yellow-notice" />
               </div>
             </Library.Demo>
           </Library.Example>


### PR DESCRIPTION
Add `buttonClasses`, `containerClasses` and `listboxClasses` props to `SelectNext`, to have more control over how individual components are styled.

The `classes` props is now deprecated in favor of `buttonClasses`.

We have discussed this approach in previous PRs, but it was always possible to work around it by wrapping the `SelectNext` in other elements. However, the need for this is more obvious the more we use it.

![Captura desde 2023-11-14 11-01-01](https://github.com/hypothesis/frontend-shared/assets/2719332/32631edc-c747-4e17-887b-8bb5f3028fb4)

Closes #1319