### PR TITLE
Remove border radius config from tailwind preset

### DIFF
--- a/src/tailwind.preset.js
+++ b/src/tailwind.preset.js
@@ -17,15 +17,6 @@ export default /** @type {Partial<import('tailwindcss').Config>} */ ({
       borderColor: {
         DEFAULT: '#dbdbdb',
       },
-      borderRadius: {
-        // Equivalent to tailwind default `rounded-sm` size.
-        // These should be overwritten by downstream projects in order to
-        // "enable" rounded corners.
-        // Next major version will remove this config, effectively enabling
-        // rounded corners.
-        lg: 'var(--h-border-radius-lg, 0.125rem)',
-        DEFAULT: 'var(--h-border-radius, 0.125rem)',
-      },
       boxShadow: {
         DEFAULT: '0 1px 1px rgba(0, 0, 0, 0.1)',
         md: '0px 2px 3px 0px rgba(0, 0, 0, 0.15)',

--- a/styles/library.scss
+++ b/styles/library.scss
@@ -2,15 +2,6 @@
  * This stylesheet contains styles for pattern-library components (only).
  */
 
-@layer base {
-  :root {
-    // This is the same as default tailwind values
-    // Once our overwrites have been removed from the preset, this can be dropped
-    --h-border-radius: 0.25rem;
-    --h-border-radius-lg: 0.5rem;
-  }
-}
-
 @layer components {
   // Support some basic text styling in Library components
   .styled-text {


### PR DESCRIPTION
Closes #1356 

Remove the borderRadius config from the preset, as all downstream projects are currently overriding this to use tailwind's defaults.