### PR TITLE
New dialog poc

### DIFF
--- a/src/components/feedback/DialogNext.tsx
+++ b/src/components/feedback/DialogNext.tsx
@@ -7,11 +7,26 @@ import type { PresentationalProps } from '../../types';
 import type { CloseableInfo } from '../CloseableContext';
 import CloseableContext from '../CloseableContext';
 
+export type ModalSize = 'sm' | 'md' | 'lg';
+
 type ComponentProps = {
   open?: boolean;
   onClose?: () => void;
   closeTitle?: string;
-  modal?: boolean;
+
+  /**
+   * Determines if this dialog should be opened as a modal, ensuring proper
+   * focus trap.
+   * The modal size can be optionally provided too, otherwise it will adjust its
+   * contents.
+   * Defaults to `false`.
+   *
+   * <Dialog modal /> -> A modal dialog with automatic sizing.
+   * <Dialog modal="sm" /> -> A small-size modal dialog.
+   * <Dialog modal="md" /> -> A medium-size modal dialog.
+   * <Dialog modal="lg" /> -> A large-size modal dialog.
+   */
+  modal?: boolean | ModalSize;
 };
 
 export type DialogNextProps = PresentationalProps &
@@ -36,6 +51,7 @@ export default function DialogNext({
   children,
   ...htmlAttributes
 }: DialogNextProps) {
+  const size = typeof modal === 'boolean' ? 'custom' : modal;
   const dialogRef = useSyncedRef(elementRef) as RefObject<HTMLDialogElement>;
   const closeDialog = useCallback(
     () => dialogRef.current?.close(),
@@ -77,11 +93,20 @@ export default function DialogNext({
       <dialog
         data-component="DialogNext"
         {...htmlAttributes}
-        className={classnames(classes, {
-          'backdrop:bg-black/50': modal,
-          static: !modal,
-        })}
         ref={dialogRef}
+        className={classnames(classes, {
+          // We want to render non-modal dialogs inline. By default they are
+          // absolute-positioned
+          static: !modal,
+
+          'backdrop:bg-black/50': modal,
+
+          // Max-width rules will ensure actual width never exceeds 90vw
+          'w-[30rem]': size === 'sm',
+          'w-[36rem]': size === 'md',
+          'w-[42rem]': size === 'lg',
+          // No width classes are added if `size` is 'custom'
+        })}
       >
         {children}
       </dialog>

--- a/src/components/feedback/DialogNext.tsx
+++ b/src/components/feedback/DialogNext.tsx
@@ -1,0 +1,90 @@
+import classnames from 'classnames';
+import type { JSX, RefObject } from 'preact';
+import { useCallback, useEffect } from 'preact/hooks';
+
+import { useSyncedRef } from '../../hooks/use-synced-ref';
+import type { PresentationalProps } from '../../types';
+import type { CloseableInfo } from '../CloseableContext';
+import CloseableContext from '../CloseableContext';
+
+type ComponentProps = {
+  open?: boolean;
+  onClose?: () => void;
+  closeTitle?: string;
+  modal?: boolean;
+};
+
+export type DialogNextProps = PresentationalProps &
+  ComponentProps &
+  JSX.HTMLAttributes<HTMLDialogElement>;
+
+export default function DialogNext({
+  open = false,
+  onClose,
+  closeTitle,
+  modal = false,
+
+  // TODO
+  //   closeOnClickAway,
+  //   closeOnFocusAway,
+  //   initialFocus,
+  //   restoreFocus,
+  //   transitionComponent,
+
+  classes,
+  elementRef,
+  children,
+  ...htmlAttributes
+}: DialogNextProps) {
+  const dialogRef = useSyncedRef(elementRef) as RefObject<HTMLDialogElement>;
+  const closeDialog = useCallback(
+    () => dialogRef.current?.close(),
+    [dialogRef],
+  );
+  const openDialog = useCallback(() => {
+    if (modal) {
+      dialogRef.current?.showModal();
+    } else {
+      dialogRef.current?.show();
+    }
+  }, [dialogRef, modal]);
+
+  useEffect(() => {
+    if (open) {
+      openDialog();
+    } else {
+      closeDialog();
+    }
+  }, [open, closeDialog, openDialog]);
+
+  useEffect(() => {
+    const dialogElement = dialogRef.current;
+    const handler = () => onClose?.();
+
+    dialogElement?.addEventListener('close', handler);
+    return () => {
+      dialogElement?.removeEventListener('close', handler);
+    };
+  }, [onClose, dialogRef]);
+
+  const closeableContext: CloseableInfo = {
+    onClose: onClose ? closeDialog : undefined,
+    title: closeTitle,
+  };
+
+  return (
+    <CloseableContext.Provider value={closeableContext}>
+      <dialog
+        data-component="DialogNext"
+        {...htmlAttributes}
+        className={classnames(classes, {
+          'backdrop:bg-black/50': modal,
+          static: !modal,
+        })}
+        ref={dialogRef}
+      >
+        {children}
+      </dialog>
+    </CloseableContext.Provider>
+  );
+}

--- a/src/pattern-library/components/patterns/prototype/DialogNextPage.tsx
+++ b/src/pattern-library/components/patterns/prototype/DialogNextPage.tsx
@@ -1,0 +1,53 @@
+import { useState } from 'preact/hooks';
+
+import { Button, CloseButton } from '../../../../';
+import DialogNext from '../../../../components/feedback/DialogNext';
+import Library from '../../Library';
+import { LoremIpsum } from '../samples';
+
+function DialogNext_({ modal }: { modal?: boolean }) {
+  const [dialogOpen, setDialogOpen] = useState(false);
+
+  return (
+    <>
+      <Button onClick={() => setDialogOpen(prev => !prev)} variant="primary">
+        {dialogOpen ? 'Hide' : 'Show'} dialog
+      </Button>
+      <DialogNext
+        modal={modal}
+        open={dialogOpen}
+        onClose={() => setDialogOpen(false)}
+      >
+        {modal && <CloseButton />}
+        This is a {modal ? 'modal' : ''} native dialog
+        <LoremIpsum />
+      </DialogNext>
+    </>
+  );
+}
+
+export default function DialogNextPage() {
+  return (
+    <Library.Page
+      title="Dialogs"
+      intro={
+        <p>
+          <code>DialogNext</code> provides functionality to use a {"browser's"}{' '}
+          <code>dialog</code> element,.
+        </p>
+      }
+    >
+      <Library.Section id="dialog-next" title="DialogNext">
+        <Library.Pattern>
+          <Library.Usage componentName="DialogNext" />
+          <Library.Demo title="Basic DialogNext">
+            <DialogNext_ />
+          </Library.Demo>
+          <Library.Demo title="Modal DialogNext">
+            <DialogNext_ modal />
+          </Library.Demo>
+        </Library.Pattern>
+      </Library.Section>
+    </Library.Page>
+  );
+}

--- a/src/pattern-library/components/patterns/prototype/DialogNextPage.tsx
+++ b/src/pattern-library/components/patterns/prototype/DialogNextPage.tsx
@@ -2,10 +2,17 @@ import { useState } from 'preact/hooks';
 
 import { Button, CloseButton } from '../../../../';
 import DialogNext from '../../../../components/feedback/DialogNext';
+import type { ModalSize } from '../../../../components/feedback/DialogNext';
 import Library from '../../Library';
 import { LoremIpsum } from '../samples';
 
-function DialogNext_({ modal }: { modal?: boolean }) {
+function DialogNext_({
+  modal,
+  skipLorem = false,
+}: {
+  modal?: boolean | ModalSize;
+  skipLorem?: boolean;
+}) {
   const [dialogOpen, setDialogOpen] = useState(false);
 
   return (
@@ -20,7 +27,7 @@ function DialogNext_({ modal }: { modal?: boolean }) {
       >
         {modal && <CloseButton />}
         This is a {modal ? 'modal' : ''} native dialog
-        <LoremIpsum />
+        {!skipLorem && <LoremIpsum />}
       </DialogNext>
     </>
   );
@@ -43,8 +50,20 @@ export default function DialogNextPage() {
           <Library.Demo title="Basic DialogNext">
             <DialogNext_ />
           </Library.Demo>
-          <Library.Demo title="Modal DialogNext">
+          <Library.Demo title="Auto-size modal DialogNext">
             <DialogNext_ modal />
+          </Library.Demo>
+          <Library.Demo title="Large-size modal DialogNext">
+            <DialogNext_ modal="lg" />
+          </Library.Demo>
+          <Library.Demo title="Medium-size modal DialogNext">
+            <DialogNext_ modal="md" />
+          </Library.Demo>
+          <Library.Demo title="Small-size modal DialogNext">
+            <DialogNext_ modal="sm" />
+          </Library.Demo>
+          <Library.Demo title="Small-size modal DialogNext with little content">
+            <DialogNext_ modal="sm" skipLorem />
           </Library.Demo>
         </Library.Pattern>
       </Library.Section>

--- a/src/pattern-library/routes.ts
+++ b/src/pattern-library/routes.ts
@@ -30,6 +30,7 @@ import LinkButtonPage from './components/patterns/navigation/LinkButtonPage';
 import LinkPage from './components/patterns/navigation/LinkPage';
 import PointerButtonPage from './components/patterns/navigation/PointerButtonPage';
 import TabPage from './components/patterns/navigation/TabPage';
+import DialogNextPage from './components/patterns/prototype/DialogNextPage';
 import LMSContentButtonPage from './components/patterns/prototype/LMSContentButtonPage';
 import LMSContentSelectionPage from './components/patterns/prototype/LMSContentSelectionPage';
 import SelectNextPage from './components/patterns/prototype/SelectNextPage';
@@ -285,6 +286,12 @@ const routes: PlaygroundRoute[] = [
     group: 'prototype',
     component: LMSContentSelectionPage,
     route: '/lms-content-selection',
+  },
+  {
+    title: 'Native Dialog',
+    group: 'prototype',
+    component: DialogNextPage,
+    route: '/dialog-next',
   },
 ];
 


### PR DESCRIPTION
Part of https://github.com/hypothesis/frontend-shared/issues/1461

This PR is a proof of concept of what could be a new component to render native `dialog` elements.

It covers the basic functionality, with an `open` prop that triggers the `dialog.show()` side effect when true, or `dialog.close()` when false.

It also takes into consideration how regular dialogs and modal dialogs should be displayed.

Finally, it does not make assumptions about how children should be rendered, rendering what's provided verbatim.

For cases where we want to render the dialog as a panel/card, we can consider adding a new component that wraps children in a panel and then nests that into the new dialog.

### Open questions

* I reused the `modal` prop for modal sizes, because it was convenient, and the resulting API seems intuitive: `modal` for an auto-size modal dialog, and `modal="lg"` for a large-size modal dialog.
  Should we have a `size` prop that can be used with non-modal dialogs as well? Should we have a separate `ModalDialog` that handles sizes?
* Should we have a fallback for browsers not supporting `dialog` elements? Perhaps we could define a component wrapping the new dialog and the old one and orchestrating which one to render based on browser support.
* Should we drop support for the `closeOnFocusAway` prop? It is false by default and is not being redefined in any downstream project.
  Also, you cannot focus away when opening the native dialog as modal, and when it is not a modal you will likely want to keep it open.
* Should we drop support for `closeOnEscape`? It is true by default for modal dialogs and false for regular dialogs.
  Native dialogs implement this natively when opened as modal, which matches that behavior.
  There's only one use case in which we are currently using a non-modal dialog which can be closed with `Esc`, which is the grade comment popover. In this case we are using the dialog because it's convenient, but it is actually implementing the popover pattern, which is different.
* Should we drop support for `closeOnClickAway`? It's false by default and like in previous point, we are redefining this behavior only for the grade comment popover.

### TODO

* [ ] Decide if we want to support `closeOnClickAway`, and implement it if so
* [ ] Decide if we want to support `closeOnFocusAway`, and implement it if so
* [ ] Decide if we want to support `closeOnEscape`, and implement it if so
* [ ] Implement `initialFocus`
* [ ] Implement `restoreFocus`
* [ ] Implement `transitionComponent`
* [ ] Test the component with real use cases in downstream projects