### PR TITLE
Add grid and unstriped props to table

### DIFF
--- a/src/components/data/DataTable.tsx
+++ b/src/components/data/DataTable.tsx
@@ -10,6 +10,7 @@ import { ArrowDownIcon, ArrowUpIcon, SpinnerSpokesIcon } from '../icons';
 import { Button } from '../input';
 import ScrollContext from './ScrollContext';
 import Table from './Table';
+import type { TableProps } from './Table';
 import TableBody from './TableBody';
 import TableCell from './TableCell';
 import TableFoot from './TableFoot';
@@ -22,7 +23,10 @@ export type TableColumn<Field> = {
   classes?: string;
 };
 
-type ComponentProps<Row> = {
+type ComponentProps<Row> = Pick<
+  TableProps,
+  'borderless' | 'title' | 'striped' | 'grid'
+> & {
   rows: Row[];
   columns: TableColumn<keyof Row>[];
 
@@ -81,10 +85,6 @@ type ComponentProps<Row> = {
 
   /** Callback to render an individual table cell */
   renderItem?: (r: Row, field: keyof Row) => ComponentChildren;
-  title: string;
-
-  /** Turn off outer table borders */
-  borderless?: boolean;
 };
 
 export type DataTableProps<Row> = CompositeProps &
@@ -139,7 +139,6 @@ export default function DataTable<Row>({
 
   columns = [],
   rows = [],
-  title,
   selectedRow,
   selectedRows,
   loading = false,
@@ -154,7 +153,10 @@ export default function DataTable<Row>({
   orderableColumns = [],
 
   // Forwarded to Table
+  title,
   borderless,
+  striped,
+  grid,
 
   ...htmlAttributes
 }: DataTableProps<Row>) {
@@ -307,11 +309,13 @@ export default function DataTable<Row>({
       data-composite-component="DataTable"
       role="grid"
       {...htmlAttributes}
-      title={title}
       elementRef={downcastRef(tableRef)}
       interactive={interactive}
       stickyHeader
+      title={title}
       borderless={borderless}
+      striped={striped}
+      grid={grid}
     >
       <TableHead>
         <TableRow>

--- a/src/components/data/Table.tsx
+++ b/src/components/data/Table.tsx
@@ -9,13 +9,18 @@ import TableContext from './TableContext';
 import type { TableInfo } from './TableContext';
 
 export type TableProps = PresentationalProps & {
+  /** This table has a sticky header */
   stickyHeader?: boolean;
   /** Sets accessible aria-label */
   title: string;
-  /** This table has rows that can be selected */
+  /** This table has click-able, focus-able rows */
   interactive?: boolean;
   /** Turn off outer table borders */
   borderless?: boolean;
+  /** Show a different background every other row */
+  striped?: boolean;
+  /** Show grid lines around table cells */
+  grid?: boolean;
 } & Omit<JSX.HTMLAttributes<HTMLElement>, 'rows'>;
 
 /**
@@ -30,6 +35,8 @@ export default function Table({
   interactive = false,
   stickyHeader = false,
   borderless = false,
+  striped = true,
+  grid = false,
 
   ...htmlAttributes
 }: TableProps) {
@@ -40,9 +47,11 @@ export default function Table({
       interactive,
       stickyHeader,
       borderless,
+      striped,
+      grid,
       tableRef: ref,
     }),
-    [borderless, interactive, stickyHeader, ref],
+    [interactive, stickyHeader, borderless, striped, grid, ref],
   );
 
   return (

--- a/src/components/data/TableCell.tsx
+++ b/src/components/data/TableCell.tsx
@@ -25,7 +25,7 @@ export default function TableCell({
   ...htmlAttributes
 }: TableCellProps) {
   const sectionContext = useContext(TableSectionContext);
-  const { borderless } = useContext(TableContext);
+  const { borderless, grid } = useContext(TableContext);
   const isHeadCell = sectionContext && sectionContext.section === 'head';
   const Cell = isHeadCell ? 'th' : 'td';
 
@@ -42,18 +42,25 @@ export default function TableCell({
           // on scroll with sticky headers.
           'text-left border-b border-b-grey-5': isHeadCell,
           'border-t': isHeadCell && !borderless,
-          'border-none': !isHeadCell,
+          'border-none': !grid && !isHeadCell,
           // Apply a very subtle bottom border to the last row in the table (not
           // in the head). This can help delineate the end of data in tables
           // with sparse row data. Only apply border if row is not selected.
           // This uses Tailwind's nested-group syntax. See
           // https://tailwindcss.com/docs/hover-focus-and-other-states#differentiating-nested-groups
           'group-last/unselected:border-b group-last/unselected:border-grey-2 group-last/unselected:border-dotted':
-            !isHeadCell,
+            !grid && !isHeadCell,
+          // We would typically set `border` in cells together with
+          // `border-collapse` in the parent table. However, that doesn't work
+          // for sticky headers, so we mimic the behavior by conditionally
+          // setting individual cell borders.
+          'group-[:not(:last-child)]:border-b': grid,
         },
         classes,
       )}
       scope={isHeadCell ? 'col' : undefined}
+      data-grid={grid}
+      data-borderless={borderless}
     >
       {children}
     </Cell>

--- a/src/components/data/TableContext.ts
+++ b/src/components/data/TableContext.ts
@@ -8,6 +8,10 @@ export type TableInfo = {
   stickyHeader: boolean;
   /** Turn off outer table borders */
   borderless: boolean;
+  /** Show a different background every other row */
+  striped: boolean;
+  /** Show grid lines around table cells */
+  grid: boolean;
   tableRef: RefObject<HTMLElement | undefined>;
 };
 

--- a/src/components/data/TableRow.tsx
+++ b/src/components/data/TableRow.tsx
@@ -31,7 +31,7 @@ export default function TableRow({
   const rowRef = useSyncedRef(elementRef);
 
   const sectionContext = useContext(TableSectionContext);
-  const tableContext = useContext(TableContext);
+  const { interactive, striped, grid } = useContext(TableContext);
 
   const isHeadRow = sectionContext?.section === 'head';
 
@@ -46,15 +46,22 @@ export default function TableRow({
         'focus-visible-ring ring-inset',
         {
           // Low-opacity backgrounds allow any scroll shadows to be visible
-          'odd:bg-slate-9/[.03]': !isHeadRow && !selected,
+          'odd:bg-slate-9/[.03]': striped && !isHeadRow && !selected,
           'bg-slate-7 text-color-text-inverted': selected,
-          'hover:bg-slate-9/[.08]': tableContext?.interactive && !selected,
+          'hover:bg-slate-9/[.08]': interactive && !selected,
           'group/unselected': !selected,
           'group/selected': selected,
+          // We would typically set `border` in cells together with
+          // `border-collapse` in the parent table. However, that doesn't work
+          // for sticky headers, so we mimic the behavior by conditionally
+          // setting individual cell borders.
+          'divide-x': grid,
         },
         classes,
       )}
       data-section={isHeadRow ? 'head' : 'body'}
+      data-striped={striped}
+      data-grid={grid}
     >
       {children}
     </tr>

--- a/src/components/data/test/TableCell-test.js
+++ b/src/components/data/test/TableCell-test.js
@@ -2,20 +2,24 @@ import { mount } from 'enzyme';
 
 import { testPresentationalComponent } from '../../test/common-tests';
 import TableCell from '../TableCell';
+import TableContext from '../TableContext';
 import TableSectionContext from '../TableSectionContext';
 
 describe('TableCell', () => {
+  let tableContextValue;
   let contextValue;
 
-  const createComponent = (Component, props = {}) => {
+  const createComponent = (props = {}) => {
     return mount(
-      <table>
-        <TableSectionContext.Provider value={contextValue}>
-          <tr>
-            <Component {...props} />
-          </tr>
-        </TableSectionContext.Provider>
-      </table>,
+      <TableContext.Provider value={tableContextValue}>
+        <table>
+          <TableSectionContext.Provider value={contextValue}>
+            <tr>
+              <TableCell {...props}>{props.children ?? 'Content'}</TableCell>
+            </tr>
+          </TableSectionContext.Provider>
+        </table>
+      </TableContext.Provider>,
     );
   };
 
@@ -32,6 +36,7 @@ describe('TableCell', () => {
   };
 
   beforeEach(() => {
+    tableContextValue = {};
     contextValue = {};
   });
 
@@ -40,18 +45,38 @@ describe('TableCell', () => {
     elementSelector: '[data-component="TableCell"]',
   });
 
+  [true, false].forEach(flag => {
+    it('is set as grid', () => {
+      tableContextValue.grid = flag;
+      const wrapper = createComponent();
+      assert.equal(
+        wrapper.find('[data-component="TableCell"]').prop('data-grid'),
+        flag,
+      );
+    });
+
+    it('is set as borderless', () => {
+      tableContextValue.borderless = flag;
+      const wrapper = createComponent();
+      assert.equal(
+        wrapper.find('[data-component="TableCell"]').prop('data-borderless'),
+        flag,
+      );
+    });
+  });
+
   context('when in a table header', () => {
     beforeEach(() => {
       contextValue = { section: 'head' };
     });
 
     it('renders as a TH element', () => {
-      const wrapper = createComponent(TableCell, { children: 'Content' });
+      const wrapper = createComponent();
       assert.isTrue(wrapper.find('th').exists());
     });
 
     it('adds column scope to the TH', () => {
-      const wrapper = createComponent(TableCell, { children: 'Content' });
+      const wrapper = createComponent();
       assert.equal(wrapper.find('th').prop('scope'), 'col');
     });
   });
@@ -62,7 +87,7 @@ describe('TableCell', () => {
     });
 
     it('renders as a TD element', () => {
-      const wrapper = createComponent(TableCell, { children: 'Content' });
+      const wrapper = createComponent();
       assert.isTrue(wrapper.find('td').exists());
     });
   });

--- a/src/components/data/test/TableRow-test.js
+++ b/src/components/data/test/TableRow-test.js
@@ -9,14 +9,14 @@ describe('TableRow', () => {
   let tableContextValue;
   let sectionContextValue;
 
-  const createComponent = (Component, props = {}) => {
+  const createComponent = (props = {}) => {
     return mount(
       <TableContext.Provider value={tableContextValue}>
         <table>
           <TableSectionContext.Provider value={sectionContextValue}>
-            <Component {...props}>
+            <TableRow {...props}>
               <td>Cell content</td>
-            </Component>
+            </TableRow>
           </TableSectionContext.Provider>
         </table>
       </TableContext.Provider>,
@@ -46,8 +46,8 @@ describe('TableRow', () => {
   });
 
   it('sets aria-selected when selected', () => {
-    const selectedWrapper = createComponent(TableRow, { selected: true });
-    const unselectedWrapper = createComponent(TableRow, { selected: false });
+    const selectedWrapper = createComponent({ selected: true });
+    const unselectedWrapper = createComponent({ selected: false });
 
     assert.isTrue(
       selectedWrapper.find('[data-component="TableRow"]').prop('aria-selected'),
@@ -59,13 +59,33 @@ describe('TableRow', () => {
     );
   });
 
+  [true, false].forEach(flag => {
+    it('is set as striped', () => {
+      tableContextValue.striped = flag;
+      const wrapper = createComponent();
+      assert.equal(
+        wrapper.find('[data-component="TableRow"]').prop('data-striped'),
+        flag,
+      );
+    });
+
+    it('is set as grid', () => {
+      tableContextValue.grid = flag;
+      const wrapper = createComponent();
+      assert.equal(
+        wrapper.find('[data-component="TableRow"]').prop('data-grid'),
+        flag,
+      );
+    });
+  });
+
   context('when in a table header', () => {
     beforeEach(() => {
       sectionContextValue = { section: 'head' };
     });
 
     it('renders in a head context', () => {
-      const wrapper = createComponent(TableRow);
+      const wrapper = createComponent();
       assert.equal(
         wrapper.find('[data-component="TableRow"]').prop('data-section'),
         'head',
@@ -79,7 +99,7 @@ describe('TableRow', () => {
     });
 
     it('renders in a head context', () => {
-      const wrapper = createComponent(TableRow);
+      const wrapper = createComponent();
       assert.equal(
         wrapper.find('[data-component="TableRow"]').prop('data-section'),
         'body',

--- a/src/pattern-library/components/patterns/data/DataTablePage.tsx
+++ b/src/pattern-library/components/patterns/data/DataTablePage.tsx
@@ -211,6 +211,20 @@ export default function DataTablePage() {
 ];`}
             />
           </Library.Example>
+          <Library.Example title="Grid DataTables with scroll">
+            <Library.Demo title="Grid DataTables with scroll" withSource>
+              <div className="w-full h-[250px]">
+                <Scroll>
+                  <DataTable
+                    title="A subset of Nabokov's novels with publish date and original language"
+                    rows={nabokovRows}
+                    columns={nabokovColumns}
+                    grid
+                  />
+                </Scroll>
+              </div>
+            </Library.Demo>
+          </Library.Example>
           <Library.Example title="Interactive DataTables">
             <p>
               The presence of a <code>onSelectRow</code>,{' '}
@@ -296,12 +310,12 @@ export default function DataTablePage() {
             <code>DataTable</code> accepts all standard{' '}
             <Library.Link href="/using-components#composite-components-api">
               composite component props
+            </Library.Link>{' '}
+            and some{' '}
+            <Library.Link href="/data-table#table-props">
+              <code>Table</code> presentational props
             </Library.Link>
             .
-          </p>
-          <p>
-            <code>rows</code>, <code>columns</code> and <code>title</code> are
-            required.
           </p>
           <Library.Example title="columns">
             <Library.Info>
@@ -709,18 +723,6 @@ export default function DataTablePage() {
                 />
               </div>
             </Library.Demo>
-          </Library.Example>
-
-          <Library.Example title="borderless">
-            <Library.Info>
-              <Library.InfoItem label="description">
-                See{' '}
-                <Library.Link href="/data-table#table-props-borderless">
-                  borderless Table
-                </Library.Link>
-                .
-              </Library.InfoItem>
-            </Library.Info>
           </Library.Example>
 
           <Library.Example title="...htmlAttributes">

--- a/src/pattern-library/components/patterns/data/TablePage.tsx
+++ b/src/pattern-library/components/patterns/data/TablePage.tsx
@@ -138,7 +138,7 @@ export default function TablePage() {
           </Library.Example>
         </Library.Pattern>
 
-        <Library.Pattern title="Component API">
+        <Library.Pattern id="table-props" title="Component API">
           <code>Table</code> accepts all standard{' '}
           <Library.Link href="/using-components#presentational-components-api">
             presentational component props
@@ -298,6 +298,145 @@ export default function TablePage() {
 
             <Library.Demo title="Table without borders" withSource>
               <Table title="Some sushi rolls" borderless>
+                <TableHead>
+                  <TableRow>
+                    <TableCell classes="w-[180px]">Sushi roll name</TableCell>
+                    <TableCell>Definition</TableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  <TableRow onClick={() => alert('Yum, Alaska roll!')}>
+                    <TableCell>Alaskan roll</TableCell>
+                    <TableCell>
+                      A variant of the California roll with smoked salmon on the
+                      inside, or layered on the outside.
+                    </TableCell>
+                  </TableRow>
+                  <TableRow onClick={() => alert('This is a new one!')}>
+                    <TableCell>Boston roll</TableCell>
+                    <TableCell>
+                      An uramaki California roll with poached shrimp instead of
+                      imitation crab.
+                    </TableCell>
+                  </TableRow>
+                  <TableRow
+                    onClick={() => alert('I call this a salmon-skin roll')}
+                  >
+                    <TableCell>British Columbia roll</TableCell>
+                    <TableCell>
+                      A roll containing grilled or barbecued salmon skin,
+                      cucumber, sweet sauce, sometimes with roe. Also sometimes
+                      referred to as salmon skin rolls outside of British
+                      Columbia, Canada.
+                    </TableCell>
+                  </TableRow>
+                </TableBody>
+              </Table>
+            </Library.Demo>
+          </Library.Example>
+          <Library.Example title="striped">
+            <Library.Info>
+              <Library.InfoItem label="description">
+                Renders a different background for odd rows.
+              </Library.InfoItem>
+              <Library.InfoItem label="type">
+                <code>boolean</code>
+              </Library.InfoItem>
+              <Library.InfoItem label="default">
+                <code>true</code>
+              </Library.InfoItem>
+            </Library.Info>
+
+            <Library.Demo title="Table without stripes" withSource>
+              <Table title="Some sushi rolls" striped={false}>
+                <TableHead>
+                  <TableRow>
+                    <TableCell classes="w-[180px]">Sushi roll name</TableCell>
+                    <TableCell>Definition</TableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  <TableRow onClick={() => alert('Yum, Alaska roll!')}>
+                    <TableCell>Alaskan roll</TableCell>
+                    <TableCell>
+                      A variant of the California roll with smoked salmon on the
+                      inside, or layered on the outside.
+                    </TableCell>
+                  </TableRow>
+                  <TableRow onClick={() => alert('This is a new one!')}>
+                    <TableCell>Boston roll</TableCell>
+                    <TableCell>
+                      An uramaki California roll with poached shrimp instead of
+                      imitation crab.
+                    </TableCell>
+                  </TableRow>
+                  <TableRow
+                    onClick={() => alert('I call this a salmon-skin roll')}
+                  >
+                    <TableCell>British Columbia roll</TableCell>
+                    <TableCell>
+                      A roll containing grilled or barbecued salmon skin,
+                      cucumber, sweet sauce, sometimes with roe. Also sometimes
+                      referred to as salmon skin rolls outside of British
+                      Columbia, Canada.
+                    </TableCell>
+                  </TableRow>
+                </TableBody>
+              </Table>
+            </Library.Demo>
+          </Library.Example>
+          <Library.Example title="grid">
+            <Library.Info>
+              <Library.InfoItem label="description">
+                Renders borders for table cells.
+              </Library.InfoItem>
+              <Library.InfoItem label="type">
+                <code>boolean</code>
+              </Library.InfoItem>
+              <Library.InfoItem label="default">
+                <code>false</code>
+              </Library.InfoItem>
+            </Library.Info>
+
+            <Library.Demo title="Table with grid" withSource>
+              <Table title="Some sushi rolls" grid>
+                <TableHead>
+                  <TableRow>
+                    <TableCell classes="w-[180px]">Sushi roll name</TableCell>
+                    <TableCell>Definition</TableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  <TableRow onClick={() => alert('Yum, Alaska roll!')}>
+                    <TableCell>Alaskan roll</TableCell>
+                    <TableCell>
+                      A variant of the California roll with smoked salmon on the
+                      inside, or layered on the outside.
+                    </TableCell>
+                  </TableRow>
+                  <TableRow onClick={() => alert('This is a new one!')}>
+                    <TableCell>Boston roll</TableCell>
+                    <TableCell>
+                      An uramaki California roll with poached shrimp instead of
+                      imitation crab.
+                    </TableCell>
+                  </TableRow>
+                  <TableRow
+                    onClick={() => alert('I call this a salmon-skin roll')}
+                  >
+                    <TableCell>British Columbia roll</TableCell>
+                    <TableCell>
+                      A roll containing grilled or barbecued salmon skin,
+                      cucumber, sweet sauce, sometimes with roe. Also sometimes
+                      referred to as salmon skin rolls outside of British
+                      Columbia, Canada.
+                    </TableCell>
+                  </TableRow>
+                </TableBody>
+              </Table>
+            </Library.Demo>
+            <Library.Demo title="Table with grid, without stripes" withSource>
+              <Table title="Some sushi rolls" grid striped={false}>
                 <TableHead>
                   <TableRow>
                     <TableCell classes="w-[180px]">Sushi roll name</TableCell>


### PR DESCRIPTION
This is an alternative to https://github.com/hypothesis/frontend-shared/pull/1524, where we manage the UI variants via `grid` and `striped` boolean props that can be combined if needed, instead of a single `variant` prop.

![image](https://github.com/hypothesis/frontend-shared/assets/2719332/a34ed1d0-2335-40aa-961e-efdcd5f237bb)
![image](https://github.com/hypothesis/frontend-shared/assets/2719332/91db0247-077e-4059-b357-26f4b030b62b)
![image](https://github.com/hypothesis/frontend-shared/assets/2719332/f37a4457-73c8-47ac-9568-cbb6ac0689c1)

### TODO

- [x] Add tests
- [x] Test in combination with interactive tables
- [x] Test in combination with `borderless`
- [x] Test in combination with `Scroll`
- [x] Test in `DataTable`