### PR TITLE
Adjusting overall size of padding within `Panel`, `Card` and `Dialog` instances

### DIFF
--- a/src/components/feedback/Dialog.tsx
+++ b/src/components/feedback/Dialog.tsx
@@ -100,7 +100,7 @@ export default function Dialog({
   const {
     buttons,
     icon,
-    paddingSize = 'md',
+    paddingSize = 'lg',
     title = '',
     scrollable = true,
     ...htmlAttributes

--- a/src/components/feedback/Dialog.tsx
+++ b/src/components/feedback/Dialog.tsx
@@ -15,12 +15,17 @@ import { useClickAway } from '../../hooks/use-click-away';
 import { useFocusAway } from '../../hooks/use-focus-away';
 import { useKeyPress } from '../../hooks/use-key-press';
 import { useSyncedRef } from '../../hooks/use-synced-ref';
-import type { PresentationalProps, TransitionComponent } from '../../types';
+import type {
+  PresentationalProps,
+  Size,
+  TransitionComponent,
+} from '../../types';
 import { downcastRef } from '../../util/typing';
 import CloseableContext from '../CloseableContext';
 import type { CloseableInfo } from '../CloseableContext';
 import Panel from '../layout/Panel';
 import type { PanelProps } from '../layout/Panel';
+import type { ModalSize } from './ModalDialog';
 
 type ComponentProps = {
   closeOnClickAway?: boolean;
@@ -100,7 +105,7 @@ export default function Dialog({
   const {
     buttons,
     icon,
-    paddingSize = 'lg',
+    paddingSize = 'md',
     title = '',
     scrollable = true,
     ...htmlAttributes
@@ -234,6 +239,14 @@ export default function Dialog({
     title: closeTitle,
   };
 
+  const modalSize: ModalSize = (htmlAttributes as any)[
+    'data-modal-size'
+  ] as ModalSize;
+  const modalSizeScoped: undefined | Size =
+    modalSize === 'sm' || modalSize === 'md' || modalSize === 'lg'
+      ? modalSize
+      : undefined;
+
   return (
     <CloseableContext.Provider value={closeableContext}>
       <Wrapper
@@ -258,7 +271,7 @@ export default function Dialog({
               buttons={buttons}
               fullWidthHeader={true}
               icon={icon}
-              paddingSize={paddingSize}
+              paddingSize={modalSizeScoped || paddingSize}
               title={title}
               scrollable={scrollable}
             >

--- a/src/components/feedback/ModalDialog.tsx
+++ b/src/components/feedback/ModalDialog.tsx
@@ -2,12 +2,13 @@ import classnames from 'classnames';
 
 import { useSyncedRef } from '../../hooks/use-synced-ref';
 import { useTabKeyNavigation } from '../../hooks/use-tab-key-navigation';
+import type { Size } from '../../types';
 import { downcastRef } from '../../util/typing';
 import Overlay from '../layout/Overlay';
 import Dialog from './Dialog';
 import type { CustomDialogProps, PanelDialogProps } from './Dialog';
 
-type ModalSize = 'sm' | 'md' | 'lg' | 'custom';
+export type ModalSize = Size | 'custom' | 'none';
 
 type ComponentProps = {
   /**

--- a/src/components/layout/CardContent.tsx
+++ b/src/components/layout/CardContent.tsx
@@ -1,12 +1,11 @@
 import classnames from 'classnames';
 import type { JSX } from 'preact';
 
-import type { PresentationalProps } from '../../types';
+import type { PresentationalProps, Size } from '../../types';
 import { downcastRef } from '../../util/typing';
 
 type ComponentProps = {
-  /** relative internal spacing */
-  size?: 'sm' | 'md' | 'lg';
+  size?: Size;
 };
 
 export type CardContentProps = PresentationalProps &

--- a/src/components/layout/CardContent.tsx
+++ b/src/components/layout/CardContent.tsx
@@ -34,7 +34,7 @@ export default function CardContent({
         {
           'p-3 space-y-4': size === 'md', // Default
           'p-2 space-y-3': size === 'sm',
-          'p-4 space-y-6': size === 'lg',
+          'p-6 space-y-6': size === 'lg',
         },
         classes,
       )}

--- a/src/components/layout/CardHeader.tsx
+++ b/src/components/layout/CardHeader.tsx
@@ -10,7 +10,7 @@ import CardTitle from './CardTitle';
 
 type ComponentProps = {
   title?: string;
-  size?: 'sm' | 'md' | 'lg';
+
   /**
    * Optional callback for close-button click. When present, a close button
    * will be rendered.
@@ -25,9 +25,11 @@ type ComponentProps = {
   variant?: 'primary' | 'secondary';
 };
 
+type HTMLAttributes = JSX.HTMLAttributes<HTMLElement>;
+
 export type CardHeaderProps = PresentationalProps &
   ComponentProps &
-  Omit<JSX.HTMLAttributes<HTMLElement>, 'size'>;
+  HTMLAttributes;
 
 /**
  * Render a header area in a Card with optional title and/or close button
@@ -36,7 +38,7 @@ export default function CardHeader({
   children,
   classes,
   elementRef,
-  size,
+
   fullWidth = false,
   onClose,
   title,
@@ -58,8 +60,7 @@ export default function CardHeader({
           'bg-slate-0 border-slate-5 rounded-t-[inherit]':
             variant === 'secondary',
           'mx-3': !fullWidth && variant === 'primary',
-          'px-3': fullWidth || (variant === 'secondary' && !size),
-          'px-6': fullWidth && size === 'lg',
+          'px-3': fullWidth || variant === 'secondary',
         },
         classes,
       )}

--- a/src/components/layout/CardHeader.tsx
+++ b/src/components/layout/CardHeader.tsx
@@ -10,7 +10,7 @@ import CardTitle from './CardTitle';
 
 type ComponentProps = {
   title?: string;
-
+  size?: 'sm' | 'md' | 'lg';
   /**
    * Optional callback for close-button click. When present, a close button
    * will be rendered.
@@ -25,11 +25,9 @@ type ComponentProps = {
   variant?: 'primary' | 'secondary';
 };
 
-type HTMLAttributes = JSX.HTMLAttributes<HTMLElement>;
-
 export type CardHeaderProps = PresentationalProps &
   ComponentProps &
-  HTMLAttributes;
+  Omit<JSX.HTMLAttributes<HTMLElement>, 'size'>;
 
 /**
  * Render a header area in a Card with optional title and/or close button
@@ -38,7 +36,7 @@ export default function CardHeader({
   children,
   classes,
   elementRef,
-
+  size,
   fullWidth = false,
   onClose,
   title,
@@ -60,7 +58,8 @@ export default function CardHeader({
           'bg-slate-0 border-slate-5 rounded-t-[inherit]':
             variant === 'secondary',
           'mx-3': !fullWidth && variant === 'primary',
-          'px-3': fullWidth || variant === 'secondary',
+          'px-3': fullWidth || (variant === 'secondary' && !size),
+          'px-6': fullWidth && size === 'lg',
         },
         classes,
       )}

--- a/src/components/layout/Panel.tsx
+++ b/src/components/layout/Panel.tsx
@@ -1,7 +1,7 @@
 import classNames from 'classnames';
 import type { ComponentChildren, JSX } from 'preact';
 
-import type { IconComponent, CompositeProps } from '../../types';
+import type { IconComponent, CompositeProps, Size } from '../../types';
 import { downcastRef } from '../../util/typing';
 import Scroll from '../data/Scroll';
 import Card from './Card';
@@ -9,6 +9,8 @@ import CardActions from './CardActions';
 import CardContent from './CardContent';
 import CardHeader from './CardHeader';
 import CardTitle from './CardTitle';
+
+export type PanelSize = Size | 'none';
 
 type ComponentProps = {
   /** Buttons are rendered at the bottom right of the Panel. */
@@ -24,7 +26,7 @@ type ComponentProps = {
    * `CardContent`. This allows content to span the full width and height of
    * the Panel's content area without any inset/padding.
    */
-  paddingSize?: 'sm' | 'md' | 'lg' | 'none';
+  paddingSize?: PanelSize;
 
   /** Optional icon to render in the header */
   icon?: IconComponent;
@@ -74,6 +76,11 @@ export default function Panel({
   // parent elements. This allows for control over scrolling content,
   // specifically.
   const heightConstraintClasses = 'flex flex-col min-h-0 h-full';
+  // To better correlate the relationship between `paddingSize` and `size`
+  // within the `Card` parts, we map all values except "none" to this prop,
+  // which now matches the context of the card sizes themselves.
+  const cardSize: undefined | Size =
+    paddingSize !== 'none' ? (paddingSize as Size) : undefined;
   const panelContent =
     paddingSize === 'none' ? (
       children
@@ -81,7 +88,7 @@ export default function Panel({
       <CardContent
         classes={heightConstraintClasses}
         data-testid="panel-content-wrapper"
-        size={paddingSize}
+        size={cardSize}
       >
         {children}
       </CardContent>
@@ -96,7 +103,7 @@ export default function Panel({
       <CardHeader
         onClose={onClose}
         fullWidth={scrollable || fullWidthHeader}
-        size={paddingSize !== 'none' ? paddingSize : undefined}
+        classes={cardSize === 'lg' ? 'px-6' : undefined}
       >
         {Icon && <Icon className="w-em h-em" />}
         <CardTitle>{title}</CardTitle>
@@ -117,7 +124,7 @@ export default function Panel({
       {buttons && (
         <CardContent
           data-testid="panel-buttons"
-          size={paddingSize !== 'none' ? paddingSize : undefined}
+          size={cardSize}
           style={{ paddingBlockStart: 'unset' }}
         >
           <CardActions>{buttons}</CardActions>

--- a/src/components/layout/Panel.tsx
+++ b/src/components/layout/Panel.tsx
@@ -93,7 +93,11 @@ export default function Panel({
       classes={heightConstraintClasses}
       elementRef={downcastRef(elementRef)}
     >
-      <CardHeader onClose={onClose} fullWidth={scrollable || fullWidthHeader}>
+      <CardHeader
+        onClose={onClose}
+        fullWidth={scrollable || fullWidthHeader}
+        size={paddingSize !== 'none' ? paddingSize : undefined}
+      >
         {Icon && <Icon className="w-em h-em" />}
         <CardTitle>{title}</CardTitle>
       </CardHeader>
@@ -111,7 +115,11 @@ export default function Panel({
         <>{panelContent}</>
       )}
       {buttons && (
-        <CardContent data-testid="panel-buttons">
+        <CardContent
+          data-testid="panel-buttons"
+          size={paddingSize !== 'none' ? paddingSize : undefined}
+          style={{ paddingBlockStart: 'unset' }}
+        >
           <CardActions>{buttons}</CardActions>
         </CardContent>
       )}

--- a/src/types.ts
+++ b/src/types.ts
@@ -34,3 +34,5 @@ export type TransitionComponent = FunctionComponent<{
   direction?: 'in' | 'out';
   onTransitionEnd?: (direction: 'in' | 'out') => void;
 }>;
+
+export type Size = 'sm' | 'md' | 'lg';


### PR DESCRIPTION
To provide more overall padding within the `Dialog` component, I adjusted various sub-components used and tied into the `paddingSize` prop used within various `Panel` and `Card` components. I specifically mapped the sizing to `lg` and changed the default `paddingSize` prop on `Dialog` to account for this.