### PR TITLE
Allow ordering DataTables by clicking a header

### DIFF
--- a/src/components/data/TableCell.tsx
+++ b/src/components/data/TableCell.tsx
@@ -8,7 +8,10 @@ import TableContext from './TableContext';
 import TableSectionContext from './TableSectionContext';
 
 export type TableCellProps = PresentationalProps &
-  Omit<JSX.HTMLAttributes<HTMLElement>, 'size'>;
+  Omit<JSX.HTMLAttributes<HTMLElement>, 'size'> & {
+    /** Remove default padding, allowing consuming code to control it */
+    unpadded?: boolean;
+  };
 
 /**
  * Render a single table cell
@@ -17,6 +20,7 @@ export default function TableCell({
   children,
   classes,
   elementRef,
+  unpadded = false,
 
   ...htmlAttributes
 }: TableCellProps) {
@@ -31,8 +35,8 @@ export default function TableCell({
       {...htmlAttributes}
       ref={downcastRef(elementRef)}
       className={classnames(
-        'p-3',
         {
+          'p-3': !unpadded,
           // Set horizontal borders here for table headers. This needs to be
           // done here (versus on the row or table) to prevent a 1-pixel wiggle
           // on scroll with sticky headers.

--- a/src/pattern-library/components/patterns/feedback/DialogPage.tsx
+++ b/src/pattern-library/components/patterns/feedback/DialogPage.tsx
@@ -29,9 +29,9 @@ import type { NabokovNovel } from '../samples';
 
 const nabokovRows = nabokovNovels();
 const nabokovColumns = [
-  { field: 'title', label: 'Title' },
-  { field: 'year', label: 'Year' },
-  { field: 'language', label: 'Language' },
+  { field: 'title' as const, label: 'Title' },
+  { field: 'year' as const, label: 'Year' },
+  { field: 'language' as const, label: 'Language' },
 ];
 
 function DialogButtons() {


### PR DESCRIPTION
Add new `order` and `onOrderChange` optional props to `DataTable`, that can be used to handle which column is being used to order the rows and display a visual hint.

The type of `order` is `null | { field: Field; direction: 'ascending' | 'descending' }`, where `Field` represents any key of the generic `Row` type from the table.

The value `null` is also the default, and represents that no ordering is being applied.

Every time a column is clicked, if `onOrderChange` was provided, it tries to determine what's the new ordering following this logic.

* When the same column is clicked it transitions from `null`->`{ field: 'the_column', direction: 'ascending' }`->`{ field: 'the_column', direction: 'descending' }`->`null`->...
* When a different column is clicked, it resets whatever ordering is active into `{ field: 'the_new_column', direction: 'ascending' }`

Once determined, `onOrderChange` is invoked with the new value.

### Examples

This PR includes examples in the docs where ordering the rows happens client-side and server-side. This is possible thanks to the fact that both props are controlled by the consumer component.

https://github.com/hypothesis/frontend-shared/assets/2719332/58e955aa-4461-4f8b-bfb4-cea1aaf7b46e

https://github.com/hypothesis/frontend-shared/assets/2719332/2eddace6-517f-4447-b236-192390e58b9a

### A11y

Accessibility is implemented as described in https://www.w3.org/WAI/ARIA/apg/patterns/table/examples/sortable-table/

* The active sorting column includes `aria-sort="ascending|descending"`.
* Ordering icons are hidden from screen readers via `aria-hidden`.
* Columns that can be used to order the table, render a header button with special focus style.
* Orderable columns include an `aria-label` and `title` which explains that clicking on them will order the table.

### TODO

 - [x]  Make the solution accessible
 - [x] Add an example where data is loaded asynchronously
 - [x] Consider allowing to define the columns that can be used to order
 - [x] Add tests