### PR TITLE
Allow case-insensitive comparisons in useOrderedRows hook

### DIFF
--- a/src/hooks/test/use-ordered-rows-test.js
+++ b/src/hooks/test/use-ordered-rows-test.js
@@ -5,14 +5,15 @@ import { useOrderedRows } from '../use-ordered-rows';
 
 const starWarsCharacters = [
   { name: 'Luke Skywalker', age: 20 },
-  { name: 'Princess Leia Organa', age: 20 },
+  // Lowercased on purpose to test case-sensitivity capabilities
+  { name: 'leia Organa', age: 20 },
   { name: 'Han Solo', age: 25 },
 ];
 
 describe('useOrderedRows', () => {
-  function FakeComponent() {
+  function FakeComponent({ options }) {
     const [order, setOrder] = useState();
-    const orderedRows = useOrderedRows(starWarsCharacters, order);
+    const orderedRows = useOrderedRows(starWarsCharacters, order, options);
 
     return (
       <div>
@@ -56,8 +57,8 @@ describe('useOrderedRows', () => {
     );
   }
 
-  function createComponent() {
-    return mount(<FakeComponent />);
+  function createComponent(options) {
+    return mount(<FakeComponent options={options} />);
   }
 
   function assertDefaultOrder(wrapper) {
@@ -82,15 +83,24 @@ describe('useOrderedRows', () => {
       orderId: 'button-order-by-name-asc',
       expectedRows: [
         { name: 'Han Solo', age: 25 },
+        { name: 'leia Organa', age: 20 },
         { name: 'Luke Skywalker', age: 20 },
-        { name: 'Princess Leia Organa', age: 20 },
+      ],
+    },
+    {
+      orderId: 'button-order-by-name-asc',
+      options: { caseSensitive: true },
+      expectedRows: [
+        { name: 'Han Solo', age: 25 },
+        { name: 'Luke Skywalker', age: 20 },
+        { name: 'leia Organa', age: 20 },
       ],
     },
     {
       orderId: 'button-order-by-name-desc',
       expectedRows: [
-        { name: 'Princess Leia Organa', age: 20 },
         { name: 'Luke Skywalker', age: 20 },
+        { name: 'leia Organa', age: 20 },
         { name: 'Han Solo', age: 25 },
       ],
     },
@@ -98,7 +108,7 @@ describe('useOrderedRows', () => {
       orderId: 'button-order-by-age-asc',
       expectedRows: [
         { name: 'Luke Skywalker', age: 20 },
-        { name: 'Princess Leia Organa', age: 20 },
+        { name: 'leia Organa', age: 20 },
         { name: 'Han Solo', age: 25 },
       ],
     },
@@ -107,12 +117,12 @@ describe('useOrderedRows', () => {
       expectedRows: [
         { name: 'Han Solo', age: 25 },
         { name: 'Luke Skywalker', age: 20 },
-        { name: 'Princess Leia Organa', age: 20 },
+        { name: 'leia Organa', age: 20 },
       ],
     },
-  ].forEach(({ orderId, expectedRows }) => {
+  ].forEach(({ orderId, options, expectedRows }) => {
     it('orders rows based on field and direction', () => {
-      const wrapper = createComponent();
+      const wrapper = createComponent(options);
 
       // Rows are initially not ordered
       assertDefaultOrder(wrapper);

--- a/src/hooks/use-ordered-rows.ts
+++ b/src/hooks/use-ordered-rows.ts
@@ -2,29 +2,44 @@ import { useMemo } from 'preact/hooks';
 
 import type { Order } from '../types';
 
+export type UseOrderedRowsOptions = {
+  /**
+   * Make case-sensitive comparisons for string values.
+   * Defaults to false.
+   */
+  caseSensitive?: boolean;
+};
+
 /**
  * Orders a list of rows based on provided order options.
  * Provided rows are not mutated, but a copy is returned instead.
+ * Values are compared preserving their type.
  */
 export function useOrderedRows<Row>(
   rows: Row[],
   order?: Order<keyof Row>,
+  { caseSensitive = false }: UseOrderedRowsOptions = {},
 ): Row[] {
   return useMemo(() => {
     if (!order) {
       return rows;
     }
 
-    return [...rows].sort((a, b) => {
-      if (a[order.field] === b[order.field]) {
+    return [...rows].sort(({ [order.field]: a }, { [order.field]: b }) => {
+      const aField =
+        !caseSensitive && typeof a === 'string' ? a.toLowerCase() : a;
+      const bField =
+        !caseSensitive && typeof b === 'string' ? b.toLowerCase() : b;
+
+      if (aField === bField) {
         return 0;
       }
 
       if (order.direction === 'ascending') {
-        return a[order.field] > b[order.field] ? 1 : -1;
+        return aField > bField ? 1 : -1;
       }
 
-      return a[order.field] > b[order.field] ? -1 : 1;
+      return aField > bField ? -1 : 1;
     });
-  }, [order, rows]);
+  }, [caseSensitive, order, rows]);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ export { useArrowKeyNavigation } from './hooks/use-arrow-key-navigation';
 export { useClickAway } from './hooks/use-click-away';
 export { useFocusAway } from './hooks/use-focus-away';
 export { useKeyPress } from './hooks/use-key-press';
+export type { UseOrderedRowsOptions } from './hooks/use-ordered-rows';
 export { useOrderedRows } from './hooks/use-ordered-rows';
 export { useStableCallback } from './hooks/use-stable-callback';
 export { useSyncedRef } from './hooks/use-synced-ref';


### PR DESCRIPTION
Add an `options` argument to `useOrderedRows`, which can be used to configure how comparisons are done.

For now this introduces the `caseSensitive` option, which allows consumers to decide if strings should be compared in a case-insensitive or a case-sensitive way.

This option defaults to `false`, changing current behavior, but I consider it was a bug to not do case-insensitive comparisons by default.

Case sensitive comparison:

https://github.com/hypothesis/frontend-shared/assets/2719332/ca872ba9-e095-40ca-854a-504de7512295

Case insensitive comparison (default):

https://github.com/hypothesis/frontend-shared/assets/2719332/ab679132-4b10-484d-8d78-42374b4a54be


