### PR TITLE
Do not render prefix for visually hidden toast messages

### DIFF
--- a/src/components/feedback/ToastMessages.tsx
+++ b/src/components/feedback/ToastMessages.tsx
@@ -52,9 +52,9 @@ type ToastMessageItemProps = {
  */
 function ToastMessageItem({ message, onDismiss }: ToastMessageItemProps) {
   // Capitalize the message type for prepending; Don't prepend a message
-  // type for "notice" messages
+  // type for "notice" or hidden messages
   const prefix =
-    message.type !== 'notice'
+    message.type !== 'notice' && !message.visuallyHidden
       ? `${message.type.charAt(0).toUpperCase() + message.type.slice(1)}: `
       : '';
 

--- a/src/components/feedback/test/ToastMessages-test.js
+++ b/src/components/feedback/test/ToastMessages-test.js
@@ -165,4 +165,22 @@ describe('ToastMessages', () => {
 
     assert.notCalled(fakeOnMessageDismiss);
   });
+
+  it('adds the appropriate prefix to every message', () => {
+    const wrapper = createToastMessages([
+      ...toastMessages,
+      {
+        id: '4',
+        type: 'success',
+        message: 'Hello world',
+        visuallyHidden: true,
+      },
+    ]);
+    const callouts = wrapper.find('Callout');
+
+    assert.equal(callouts.at(0).text(), 'Success: Hello world');
+    assert.equal(callouts.at(1).text(), 'Foobar');
+    assert.equal(callouts.at(2).text(), 'Error: Something failed');
+    assert.equal(callouts.at(3).text(), 'Hello world');
+  });
 });


### PR DESCRIPTION
Historically, all `success` and `error` toast messages have been rendered with the **Success** or **Error** prefixes. However, this doesn't usually make sense for hidden toast messages, as the message itself is usually composed taking into consideration that it is going to be announced by a screen reader, and therefore it should be as specific as possible.

This PR removes prefixes for any message when it has `visuallyHidden: true`.