### PR TITLE
Set z-index > 0 for `DataTable` header

### DIFF
--- a/src/components/data/TableHead.tsx
+++ b/src/components/data/TableHead.tsx
@@ -37,6 +37,9 @@ export default function TableHead({
         {...htmlAttributes}
         ref={downcastRef(elementRef)}
         className={classnames(
+          // This ensures the header is drawn on top of positioned content
+          // in table cells.
+          'z-1',
           'bg-grey-2',
           {
             'sticky top-0': tableContext?.stickyHeader,


### PR DESCRIPTION
This ensures that sticky headers are drawn above any positioned content in table cells. See https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_positioned_layout/Understanding_z-index/Stacking_without_z-index.

This fixes an issue in https://github.com/hypothesis/lms/pull/6187 where introducing the use of `position: relative` for thumbnail elements caused them to be rendered above the sticky header when scrolled.