### PR TITLE
Add variant prop to Table

### DIFF
--- a/src/components/data/DataTable.tsx
+++ b/src/components/data/DataTable.tsx
@@ -10,6 +10,7 @@ import { ArrowDownIcon, ArrowUpIcon, SpinnerSpokesIcon } from '../icons';
 import { Button } from '../input';
 import ScrollContext from './ScrollContext';
 import Table from './Table';
+import type { TableProps } from './Table';
 import TableBody from './TableBody';
 import TableCell from './TableCell';
 import TableFoot from './TableFoot';
@@ -22,7 +23,10 @@ export type TableColumn<Field> = {
   classes?: string;
 };
 
-type ComponentProps<Row> = {
+type ComponentProps<Row> = Pick<
+  TableProps,
+  'borderless' | 'variant' | 'title'
+> & {
   rows: Row[];
   columns: TableColumn<keyof Row>[];
 
@@ -81,10 +85,6 @@ type ComponentProps<Row> = {
 
   /** Callback to render an individual table cell */
   renderItem?: (r: Row, field: keyof Row) => ComponentChildren;
-  title: string;
-
-  /** Turn off outer table borders */
-  borderless?: boolean;
 };
 
 export type DataTableProps<Row> = CompositeProps &
@@ -139,7 +139,6 @@ export default function DataTable<Row>({
 
   columns = [],
   rows = [],
-  title,
   selectedRow,
   selectedRows,
   loading = false,
@@ -154,7 +153,9 @@ export default function DataTable<Row>({
   orderableColumns = [],
 
   // Forwarded to Table
+  title,
   borderless,
+  variant,
 
   ...htmlAttributes
 }: DataTableProps<Row>) {
@@ -307,11 +308,12 @@ export default function DataTable<Row>({
       data-composite-component="DataTable"
       role="grid"
       {...htmlAttributes}
-      title={title}
       elementRef={downcastRef(tableRef)}
       interactive={interactive}
       stickyHeader
+      title={title}
       borderless={borderless}
+      variant={variant}
     >
       <TableHead>
         <TableRow>

--- a/src/components/data/Table.tsx
+++ b/src/components/data/Table.tsx
@@ -6,17 +6,14 @@ import { useSyncedRef } from '../../hooks/use-synced-ref';
 import type { PresentationalProps } from '../../types';
 import { downcastRef } from '../../util/typing';
 import TableContext from './TableContext';
+import type { CommonTableInfo } from './TableContext';
 import type { TableInfo } from './TableContext';
 
-export type TableProps = PresentationalProps & {
-  stickyHeader?: boolean;
-  /** Sets accessible aria-label */
-  title: string;
-  /** This table has rows that can be selected */
-  interactive?: boolean;
-  /** Turn off outer table borders */
-  borderless?: boolean;
-} & Omit<JSX.HTMLAttributes<HTMLElement>, 'rows'>;
+export type TableProps = PresentationalProps &
+  CommonTableInfo & {
+    /** Sets accessible aria-label */
+    title: string;
+  } & Omit<JSX.HTMLAttributes<HTMLElement>, 'rows'>;
 
 /**
  * Render table content
@@ -30,6 +27,7 @@ export default function Table({
   interactive = false,
   stickyHeader = false,
   borderless = false,
+  variant = 'striped',
 
   ...htmlAttributes
 }: TableProps) {
@@ -40,9 +38,10 @@ export default function Table({
       interactive,
       stickyHeader,
       borderless,
+      variant,
       tableRef: ref,
     }),
-    [borderless, interactive, stickyHeader, ref],
+    [borderless, interactive, stickyHeader, variant, ref],
   );
 
   return (
@@ -57,14 +56,18 @@ export default function Table({
           // Set the width of columns based on the width of the columns in the
           // first table row (typically headers)
           'table-fixed',
-          // `border-separate` is required to handle borders on sticky headers.
-          // A side effect is that borders need to be set primarily on table
-          // cells, not rows
-          'border-separate border-spacing-0',
-          // No top border is set here: that border is set by `TableCell`.
-          // If it is set here, there will be a 1-pixel wiggle in the sticky
-          // header on scroll
-          { 'border-x border-b': !borderless },
+          'border-spacing-0',
+          {
+            // No top border is set here: that border is set by `TableCell`.
+            // If it is set here, there will be a 1-pixel wiggle in the sticky
+            // header on scroll
+            'border-x border-b': !borderless,
+            // `border-separate` is required to handle borders on sticky headers.
+            // A side effect is that borders need to be set primarily on table
+            // cells, not rows
+            'border-separate': variant === 'striped',
+            'border-collapse': variant === 'grid',
+          },
           classes,
         )}
         ref={downcastRef(ref)}

--- a/src/components/data/TableCell.tsx
+++ b/src/components/data/TableCell.tsx
@@ -25,7 +25,7 @@ export default function TableCell({
   ...htmlAttributes
 }: TableCellProps) {
   const sectionContext = useContext(TableSectionContext);
-  const { borderless } = useContext(TableContext);
+  const { borderless, variant } = useContext(TableContext);
   const isHeadCell = sectionContext && sectionContext.section === 'head';
   const Cell = isHeadCell ? 'th' : 'td';
 
@@ -42,14 +42,15 @@ export default function TableCell({
           // on scroll with sticky headers.
           'text-left border-b border-b-grey-5': isHeadCell,
           'border-t': isHeadCell && !borderless,
-          'border-none': !isHeadCell,
+          'border-none': variant === 'striped' && !isHeadCell,
           // Apply a very subtle bottom border to the last row in the table (not
           // in the head). This can help delineate the end of data in tables
           // with sparse row data. Only apply border if row is not selected.
           // This uses Tailwind's nested-group syntax. See
           // https://tailwindcss.com/docs/hover-focus-and-other-states#differentiating-nested-groups
           'group-last/unselected:border-b group-last/unselected:border-grey-2 group-last/unselected:border-dotted':
-            !isHeadCell,
+            variant === 'striped' && !isHeadCell,
+          border: variant === 'grid',
         },
         classes,
       )}

--- a/src/components/data/TableContext.ts
+++ b/src/components/data/TableContext.ts
@@ -1,13 +1,23 @@
 import { createContext } from 'preact';
 import type { RefObject } from 'preact';
 
-export type TableInfo = {
+export type CommonTableInfo = {
   /** This table has click-able, focus-able rows */
-  interactive: boolean;
+  interactive?: boolean;
   /** This table has a sticky header */
-  stickyHeader: boolean;
+  stickyHeader?: boolean;
   /** Turn off outer table borders */
-  borderless: boolean;
+  borderless?: boolean;
+
+  /**
+   * Table variant:
+   *  - striped: Show a different background every other row
+   *  - grid: Show the table cells as a grid
+   */
+  variant?: 'striped' | 'grid';
+};
+
+export type TableInfo = Required<CommonTableInfo> & {
   tableRef: RefObject<HTMLElement | undefined>;
 };
 

--- a/src/components/data/TableRow.tsx
+++ b/src/components/data/TableRow.tsx
@@ -31,7 +31,7 @@ export default function TableRow({
   const rowRef = useSyncedRef(elementRef);
 
   const sectionContext = useContext(TableSectionContext);
-  const tableContext = useContext(TableContext);
+  const { interactive, variant } = useContext(TableContext);
 
   const isHeadRow = sectionContext?.section === 'head';
 
@@ -46,9 +46,10 @@ export default function TableRow({
         'focus-visible-ring ring-inset',
         {
           // Low-opacity backgrounds allow any scroll shadows to be visible
-          'odd:bg-slate-9/[.03]': !isHeadRow && !selected,
+          'odd:bg-slate-9/[.03]':
+            variant === 'striped' && !isHeadRow && !selected,
           'bg-slate-7 text-color-text-inverted': selected,
-          'hover:bg-slate-9/[.08]': tableContext?.interactive && !selected,
+          'hover:bg-slate-9/[.08]': interactive && !selected,
           'group/unselected': !selected,
           'group/selected': selected,
         },

--- a/src/pattern-library/components/patterns/data/TablePage.tsx
+++ b/src/pattern-library/components/patterns/data/TablePage.tsx
@@ -334,6 +334,70 @@ export default function TablePage() {
               </Table>
             </Library.Demo>
           </Library.Example>
+          <Library.Example id="table-props-borderless" title="variant">
+            <Library.Info>
+              <Library.InfoItem label="description">
+                Overall aspect of the table. When set to{' '}
+                <code>
+                  {"'"}striped{"'"}
+                </code>
+                , the table has not cell borders, and every odd row has a
+                slightly darker background color. When set to{' '}
+                <code>
+                  {"'"}grid{"'"}
+                </code>
+                , cell borders are rendered and all rows have no background.
+              </Library.InfoItem>
+              <Library.InfoItem label="type">
+                <code>
+                  {"'"}striped{"'"} | {"'"}grid{"'"}
+                </code>
+              </Library.InfoItem>
+              <Library.InfoItem label="default">
+                <code>
+                  {"'"}striped{"'"}
+                </code>
+              </Library.InfoItem>
+            </Library.Info>
+
+            <Library.Demo title="Table with grid variant" withSource>
+              <Table title="Some sushi rolls" variant="grid">
+                <TableHead>
+                  <TableRow>
+                    <TableCell classes="w-[180px]">Sushi roll name</TableCell>
+                    <TableCell>Definition</TableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  <TableRow onClick={() => alert('Yum, Alaska roll!')}>
+                    <TableCell>Alaskan roll</TableCell>
+                    <TableCell>
+                      A variant of the California roll with smoked salmon on the
+                      inside, or layered on the outside.
+                    </TableCell>
+                  </TableRow>
+                  <TableRow onClick={() => alert('This is a new one!')}>
+                    <TableCell>Boston roll</TableCell>
+                    <TableCell>
+                      An uramaki California roll with poached shrimp instead of
+                      imitation crab.
+                    </TableCell>
+                  </TableRow>
+                  <TableRow
+                    onClick={() => alert('I call this a salmon-skin roll')}
+                  >
+                    <TableCell>British Columbia roll</TableCell>
+                    <TableCell>
+                      A roll containing grilled or barbecued salmon skin,
+                      cucumber, sweet sauce, sometimes with roe. Also sometimes
+                      referred to as salmon skin rolls outside of British
+                      Columbia, Canada.
+                    </TableCell>
+                  </TableRow>
+                </TableBody>
+              </Table>
+            </Library.Demo>
+          </Library.Example>
           <Library.Example title="...htmlAttributes">
             <Library.Info>
               <Library.InfoItem label="description">


### PR DESCRIPTION
Add a new `variant` prop to `Table` component, that accepts the values `'striped'` and `'grid'`.

* `'striped'`: Current behavior. Renders borderless cells, and uses a slightly darker background color for odd rows. It's the default value.
* `'grid'`: Renders borders for every cell, and does not set a different background color for rows.

Comparison:

![image](https://github.com/hypothesis/frontend-shared/assets/2719332/28659cc5-908e-4e6f-8870-cbade08f7ed7)
![image](https://github.com/hypothesis/frontend-shared/assets/2719332/4b3cef42-11a7-4d0d-83aa-f30c781ebf0c)

### TODO

- [ ] Add tests
- [ ] Test in combination with interactive tables
- [ ] Test in combination with `borderless`
- [ ] Test in combination with `Scroll`
- [ ] Test in `DataTable`

### To be decided

- Should the header not use grey background when using the grid variant?
- Should the header not use grid separators?