### PR TITLE
Do not set height classes in ModalDialog when size is 'custom'

### DIFF
--- a/src/components/feedback/ModalDialog.tsx
+++ b/src/components/feedback/ModalDialog.tsx
@@ -86,14 +86,14 @@ export default function ModalDialog({
         classes={classnames(
           // Column-flex layout to constrain content to max-height
           'flex flex-col',
-          'max-w-[90vw] max-h-[90vh]',
+          size !== 'custom' && 'max-w-[90vw] max-h-[90vh]',
           // Overlay sets up a flex layout centered on both axes. For taller
           // viewports, remove this modal container from the flex flow with
           // fixed positioning and position it 10vh from the top of the
           // viewport. This feels more balanced on taller screens. Ensure an
           // equal 10vh gap at the bottom of the screen by adjusting max-height
           // to `80vh`.
-          'tall:fixed tall:max-h-[80vh] tall:top-[10vh]',
+          size !== 'custom' && 'tall:fixed tall:max-h-[80vh] tall:top-[10vh]',
           {
             // Max-width rules will ensure actual width never exceeds 90vw
             'w-[30rem]': size === 'sm',

--- a/src/pattern-library/components/patterns/feedback/DialogPage.tsx
+++ b/src/pattern-library/components/patterns/feedback/DialogPage.tsx
@@ -836,10 +836,13 @@ export default function DialogPage() {
             <Library.Info>
               <Library.InfoItem label="description">
                 Set the relative width of the modal element. Set to {`'custom'`}{' '}
-                to customize width via <code>classes</code>.
+                to customize dimensions via <code>classes</code>.
+                <br />
+                Note that setting {`'custom'`} value will disable both
+                horizontal and vertical automatic sizing.
               </Library.InfoItem>
               <Library.InfoItem label="type">
-                <code>{`'sm' | 'md' | 'lg' | 'custom'`}]</code>
+                <code>{`'sm' | 'md' | 'lg' | 'custom'`}</code>
               </Library.InfoItem>
               <Library.InfoItem label="default">
                 <code>{`'md'`}</code>
@@ -860,7 +863,7 @@ export default function DialogPage() {
               <ModalDialog_
                 buttons={<DialogButtons />}
                 onClose={() => {}}
-                title="Medium-width modal"
+                title="Medium-size modal"
                 size="md"
               >
                 <LoremIpsum size="md" />
@@ -881,9 +884,9 @@ export default function DialogPage() {
             <Library.Demo title="size='custom'" withSource>
               <ModalDialog_
                 buttons={<DialogButtons />}
-                classes="w-[40em]"
+                classes="w-[40em] h-[80vh] top-[10vh]"
                 onClose={() => {}}
-                title="Custom-width modal"
+                title="Custom-size modal"
                 size="custom"
               >
                 <LoremIpsum size="md" />


### PR DESCRIPTION
Part of https://github.com/hypothesis/client/issues/6151 and https://github.com/hypothesis/client/issues/6158

Depends on https://github.com/hypothesis/frontend-shared/pull/1442

All `ModalDialog` instances have currently these hardcoded classes:

* `max-w-[90vw] max-h-[90vh]` -> Ensure they don't span more than 90% of the viewport's width and height.
* `tall:fixed tall:max-h-[80vh] tall:top-[10vh]` -> When the screen is tall (`(min-height: 32rem)`), ensure a fixed position of the modal.

This usually makes sense, as these play nicely with the regular sizes. However, when providing `custom` size, the classes which affect vertical size and positioning can get in the way and force you to override them with other classes including the important modifier (`!`).

This PR changes that behavior to make those classes be skipped when `size` is `custom`, so that consumer code has more control over how it behaves.

This is technically speaking a breaking change, but we are currently not using custom size modals in downstream projects.

The main motivation for this change is being able to use `ModalDialog` for the client's notebook, and benefit from its accessibility afordances.