### PR TITLE
Mark inputs as invalid if `feedback="error"`

### DIFF
--- a/src/components/input/Input.tsx
+++ b/src/components/input/Input.tsx
@@ -1,6 +1,8 @@
 import classnames from 'classnames';
-import type { JSX } from 'preact';
+import type { JSX, RefObject } from 'preact';
+import { useEffect } from 'preact/hooks';
 
+import { useSyncedRef } from '../../hooks/use-synced-ref';
 import type { PresentationalProps } from '../../types';
 import { downcastRef } from '../../util/typing';
 import { inputGroupStyles } from './InputGroup';
@@ -46,6 +48,17 @@ export default function Input({
 
   ...htmlAttributes
 }: InputProps) {
+  const inputRef = useSyncedRef(elementRef) as RefObject<
+    HTMLInputElement | undefined
+  >;
+
+  useEffect(() => {
+    const input = inputRef.current;
+    if (typeof input?.setCustomValidity === 'function') {
+      input.setCustomValidity(feedback === 'error' ? 'Invalid' : '');
+    }
+  }, [feedback, inputRef]);
+
   if (!htmlAttributes.id && !htmlAttributes['aria-label']) {
     console.warn(
       '`Input` component should have either an `id` or an `aria-label` attribute',
@@ -56,7 +69,7 @@ export default function Input({
     <input
       data-component="Input"
       {...htmlAttributes}
-      ref={downcastRef(elementRef)}
+      ref={downcastRef(inputRef)}
       type={type}
       className={inputStyles({ classes, feedback })}
     />


### PR DESCRIPTION
Part of https://github.com/hypothesis/lms/issues/6012

This PR updates the `Input` component so that it is accessibly marked as invalid when `feedback` prop is provided with `"error"` value.

This requires [HTMLObjectElement.setCustomValidity()](https://developer.mozilla.org/en-US/docs/Web/API/HTMLObjectElement/setCustomValidity) to be supported by the browser. Since not all browsers we support do it yet, the logic also checks the method is available, and behaves as before otherwise.

### Testing steps

1. Go to http://localhost:4001/input-input
2. Run a screen reader
3. Scroll to the part where the `feedback` prop is documented.
4. Focus the input which has `feedback="error"` -> The screen reader should announce it as "invalid input".