### PR TITLE
Remove prefixes from toast messages

### DIFF
--- a/src/components/feedback/ToastMessages.tsx
+++ b/src/components/feedback/ToastMessages.tsx
@@ -51,13 +51,6 @@ type ToastMessageItemProps = {
  * messages will not be visible but are still available to screen readers.
  */
 function ToastMessageItem({ message, onDismiss }: ToastMessageItemProps) {
-  // Capitalize the message type for prepending; Don't prepend a message
-  // type for "notice" messages
-  const prefix =
-    message.type !== 'notice'
-      ? `${message.type.charAt(0).toUpperCase() + message.type.slice(1)}: `
-      : '';
-
   return (
     <Callout
       classes={classnames({
@@ -67,7 +60,6 @@ function ToastMessageItem({ message, onDismiss }: ToastMessageItemProps) {
       onClick={() => onDismiss(message.id)}
       variant="raised"
     >
-      <strong>{prefix}</strong>
       {message.message}
     </Callout>
   );


### PR DESCRIPTION
This PR removes the `Success` and `Error` prefixes from toast messages of those types, as it feels redundant.

Instead, messages should me concise and specific, so that it is clear what they are announcing.

Before:

![image](https://github.com/hypothesis/frontend-shared/assets/2719332/b47057a5-9af8-4a53-a473-36fba28c75d5)

After:

![image](https://github.com/hypothesis/frontend-shared/assets/2719332/80692eb8-65e9-4c9c-a7b6-71fef4c9b8bf)
