### PR TITLE
Add `right` prop to SelectNext

### DIFF
--- a/src/components/input/SelectNext.tsx
+++ b/src/components/input/SelectNext.tsx
@@ -156,6 +156,14 @@ export type SelectProps<T> = CompositeProps & {
   /** Additional classes to pass to listbox */
   listboxClasses?: string | string[];
 
+  /**
+   * Align the listbox to the right.
+   * Useful when the listbox is bigger than the toggle button and this component
+   * is rendered next to the right side of the page/container.
+   * Defaults to false.
+   */
+  right?: boolean;
+
   'aria-label'?: string;
   'aria-labelledby'?: string;
 
@@ -176,6 +184,7 @@ function SelectMain<T>({
   buttonClasses,
   listboxClasses,
   containerClasses,
+  right = false,
   'aria-label': ariaLabel,
   'aria-labelledby': ariaLabelledBy,
   label,
@@ -277,6 +286,7 @@ function SelectMain<T>({
             {
               'top-full mt-1': !shouldListboxDropUp,
               'bottom-full mb-1': shouldListboxDropUp,
+              'right-0': right,
 
               // Hiding instead of unmounting to
               // * Ensure screen readers detect button as a listbox handler

--- a/src/pattern-library/components/patterns/prototype/SelectNextPage.tsx
+++ b/src/pattern-library/components/patterns/prototype/SelectNextPage.tsx
@@ -34,6 +34,7 @@ function SelectExample({
   | 'containerClasses'
   | 'listboxClasses'
   | 'disabled'
+  | 'right'
 > & {
   textOnly?: boolean;
   items?: ItemType[];
@@ -392,6 +393,25 @@ export default function SelectNextPage() {
             <Library.Demo title="Disabled Select">
               <div className="w-96 mx-auto">
                 <SelectExample disabled />
+              </div>
+            </Library.Demo>
+          </Library.Example>
+          <Library.Example title="right">
+            <Library.Info>
+              <Library.InfoItem label="description">
+                Whether the listbox should be aligned to the right when it grows
+                bigger than the toggle button.
+              </Library.InfoItem>
+              <Library.InfoItem label="type">
+                <code>boolean</code>
+              </Library.InfoItem>
+              <Library.InfoItem label="default">
+                <code>false</code>
+              </Library.InfoItem>
+            </Library.Info>
+            <Library.Demo title="Right listbox">
+              <div className="mx-auto">
+                <SelectExample right buttonClasses="!w-36" />
               </div>
             </Library.Demo>
           </Library.Example>


### PR DESCRIPTION
Closes #1371

The first time we had to implement a SelectNext that is rendered at the very end of the viewport, we realized the listbox aligns to the left side of the select, making it look odd (see screenshot from #1371).

This PR adds a new `right` boolean prop that makes the listbox align to the right side when it grows bigger than the toggle button.

![image](https://github.com/hypothesis/frontend-shared/assets/2719332/e04dda87-2d32-4522-8b61-33f8fc33dccc)

### Context

Initially, I wanted to find a way to make this work transparently, but it requires a lot of custom logic that's not easy to maintain.

Material UI does this, but through the popper.js library, which renders popover-like elements individually, and calculates their position at runtime.

I checked how other solved this problem:

* Headless UI does not deal with this. The listbox is always as big or small as the toggle button, and the extra content is cropped.
* [Reactstrap](https://reactstrap.github.io/?path=/docs/components-dropdown--dropdown) has a similar `end` option. In their case it's more obvious, because menus from dropdowns don't have a minimum width matching the button.

I decided to go with the `right` prop because it's very simple.