### PR TITLE
Do not reset DataTable when clicking a column

### DIFF
--- a/src/components/data/DataTable.tsx
+++ b/src/components/data/DataTable.tsx
@@ -25,7 +25,7 @@ export type TableColumn<Field> = {
 export type Order<Field> = {
   field: Field;
   direction: 'ascending' | 'descending';
-} | null;
+};
 
 type ComponentProps<Row> = {
   rows: Row[];
@@ -72,8 +72,8 @@ type ComponentProps<Row> = {
    * Callback invoked when user clicks a column header to change the sort order.
    * When a header is clicked, if that's not the active order, it is set with
    * order='ascending'.
-   * If the active header is clicked consecutively, direction rotates from
-   * 'ascending' to 'descending', and from 'descending' to no-active-order.
+   * If the active header is clicked consecutively, direction toggles between
+   * 'ascending' and 'descending'.
    */
   onOrderChange?: (order: Order<keyof Row>) => void;
 
@@ -100,14 +100,14 @@ function defaultRenderItem<Row>(r: Row, field: keyof Row): ComponentChildren {
   return r[field] as ComponentChildren;
 }
 
-function calculateNewOrder<T>(newField: T, prevOrder: Order<T>): Order<T> {
+function calculateNewOrder<T>(newField: T, prevOrder?: Order<T>): Order<T> {
   if (newField !== prevOrder?.field) {
     return { field: newField, direction: 'ascending' };
   }
 
-  return prevOrder.direction === 'ascending'
-    ? { field: newField, direction: 'descending' }
-    : null;
+  const newDirection =
+    prevOrder.direction === 'ascending' ? 'descending' : 'ascending';
+  return { field: newField, direction: newDirection };
 }
 
 type HeaderComponentProps = {
@@ -151,7 +151,7 @@ export default function DataTable<Row>({
   onConfirmRow,
   emptyMessage,
 
-  order = null,
+  order,
   onOrderChange,
   orderableColumns = [],
 
@@ -288,9 +288,7 @@ export default function DataTable<Row>({
         onKeyDown={event => handleKeyDown(event, row)}
       >
         {fields.map(field => (
-          <TableCell key={field}>
-            {renderItem(row, field as keyof Row)}
-          </TableCell>
+          <TableCell key={field}>{renderItem(row, field)}</TableCell>
         ))}
       </TableRow>
     ));

--- a/src/components/data/test/DataTable-test.js
+++ b/src/components/data/test/DataTable-test.js
@@ -432,11 +432,11 @@ describe('DataTable', () => {
           direction: 'descending',
         },
       },
-      // Clicking the same column when initially descending, transitions to no order
+      // Clicking the same column when initially descending, transitions to ascending
       {
         initialOrder: { field: 'name', direction: 'descending' },
         clickedColumn: 'name',
-        expectedNewOrder: null,
+        expectedNewOrder: { field: 'name', direction: 'ascending' },
       },
       // Clicking another column sets direction as ascending
       {

--- a/src/pattern-library/components/patterns/data/DataTablePage.tsx
+++ b/src/pattern-library/components/patterns/data/DataTablePage.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useMemo, useRef, useState } from 'preact/hooks';
 
-import { DataTable, type DataTableProps, Scroll } from '../../../../';
+import { Button, DataTable, type DataTableProps, Scroll } from '../../../../';
 import type { Order } from '../../../../components/data/DataTable';
 import Library from '../../Library';
 import { nabokovNovels } from '../samples';
@@ -17,7 +17,7 @@ type SimpleNabokovNovel = Omit<NabokovNovel, 'translatedTitle'>;
 
 function useOrderedRows(
   rows: SimpleNabokovNovel[],
-  order: Order<keyof SimpleNabokovNovel>,
+  order?: Order<keyof SimpleNabokovNovel>,
 ) {
   return useMemo(() => {
     if (!order) {
@@ -44,17 +44,26 @@ function ClientOrderableDataTable({
   orderableColumns = nabokovColumns.map(({ field }) => field),
   ...rest
 }: Omit<DataTableProps<SimpleNabokovNovel>, 'order' | 'onOrderChange'>) {
-  const [order, setOrder] = useState<Order<keyof SimpleNabokovNovel>>(null);
+  const [order, setOrder] = useState<Order<keyof SimpleNabokovNovel>>();
   const orderedRows = useOrderedRows(rows, order);
 
   return (
-    <DataTable
-      {...rest}
-      rows={orderedRows}
-      order={order}
-      orderableColumns={orderableColumns}
-      onOrderChange={setOrder}
-    />
+    <>
+      <Button classes="mb-2" onClick={() => setOrder(undefined)}>
+        Reset order
+      </Button>
+      <div className="h-[250px]">
+        <Scroll>
+          <DataTable
+            {...rest}
+            rows={orderedRows}
+            order={order}
+            orderableColumns={orderableColumns}
+            onOrderChange={setOrder}
+          />
+        </Scroll>
+      </div>
+    </>
   );
 }
 
@@ -65,11 +74,11 @@ function AsyncOrderableDataTable({
   ...rest
 }: Omit<DataTableProps<SimpleNabokovNovel>, 'order' | 'onOrderChange'>) {
   const [loading, setLoading] = useState(false);
-  const [order, setOrder] = useState<Order<keyof SimpleNabokovNovel>>(null);
+  const [order, setOrder] = useState<Order<keyof SimpleNabokovNovel>>();
   const activeTimeout = useRef<number | null>(null);
 
   const changeOrder = useCallback(
-    (newOrder: Order<keyof SimpleNabokovNovel>) => {
+    (newOrder?: Order<keyof SimpleNabokovNovel>) => {
       if (activeTimeout.current) {
         // Abort current ordering, if any
         clearTimeout(activeTimeout.current);
@@ -88,14 +97,23 @@ function AsyncOrderableDataTable({
   const orderedRows = useOrderedRows(rows, order);
 
   return (
-    <DataTable
-      {...rest}
-      rows={orderedRows}
-      order={order}
-      orderableColumns={orderableColumns}
-      onOrderChange={changeOrder}
-      loading={loading}
-    />
+    <>
+      <Button classes="mb-2" onClick={() => changeOrder(undefined)}>
+        Reset order
+      </Button>
+      <div className="h-[250px]">
+        <Scroll>
+          <DataTable
+            {...rest}
+            rows={orderedRows}
+            order={order}
+            orderableColumns={orderableColumns}
+            onOrderChange={changeOrder}
+            loading={loading}
+          />
+        </Scroll>
+      </div>
+    </>
   );
 }
 
@@ -668,26 +686,22 @@ export default function DataTablePage() {
             </Library.Info>
 
             <Library.Demo title="DataTable with client-side ordering">
-              <div className="w-full h-[250px]">
-                <Scroll>
-                  <ClientOrderableDataTable
-                    title="Some of Nabokov's novels"
-                    rows={nabokovRows}
-                    columns={nabokovColumns}
-                  />
-                </Scroll>
+              <div className="w-full">
+                <ClientOrderableDataTable
+                  title="Some of Nabokov's novels"
+                  rows={nabokovRows}
+                  columns={nabokovColumns}
+                />
               </div>
             </Library.Demo>
 
             <Library.Demo title="DataTable with server-side ordering">
-              <div className="w-full h-[250px]">
-                <Scroll>
-                  <AsyncOrderableDataTable
-                    title="Some of Nabokov's novels"
-                    rows={nabokovRows}
-                    columns={nabokovColumns}
-                  />
-                </Scroll>
+              <div className="w-full">
+                <AsyncOrderableDataTable
+                  title="Some of Nabokov's novels"
+                  rows={nabokovRows}
+                  columns={nabokovColumns}
+                />
               </div>
             </Library.Demo>
           </Library.Example>
@@ -708,15 +722,13 @@ export default function DataTablePage() {
             </Library.Info>
 
             <Library.Demo title="Partially orderable DataTable">
-              <div className="w-full h-[250px]">
-                <Scroll>
-                  <ClientOrderableDataTable
-                    title="Some of Nabokov's novels"
-                    rows={nabokovRows}
-                    columns={nabokovColumns}
-                    orderableColumns={['title', 'year']}
-                  />
-                </Scroll>
+              <div className="w-full">
+                <ClientOrderableDataTable
+                  title="Some of Nabokov's novels"
+                  rows={nabokovRows}
+                  columns={nabokovColumns}
+                  orderableColumns={['title', 'year']}
+                />
               </div>
             </Library.Demo>
           </Library.Example>


### PR DESCRIPTION
As part of https://github.com/hypothesis/frontend-shared/pull/1482, we implemented a new capability in `DataTable` that allows rows to be ordered when clicking a column.

Initially I implemented it in a way that clicking the same column multiple consecutive times would rotate the order `ascending`->`descending`->`no-order`->`ascending`... The reasons were explained here https://github.com/hypothesis/frontend-shared/pull/1482#discussion_r1519783744

However, we have then realized it is probably better to change this behavior to be `ascending`->`descending`->`ascending`... instead, as that allows to set an initial order and have always a visual indicator that the table can be ordered.

Since the `order` property is controlled by consuming code, it is still possible to reset the order programmatically if desired.

https://github.com/hypothesis/frontend-shared/assets/2719332/9d2abaaa-609a-48fd-a58a-b6e887e5111c

https://github.com/hypothesis/frontend-shared/assets/2719332/8e1addf0-0810-4f1d-9c2f-9dd9f03c11cc