### PR TITLE
Create useToastMessages hook

### DIFF
--- a/src/hooks/test/use-toast-messages-test.js
+++ b/src/hooks/test/use-toast-messages-test.js
@@ -1,0 +1,105 @@
+import { mount } from 'enzyme';
+
+import { useToastMessages } from '../use-toast-messages';
+
+describe('useToastMessages', () => {
+  function FakeToastMessagesContainer({ initialToastMessages }) {
+    const { toastMessages, appendToastMessage, dismissToastMessage } =
+      useToastMessages(initialToastMessages);
+
+    return (
+      <div>
+        {!toastMessages.length && (
+          <span data-testid="no-toast-messages">
+            There are no toast messages
+          </span>
+        )}
+        {toastMessages.map(({ message }, index) => (
+          <span key={`${message}_${index}`} className="toast-message">
+            {message}
+          </span>
+        ))}
+        <button
+          data-testid="append-button"
+          onClick={() =>
+            appendToastMessage({
+              type: 'success',
+              message: 'Toast message',
+            })
+          }
+        >
+          Append
+        </button>
+        <button
+          data-testid="dismiss-button"
+          onClick={() =>
+            toastMessages.length && dismissToastMessage(toastMessages[0].id)
+          }
+        >
+          Dismiss
+        </button>
+      </div>
+    );
+  }
+
+  function createFakeToastMessages(initialToastMessages) {
+    return mount(
+      <FakeToastMessagesContainer
+        initialToastMessages={initialToastMessages}
+      />,
+    );
+  }
+
+  it('defaults to no initial toast messages', () => {
+    const wrapper = createFakeToastMessages();
+
+    assert.isTrue(wrapper.exists('[data-testid="no-toast-messages"]'));
+    assert.isFalse(wrapper.exists('.toast-message'));
+  });
+
+  it('allows to provide initial toast messages', () => {
+    const initialToastMessages = [
+      { message: 'This is a toast message', type: 'success' },
+      { message: 'This is another toast message', type: 'error' },
+    ];
+    const wrapper = createFakeToastMessages(initialToastMessages);
+
+    assert.isFalse(wrapper.exists('[data-testid="no-toast-messages"]'));
+    assert.equal(
+      wrapper.find('.toast-message').length,
+      initialToastMessages.length,
+    );
+  });
+
+  it('can append toast messages', () => {
+    const wrapper = createFakeToastMessages();
+    const appendButton = wrapper.find('[data-testid="append-button"]');
+
+    appendButton.simulate('click');
+    appendButton.simulate('click');
+    appendButton.simulate('click');
+
+    assert.isFalse(wrapper.exists('[data-testid="no-toast-messages"]'));
+    assert.equal(wrapper.find('.toast-message').length, 3);
+  });
+
+  it('can dismiss toast messages', () => {
+    const wrapper = createFakeToastMessages();
+    const appendButton = wrapper.find('[data-testid="append-button"]');
+    const dismissButton = wrapper.find('[data-testid="dismiss-button"]');
+
+    // Append five messages
+    appendButton.simulate('click');
+    appendButton.simulate('click');
+    appendButton.simulate('click');
+    appendButton.simulate('click');
+    appendButton.simulate('click');
+    assert.equal(wrapper.find('.toast-message').length, 5);
+
+    // Dismiss three
+    dismissButton.simulate('click');
+    dismissButton.simulate('click');
+    dismissButton.simulate('click');
+    assert.equal(wrapper.find('.toast-message').length, 2);
+  });
+});

--- a/src/hooks/use-toast-messages.ts
+++ b/src/hooks/use-toast-messages.ts
@@ -4,11 +4,9 @@ import type { ToastMessage } from '../components/feedback';
 
 export type ToastMessageData = Omit<ToastMessage, 'id'>;
 
-export type ToastMessageAppender = (toastMessageData: ToastMessageData) => void;
-
-export type ToastMessages = {
+export type ToastMessagesState = {
   toastMessages: ToastMessage[];
-  appendToastMessage: ToastMessageAppender;
+  appendToastMessage: (toastMessageData: ToastMessageData) => void;
   dismissToastMessage: (id: string) => void;
 };
 
@@ -22,12 +20,11 @@ function dataToToastMessage(toastMessageData: ToastMessageData): ToastMessage {
 }
 
 /**
- * Hook providing a simple way to handle state for <ToastMessages />
- * {@link ToastMessages}
+ * Hook providing a simple way to handle state for {@link ToastMessages}
  */
 export function useToastMessages(
   initialToastMessages: ToastMessageData[] = [],
-): ToastMessages {
+): ToastMessagesState {
   const [toastMessages, setToastMessages] = useState<ToastMessage[]>(
     initialToastMessages.map(dataToToastMessage),
   );

--- a/src/hooks/use-toast-messages.ts
+++ b/src/hooks/use-toast-messages.ts
@@ -1,0 +1,52 @@
+import { useCallback, useState } from 'preact/hooks';
+
+import type { ToastMessage } from '../components/feedback';
+
+export type ToastMessageData = Omit<ToastMessage, 'id'>;
+
+export type ToastMessageAppender = (toastMessageData: ToastMessageData) => void;
+
+export type ToastMessages = {
+  toastMessages: ToastMessage[];
+  appendToastMessage: ToastMessageAppender;
+  dismissToastMessage: (id: string) => void;
+};
+
+// Keep a global incremental counter to use as unique toast message ID
+let toastMessageCounter = 0;
+
+function dataToToastMessage(toastMessageData: ToastMessageData): ToastMessage {
+  toastMessageCounter++;
+  const id = `${toastMessageCounter}`;
+  return { ...toastMessageData, id };
+}
+
+/**
+ * Hook providing a simple way to handle state for <ToastMessages />
+ * {@link ToastMessages}
+ */
+export function useToastMessages(
+  initialToastMessages: ToastMessageData[] = [],
+): ToastMessages {
+  const [toastMessages, setToastMessages] = useState<ToastMessage[]>(
+    initialToastMessages.map(dataToToastMessage),
+  );
+  const appendToastMessage = useCallback(
+    (toastMessageData: ToastMessageData) => {
+      setToastMessages(messages => [
+        ...messages,
+        dataToToastMessage(toastMessageData),
+      ]);
+    },
+    [],
+  );
+  const dismissToastMessage = useCallback(
+    (id: string) =>
+      setToastMessages(messages =>
+        messages.filter(message => message.id !== id),
+      ),
+    [],
+  );
+
+  return { toastMessages, appendToastMessage, dismissToastMessage };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,10 @@ export { useKeyPress } from './hooks/use-key-press';
 export { useStableCallback } from './hooks/use-stable-callback';
 export { useSyncedRef } from './hooks/use-synced-ref';
 export { useToastMessages } from './hooks/use-toast-messages';
+export type {
+  ToastMessagesState,
+  ToastMessageData,
+} from './hooks/use-toast-messages';
 
 // Utils
 export { confirm } from './util/prompts';

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ export { useFocusAway } from './hooks/use-focus-away';
 export { useKeyPress } from './hooks/use-key-press';
 export { useStableCallback } from './hooks/use-stable-callback';
 export { useSyncedRef } from './hooks/use-synced-ref';
+export { useToastMessages } from './hooks/use-toast-messages';
 
 // Utils
 export { confirm } from './util/prompts';


### PR DESCRIPTION
This PR provides a convenient `useToastMessages` hook that can handle the state for `<ToastMessages />` component.

Currently both via and lms define very similar hooks, so this is a way to extract the logic from them.

Client has more complex needs, and handles toast messages through a shared redux store, but for simple use cases, it comes handy.