### PR TITLE
Create `useFocusTrap` hook

### DIFF
--- a/src/components/feedback/ModalDialog.tsx
+++ b/src/components/feedback/ModalDialog.tsx
@@ -1,5 +1,6 @@
 import classnames from 'classnames';
 
+import { useFocusTrap } from '../../hooks/use-focus-trap';
 import { useSyncedRef } from '../../hooks/use-synced-ref';
 import { useTabKeyNavigation } from '../../hooks/use-tab-key-navigation';
 import { downcastRef } from '../../util/typing';
@@ -69,7 +70,8 @@ export default function ModalDialog({
 }: ModalDialogProps) {
   const modalRef = useSyncedRef(elementRef);
 
-  useTabKeyNavigation(modalRef, { enabled: !disableFocusTrap });
+  // useTabKeyNavigation(modalRef, { enabled: !disableFocusTrap });
+  useFocusTrap(modalRef, { enabled: !disableFocusTrap });
 
   return (
     <Overlay data-composite-component="ModalDialog">

--- a/src/hooks/use-focus-trap.ts
+++ b/src/hooks/use-focus-trap.ts
@@ -1,0 +1,46 @@
+import type { RefObject } from 'preact';
+import { useLayoutEffect } from 'preact/hooks';
+
+import { defaultSelector } from './use-tab-key-navigation';
+
+export type UseFocusTrapOptions = {
+  enabled?: boolean;
+  focusableElementsSelector?: string;
+};
+
+export function useFocusTrap(
+  containerRef: RefObject<HTMLElement | undefined>,
+  {
+    enabled = true,
+    focusableElementsSelector = defaultSelector,
+  }: UseFocusTrapOptions,
+) {
+  useLayoutEffect(() => {
+    const container = containerRef.current;
+    if (!enabled || !container) {
+      return () => {};
+    }
+
+    const listener = (e: FocusEvent) => {
+      // When trying to focus an element outside the container, prevent it and
+      // move focus back to the first focusable element in the container
+      if (!e.composedPath().includes(container)) {
+        e.preventDefault();
+        const firstFocusableElement = container.querySelector(
+          focusableElementsSelector,
+        ) as HTMLElement | null;
+        firstFocusableElement?.focus();
+
+        // TODO
+        //  - Prevent scrolling to element that is going to be focused
+        //  - Allow Shift+Tab infinite loop sequence inside the modal
+        //  - Focus modal itself if no focusable elements are found on it
+      }
+    };
+
+    document.body.addEventListener('focusin', listener, { capture: true });
+    return () => {
+      document.body.removeEventListener('focusin', listener, { capture: true });
+    };
+  }, [enabled, containerRef, focusableElementsSelector]);
+}

--- a/src/hooks/use-tab-key-navigation.ts
+++ b/src/hooks/use-tab-key-navigation.ts
@@ -61,7 +61,7 @@ export type UseTabKeyNavigationOptions = {
 // inputs). Also include the containers for ARIA interactive widgets `grid` and
 // `tablist`. Internal keyboard navigation for those widgets should be handled
 // separately: exclude `tab`-role buttons from this hook's navigation sequence.
-const defaultSelector =
+export const defaultSelector =
   'a,button:not([role="tab"]),input,select,textarea,[role="grid"],[role="tablist"]';
 
 export function useTabKeyNavigation(

--- a/src/pattern-library/components/patterns/feedback/DialogPage.tsx
+++ b/src/pattern-library/components/patterns/feedback/DialogPage.tsx
@@ -760,6 +760,17 @@ export default function DialogPage() {
               </CustomModalDialog_>
             </Library.Demo>
           </Library.Example>
+          <Library.Example title="Focus trap with iframe">
+            <Library.Demo title="Modal dialog with iframe" withSource>
+              <ModalDialog_ title="Modal dialog with iframe">
+                <iframe
+                  title="Example"
+                  src="https://example.com"
+                  className="border-0 w-full h-64"
+                />
+              </ModalDialog_>
+            </Library.Demo>
+          </Library.Example>
         </Library.Pattern>
         <Library.Pattern title="ComponentAPI">
           <Library.Example title="title">


### PR DESCRIPTION
### Problem to solve

During the work in https://github.com/hypothesis/client/pull/6162 it was proved that current logic to mimic focus trap in modals does not work if the modal contains an iframe.

Current logic is based on `useTabKeyNavigation`, which takes control over the native tab sequence by capturing `keydown` on the modal and checking if <kbd>Tab</kbd> or <kbd>Shift</kbd>+<kbd>Tab</kbd> are pressed, and based on that, queries focusable elements and programmatically moves the focus to the next or previous one.

Since modals render an overlay, focusing something outside the modal itself is usually not possible by using the mouse, and the keyboard navigation is "kidnapped" by the logic explained above. 

However, when the modal renders an iframe and we include it in the programmatically handled tab sequence, we can end up focusing elements inside of it, escaping the focus trap logic, and eventually focusing elements outside the modal.

### Proposed solution

This PR introduces a new `useFocusTrap` hook, which implements a different approach intended to work even when an iframe is rendered in the modal.

The hook listenes for `focusin` events in the body, and if the element to be focused is outside the modal, we prevent it and move focus back to the modal.

If the modal contains an iframe, this allows it to be focused, which incidentally "escapes" our `focusin` listener, but as soon as the native tab sequence returns to the main document, the listener kicks-in recovering focus.

You can see here how it roughly works at the moment:

[Grabación de pantalla desde 2024-02-05 10-34-27.webm](https://github.com/hypothesis/frontend-shared/assets/2719332/b812a9f0-3b12-46c9-9689-320f42f64fc6)

### TBD

- [ ] Add tests
- [ ] Prevent scrolling to the element that was going to be focused. ~It seems that `e.prevendDefault()`, prevents the actual focusing,~ Focus events cannot be stopped, causing target element to be scrolled into the viewport anyway, which feels weird.
- [ ] Allow <kbd>Shift</kbd>+<kbd>Tab</kbd> infinite loop sequence inside the modal. Current logic focuses first focusable element in the modal, when trying to focus out, causing <kbd>Shift</kbd>+<kbd>Tab</kbd> when the first element is focused, to return focus to it instead of focusing the "last" focusable element inside the modal.
- [ ] When recovering focus, focus modal itself if no focusable elements are found on it.