### PR TITLE
Get back touch-variant classes to IconButton

### DIFF
--- a/src/components/input/IconButton.tsx
+++ b/src/components/input/IconButton.tsx
@@ -67,7 +67,7 @@ export default function IconButton({
             variant === 'dark',
         },
         sized && {
-          'gap-x-2': true,
+          'gap-x-2 touch:min-w-touch-minimum touch:min-h-touch-minimum': true,
           'p-2': size === 'md', // Default
           'p-1': size === 'xs',
           'p-1.5': size === 'sm',


### PR DESCRIPTION
This PR fixes something that was removed by mistake in https://github.com/hypothesis/frontend-shared/pull/1383/files#diff-c806587512a391a65a2657955d066801a5c46580eed7d153bc74540dd37d210aL86-L87

On that PR, The `disableTouchSizing` deprecated prop was removed. As part of this I removed some classes dynamically set based on it, but those classes should have been kept as default instead.