### PR TITLE
Set aria-invalid=true on Input and Textarea with error feedback

### DIFF
--- a/src/components/input/Input.tsx
+++ b/src/components/input/Input.tsx
@@ -59,6 +59,7 @@ export default function Input({
       ref={downcastRef(elementRef)}
       type={type}
       className={inputStyles({ classes, feedback })}
+      aria-invalid={feedback === 'error'}
     />
   );
 }

--- a/src/components/input/Textarea.tsx
+++ b/src/components/input/Textarea.tsx
@@ -34,6 +34,7 @@ export default function Textarea({
       {...htmlAttributes}
       ref={downcastRef(elementRef)}
       className={inputStyles({ classes, feedback })}
+      aria-invalid={feedback === 'error'}
     />
   );
 }

--- a/src/components/input/test/Input-test.js
+++ b/src/components/input/test/Input-test.js
@@ -22,4 +22,19 @@ describe('Input', () => {
 
     console.warn.restore();
   });
+
+  [
+    { feedback: undefined, expectedInvalid: false },
+    { feedback: 'error', expectedInvalid: true },
+    { feedback: 'warning', expectedInvalid: false },
+  ].forEach(({ feedback, expectedInvalid }) => {
+    it('sets aria-invalid based on feedback prop', () => {
+      const wrapper = mount(
+        <Input aria-label="Test input" feedback={feedback} />,
+      );
+      const input = wrapper.find('input');
+
+      assert.equal(input.prop('aria-invalid'), expectedInvalid);
+    });
+  });
 });

--- a/src/components/input/test/Textarea-test.js
+++ b/src/components/input/test/Textarea-test.js
@@ -22,4 +22,19 @@ describe('Textarea', () => {
 
     console.warn.restore();
   });
+
+  [
+    { feedback: undefined, expectedInvalid: false },
+    { feedback: 'error', expectedInvalid: true },
+    { feedback: 'warning', expectedInvalid: false },
+  ].forEach(({ feedback, expectedInvalid }) => {
+    it('sets aria-invalid based on feedback prop', () => {
+      const wrapper = mount(
+        <Textarea aria-label="Test textarea" feedback={feedback} />,
+      );
+      const textarea = wrapper.find('textarea');
+
+      assert.equal(textarea.prop('aria-invalid'), expectedInvalid);
+    });
+  });
 });

--- a/src/pattern-library/components/patterns/input/InputPage.tsx
+++ b/src/pattern-library/components/patterns/input/InputPage.tsx
@@ -74,6 +74,16 @@ export default function InputPage() {
               <Library.InfoItem label="description">
                 Set <code>feedback</code> to indicate that there is an
                 associated error or warning for the <code>Input</code>.
+                <br />
+                Notice that setting{' '}
+                <code>
+                  feedback={'"'}error{'"'}
+                </code>{' '}
+                will implicitly set{' '}
+                <code>
+                  aria-invalid={'"'}true{'"'}
+                </code>
+                .
               </Library.InfoItem>
               <Library.InfoItem label="type">
                 <code>

--- a/src/pattern-library/components/patterns/input/TextareaPage.tsx
+++ b/src/pattern-library/components/patterns/input/TextareaPage.tsx
@@ -77,6 +77,16 @@ export default function TextareaPage() {
               <Library.InfoItem label="description">
                 Set <code>feedback</code> to indicate that there is an
                 associated error or warning for the <code>Textarea</code>.
+                <br />
+                Notice that setting{' '}
+                <code>
+                  feedback={'"'}error{'"'}
+                </code>{' '}
+                will implicitly set{' '}
+                <code>
+                  aria-invalid={'"'}true{'"'}
+                </code>
+                .
               </Library.InfoItem>
               <Library.InfoItem label="type">
                 <code>


### PR DESCRIPTION
Part of https://github.com/hypothesis/lms/issues/6012

This PR updates the `Input` and `Textarea` components so that they set the `aria-invalid` attribute with value `true` when `feedback="error"` is provided.

With this attribute, screen readers report the input as invalid when focused.

Downstream projects can then decide if they want to provide a custom error message via [aria-errormessage](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-errormessage).