### PR TITLE
Remove deprecated props

### DIFF
--- a/src/components/feedback/ModalDialog.tsx
+++ b/src/components/feedback/ModalDialog.tsx
@@ -7,14 +7,9 @@ import Overlay from '../layout/Overlay';
 import Dialog from './Dialog';
 import type { PanelDialogProps } from './Dialog';
 
-type ModalWidth = 'sm' | 'md' | 'lg' | 'custom';
+type ModalSize = 'sm' | 'md' | 'lg' | 'custom';
 
 type ComponentProps = {
-  /**
-   * @deprecated  - use `size` instead
-   */
-  width?: ModalWidth;
-
   /**
    * Do not close the modal when the Escape key is pressed
    */
@@ -35,7 +30,7 @@ type ComponentProps = {
   /**
    * Relative size (width) of modal dialog
    */
-  size?: ModalWidth;
+  size?: ModalSize;
 };
 
 export type ModalDialogProps = Omit<
@@ -53,7 +48,6 @@ export default function ModalDialog({
   disableFocusTrap = false,
   disableRestoreFocus = false,
   size,
-  width,
 
   classes,
   elementRef,
@@ -66,7 +60,7 @@ export default function ModalDialog({
   ...htmlAndPanelAttributes
 }: ModalDialogProps) {
   // Prefer `size` prop but support deprecated `width` if present
-  const modalSize = size ?? width ?? 'md';
+  const modalSize = size ?? 'md';
   const modalRef = useSyncedRef(elementRef);
 
   useTabKeyNavigation(modalRef, { enabled: !disableFocusTrap });

--- a/src/components/feedback/test/ModalDialog-test.js
+++ b/src/components/feedback/test/ModalDialog-test.js
@@ -130,12 +130,6 @@ describe('ModalDialog', () => {
       assert.equal(modalSize(wrapper), 'lg');
     });
 
-    it('accepts deprecated `width` prop to set size', () => {
-      const wrapper = sizedModal({ width: 'lg' });
-
-      assert.equal(modalSize(wrapper), 'lg');
-    });
-
     it('prefers `size` over `width` to set size', () => {
       const wrapper = sizedModal({ size: 'lg', width: 'sm' });
 

--- a/src/components/input/IconButton.tsx
+++ b/src/components/input/IconButton.tsx
@@ -9,15 +9,6 @@ import { inputGroupStyles } from './InputGroup';
 type ComponentProps = {
   icon?: IconComponent;
 
-  /**
-   * Disable minimum tap target sizing for touch devices. This may be necessary
-   * in legacy patterns where there isn't enough room in the interface for these
-   * larger dimensions.
-   *
-   * @deprecated Set `size` to `'custom'` instead
-   */
-  disableTouchSizing?: boolean;
-
   /** Required for `IconButton` as there is no text label */
   title: string;
 
@@ -43,7 +34,6 @@ export default function IconButton({
   expanded,
 
   icon: Icon,
-  disableTouchSizing = false,
   size = 'md',
   title,
   variant = 'secondary',
@@ -82,9 +72,6 @@ export default function IconButton({
           'p-1': size === 'xs',
           'p-1.5': size === 'sm',
           'p-2.5': size === 'lg',
-
-          'touch:min-w-touch-minimum touch:min-h-touch-minimum':
-            !disableTouchSizing,
         },
         classes,
       )}

--- a/src/components/input/Input.tsx
+++ b/src/components/input/Input.tsx
@@ -29,11 +29,6 @@ export function inputStyles({ classes, feedback }: InputStylesOptions) {
 type ComponentProps = {
   type?: 'text' | 'email' | 'search' | 'number' | 'password' | 'url';
   feedback?: 'error' | 'warning';
-
-  /**
-   * @deprecated Use feedback="error" instead
-   */
-  hasError?: boolean;
 };
 
 export type InputProps = PresentationalProps &
@@ -48,15 +43,9 @@ export default function Input({
   type = 'text',
   classes,
   feedback,
-  hasError,
 
   ...htmlAttributes
 }: InputProps) {
-  /* istanbul ignore next */
-  if (feedback === undefined && hasError) {
-    feedback = 'error';
-  }
-
   if (!htmlAttributes.id && !htmlAttributes['aria-label']) {
     console.warn(
       '`Input` component should have either an `id` or an `aria-label` attribute',

--- a/src/components/input/OptionButton.tsx
+++ b/src/components/input/OptionButton.tsx
@@ -10,12 +10,6 @@ export type OptionButtonProps = {
   details?: ComponentChildren;
   /** alias for `pressed`: this option button is selected **/
   selected?: boolean;
-
-  /**
-   * Add rounded corners.
-   * @deprecated In next major version, OptionButtons will be rounded by default
-   */
-  rounded?: boolean;
 } & Omit<ButtonProps, 'size' | 'unstyled' | 'classes' | 'variant'>;
 
 /**
@@ -26,7 +20,6 @@ export default function OptionButton({
   children,
   details,
   selected = false,
-  rounded = false,
 
   pressed,
   ...buttonProps
@@ -37,12 +30,11 @@ export default function OptionButton({
       classes={classnames(
         'group', // Facilitate styling children based on this element's state
         'w-full gap-x-2 px-2 py-1',
-        'border border-stone-300 bg-stone-50',
+        'rounded border border-stone-300 bg-stone-50',
         'enabled:hover:border-slate-5 enabled:hover:bg-slate-0',
         'disabled:border-stone-200',
         'aria-pressed:border-slate-5 aria-pressed:bg-slate-0 aria-pressed:shadow-inner',
         'aria-expanded:border-slate-5 aria-expanded:bg-slate-0 aria-expanded:shadow-inner',
-        { rounded },
       )}
       size="custom"
       variant="custom"

--- a/src/components/input/SelectNext.tsx
+++ b/src/components/input/SelectNext.tsx
@@ -166,11 +166,6 @@ export type SelectProps<T> = CompositeProps & {
 
   'aria-label'?: string;
   'aria-labelledby'?: string;
-
-  /** @deprecated Use buttonContent instead */
-  label?: ComponentChildren;
-  /** @deprecated. Use buttonClasses instead */
-  classes?: string | string[];
 };
 
 function SelectMain<T>({
@@ -187,8 +182,6 @@ function SelectMain<T>({
   right = false,
   'aria-label': ariaLabel,
   'aria-labelledby': ariaLabelledBy,
-  label,
-  classes,
 }: SelectProps<T>) {
   const [listboxOpen, setListboxOpen] = useState(false);
   const closeListbox = useCallback(() => setListboxOpen(false), []);
@@ -253,7 +246,7 @@ function SelectMain<T>({
           // Using overflow-hidden in the parent is not an option here, because
           // that would hide the listbox
           'rounded-[inherit]',
-          buttonClasses ?? classes,
+          buttonClasses,
         )}
         type="button"
         role="combobox"
@@ -273,7 +266,7 @@ function SelectMain<T>({
         }}
         data-testid="select-toggle-button"
       >
-        <div className="truncate">{buttonContent ?? label}</div>
+        <div className="truncate">{buttonContent}</div>
         <div className="text-grey-6">
           {listboxOpen ? <MenuCollapseIcon /> : <MenuExpandIcon />}
         </div>

--- a/src/components/navigation/Link.tsx
+++ b/src/components/navigation/Link.tsx
@@ -7,9 +7,6 @@ import { downcastRef } from '../../util/typing';
 type ComponentProps = {
   underline?: 'always' | 'hover' | 'none';
 
-  /** @deprecated use `variant` instead */
-  color?: 'brand' | 'text-light' | 'text';
-
   // Styling API
   variant?: 'brand' | 'text-light' | 'text' | 'custom';
   unstyled?: boolean;
@@ -28,16 +25,13 @@ export default function Link({
   elementRef,
 
   underline = 'none',
-  color,
   unstyled = false,
   variant = 'brand',
 
   ...htmlAttributes
 }: LinkProps) {
-  // Map from deprecated `color` prop to `variant` if `color` is present
-  const theme = typeof color === 'string' ? color : variant;
   const styled = !unstyled;
-  const themed = styled && theme !== 'custom';
+  const themed = styled && variant !== 'custom';
 
   return (
     <a
@@ -56,9 +50,9 @@ export default function Link({
         },
         themed && {
           // color
-          'text-brand hover:text-brand-dark': theme === 'brand', // default
-          'text-color-text-light hover:text-brand': theme === 'text-light',
-          'text-color-text hover:text-brand-dark': theme === 'text',
+          'text-brand hover:text-brand-dark': variant === 'brand', // default
+          'text-color-text-light hover:text-brand': variant === 'text-light',
+          'text-color-text hover:text-brand-dark': variant === 'text',
         },
         classes,
       )}

--- a/src/components/navigation/LinkButton.tsx
+++ b/src/components/navigation/LinkButton.tsx
@@ -7,12 +7,8 @@ import Button from '../input/Button';
 import type { ButtonProps } from '../input/Button';
 
 type ComponentProps = {
-  /** @deprecated use `variant` instead */
-  color?: 'brand' | 'text' | 'text-light';
-
   inline?: boolean;
   underline?: 'always' | 'hover' | 'none';
-
   variant?: 'brand' | 'text-light' | 'text' | 'custom';
   unstyled?: boolean;
 };
@@ -30,7 +26,6 @@ export default function LinkButton({
   classes,
   elementRef,
 
-  color,
   inline = false,
   underline = 'none',
   variant = 'brand',
@@ -38,8 +33,6 @@ export default function LinkButton({
 
   ...htmlAttributes
 }: LinkButtonProps) {
-  // Map from deprecated `color` prop to `variant` if `color` is present
-  const theme = typeof color === 'string' ? color : variant;
   const styled = !unstyled;
   const themed = styled && variant !== 'custom';
 
@@ -63,10 +56,10 @@ export default function LinkButton({
         },
         themed && {
           'aria-pressed:font-semibold aria-expanded:font-semibold': true,
-          'text-brand enabled:hover:text-brand-dark': theme === 'brand', // default
-          'text-color-text enabled:hover:text-brand-dark': theme === 'text',
+          'text-brand enabled:hover:text-brand-dark': variant === 'brand', // default
+          'text-color-text enabled:hover:text-brand-dark': variant === 'text',
           'text-color-text-light enabled:hover:text-brand':
-            theme === 'text-light',
+            variant === 'text-light',
         },
 
         classes,

--- a/src/pattern-library/components/patterns/UsingComponentsPage.tsx
+++ b/src/pattern-library/components/patterns/UsingComponentsPage.tsx
@@ -303,19 +303,6 @@ export default function UsingComponentsPage() {
           components have a minimal, component-specific API.
         </p>
       </Library.Section>
-
-      <Library.Section title="Base components">
-        <p>
-          <Library.StatusChip status="deprecated" />
-          Base components are deprecated. Use the styling API on presentational
-          components instead.
-        </p>
-        <p>
-          <strong className="font-semibold">Base components</strong> are are
-          similar to presentational components but allow more styling
-          flexibility.
-        </p>
-      </Library.Section>
     </Library.Page>
   );
 }

--- a/src/pattern-library/components/patterns/input/ButtonPage.tsx
+++ b/src/pattern-library/components/patterns/input/ButtonPage.tsx
@@ -292,27 +292,6 @@ export default function ButtonPage() {
             </Library.Info>
           </Library.Example>
 
-          <Library.Example title="disableTouchSizing">
-            <Library.Info>
-              <Library.InfoItem label="status">
-                <Library.StatusChip status="deprecated" /> Set <code>size</code>{' '}
-                to <code>{`'custom'`}</code> and set sizing classes manually
-                instead.
-              </Library.InfoItem>
-              <Library.InfoItem label="description">
-                Disable minimum sizing on touch devices (
-                <code>pointer: coarse</code>). Buttons will be at least 44px in
-                each dimension on these devices by default.
-              </Library.InfoItem>
-              <Library.InfoItem label="type">
-                <code>boolean</code>
-              </Library.InfoItem>
-              <Library.InfoItem label="default">
-                <code>false</code>
-              </Library.InfoItem>
-            </Library.Info>
-          </Library.Example>
-
           <Library.Example title="...buttonProps">
             <code>IconButton</code> accepts and forwards all props from the{' '}
             <code>Button</code> component API.

--- a/src/pattern-library/components/patterns/input/InputPage.tsx
+++ b/src/pattern-library/components/patterns/input/InputPage.tsx
@@ -102,30 +102,6 @@ export default function InputPage() {
               </div>
             </Library.Demo>
           </Library.Example>
-          <Library.Example title="hasError">
-            <Library.Info>
-              <Library.InfoItem label="description">
-                <Library.StatusChip status="deprecated" />
-                Use <code>{`feedback="error"`}</code> instead.
-              </Library.InfoItem>
-              <Library.InfoItem label="type">
-                <code>{`boolean`}</code>
-              </Library.InfoItem>
-              <Library.InfoItem label="default">
-                <code>{`false`}</code>
-              </Library.InfoItem>
-            </Library.Info>
-
-            <Library.Demo withSource>
-              <div className="w-[350px]">
-                <Input
-                  aria-label="Example input"
-                  hasError
-                  value="something invalid"
-                />
-              </div>
-            </Library.Demo>
-          </Library.Example>
           <Library.Example title="type">
             <Library.Info>
               <Library.InfoItem label="description">

--- a/src/pattern-library/components/patterns/input/OptionButtonPage.tsx
+++ b/src/pattern-library/components/patterns/input/OptionButtonPage.tsx
@@ -110,34 +110,6 @@ export default function OptionButtonPage() {
             </Library.Demo>
           </Library.Example>
 
-          <Library.Example title="rounded">
-            <Library.Info>
-              <Library.InfoItem label="description">
-                <Library.StatusChip status="deprecated" />
-                Whether this button should render rounded corners.
-              </Library.InfoItem>
-              <Library.InfoItem label="type">
-                <code>boolean</code>
-              </Library.InfoItem>
-              <Library.InfoItem label="default">
-                <code>false</code>
-              </Library.InfoItem>
-            </Library.Info>
-
-            <Library.Demo title="Rounded OptionButton" withSource>
-              <div className="w-[250px]">
-                <OptionButton
-                  rounded
-                  details="PDF"
-                  title="Select a PDF from Google Drive"
-                  selected
-                >
-                  Google Drive
-                </OptionButton>
-              </div>
-            </Library.Demo>
-          </Library.Example>
-
           <Library.Example title="...buttonProps">
             <Library.Info>
               <Library.InfoItem label="description">

--- a/src/pattern-library/components/patterns/navigation/LinkPage.tsx
+++ b/src/pattern-library/components/patterns/navigation/LinkPage.tsx
@@ -28,24 +28,6 @@ export default function LinkPage() {
             presentational component props
           </Library.Link>
           .
-          <Library.Example title="color">
-            <Library.Info>
-              <Library.InfoItem label="status">
-                <Library.StatusChip status="deprecated" /> Use{' '}
-                <code>variant</code> prop instead.
-              </Library.InfoItem>
-              <Library.InfoItem label="description">
-                Link <code>color</code> affects the color of link text
-                (including hover color).
-              </Library.InfoItem>
-              <Library.InfoItem label="type">
-                <code>{"'brand' | 'text' | 'text-light'"}</code>
-              </Library.InfoItem>
-              <Library.InfoItem label="default">
-                <code>{"'brand'"}</code>
-              </Library.InfoItem>
-            </Library.Info>
-          </Library.Example>
           <Library.Example title="underline">
             <div className="m-4">
               <Library.Callout>


### PR DESCRIPTION
Closes #1307 

This PR removes the main deprecated props from components that are still kept for next major version.

These props are either no longer used or in the process of being removed from downstream projects.