### PR TITLE
Add `Input.error` prop, `useValidateOnSubmit` hook

### DIFF
--- a/src/components/input/Input.tsx
+++ b/src/components/input/Input.tsx
@@ -1,7 +1,9 @@
 import classnames from 'classnames';
 import type { JSX } from 'preact';
 
-import type { PresentationalProps } from '../../types';
+import { useSyncedRef } from '../../hooks/use-synced-ref';
+import { useValidationError } from '../../hooks/use-validation-error';
+import type { FormControlProps, PresentationalProps } from '../../types';
 import { downcastRef } from '../../util/typing';
 import { inputGroupStyles } from './InputGroup';
 
@@ -26,9 +28,8 @@ export function inputStyles({ classes, feedback }: InputStylesOptions) {
   );
 }
 
-type ComponentProps = {
+type ComponentProps = FormControlProps & {
   type?: 'text' | 'email' | 'search' | 'number' | 'password' | 'url';
-  feedback?: 'error' | 'warning';
 };
 
 export type InputProps = PresentationalProps &
@@ -42,6 +43,7 @@ export default function Input({
   elementRef,
   type = 'text',
   classes,
+  error,
   feedback,
 
   ...htmlAttributes
@@ -52,11 +54,21 @@ export default function Input({
     );
   }
 
+  const inputRef = downcastRef<HTMLElement | undefined, HTMLInputElement>(
+    elementRef,
+  );
+  const ref = useSyncedRef<HTMLInputElement>(inputRef);
+
+  if (error) {
+    feedback = 'error';
+  }
+  useValidationError(ref, error);
+
   return (
     <input
       data-component="Input"
       {...htmlAttributes}
-      ref={downcastRef(elementRef)}
+      ref={ref}
       type={type}
       className={inputStyles({ classes, feedback })}
       aria-invalid={feedback === 'error'}

--- a/src/components/input/test/Input-test.js
+++ b/src/components/input/test/Input-test.js
@@ -24,6 +24,26 @@ describe('Input', () => {
   });
 
   [
+    {
+      error: undefined,
+      validationMessage: '',
+      invalid: false,
+    },
+    {
+      error: 'Not a valid URL',
+      validationMessage: 'Not a valid URL',
+      invalid: true,
+    },
+  ].forEach(({ error, validationMessage, invalid }) => {
+    it('should set custom validation error if `error` prop is provided', () => {
+      const wrapper = mount(<Input aria-label="Test" error={error} />);
+      const input = wrapper.find('input');
+      assert.equal(input.getDOMNode().validationMessage, validationMessage);
+      assert.equal(input.prop('aria-invalid'), invalid);
+    });
+  });
+
+  [
     { feedback: undefined, expectedInvalid: false },
     { feedback: 'error', expectedInvalid: true },
     { feedback: 'warning', expectedInvalid: false },

--- a/src/hooks/test/use-validate-on-submit-test.js
+++ b/src/hooks/test/use-validate-on-submit-test.js
@@ -1,0 +1,134 @@
+import { mount } from 'enzyme';
+import { useState, useId } from 'preact/hooks';
+
+import { Input } from '../../components/input';
+import { useValidateOnSubmit } from '../use-validate-on-submit';
+
+// Example of a simple form that uses this hook to implement custom display of
+// validation messages.
+function CustomForm({ onSelectURL }) {
+  const [url, setURL] = useState();
+  const [error, setError] = useState();
+  const errorId = useId();
+
+  const onSubmit = useValidateOnSubmit(() => {
+    onSelectURL(url);
+  });
+
+  const onChangeURL = event => {
+    const url = event.target.value;
+    setURL(undefined);
+
+    try {
+      new URL(url);
+      setError(undefined);
+      setURL(url);
+    } catch {
+      setError('Not a valid URL');
+    }
+  };
+
+  return (
+    <form onSubmit={onSubmit} noValidate>
+      <Input
+        onChange={onChangeURL}
+        required
+        aria-label="URL"
+        aria-describedby={errorId}
+        error={error}
+      />
+      <div id={errorId}>{error}</div>
+      <button type="submit">Submit</button>
+    </form>
+  );
+}
+
+describe('useValidateOnSubmit', () => {
+  function changeURL(form, url) {
+    const input = form.find('input');
+    input.getDOMNode().value = url;
+    input.simulate('change');
+  }
+
+  function submitForm(form) {
+    form.find('form').simulate('submit');
+  }
+
+  it('should invoke callback if form has no errors', () => {
+    const onSelectURL = sinon.stub();
+    const form = mount(<CustomForm onSelectURL={onSelectURL} />);
+    changeURL(form, 'https://example.com');
+    submitForm(form);
+    assert.calledWith(onSelectURL, 'https://example.com');
+  });
+
+  it('should invoke change event for empty, required inputs', () => {
+    const onSelectURL = sinon.stub();
+    const form = mount(<CustomForm onSelectURL={onSelectURL} />);
+    const input = form.find('input');
+    const onChange = sinon.stub();
+    input.getDOMNode().addEventListener('change', onChange);
+
+    submitForm(form);
+
+    assert.notCalled(onSelectURL);
+    assert.calledOnce(onChange);
+  });
+
+  it('should not invoke callback if form has errors', () => {
+    const onSelectURL = sinon.stub();
+    const form = mount(<CustomForm onSelectURL={onSelectURL} />);
+    changeURL(form, 'not valid');
+    submitForm(form);
+    assert.notCalled(onSelectURL);
+  });
+
+  it('should focus first input with an error', () => {
+    const onSelectURL = sinon.stub();
+    const form = mount(<CustomForm onSelectURL={onSelectURL} />);
+    changeURL(form, 'not valid');
+
+    const input = form.find('input').getDOMNode();
+    const focusStub = sinon.stub(input, 'focus');
+    submitForm(form);
+
+    assert.calledOnce(focusStub);
+  });
+
+  // Create a fake `Event` for which we can control the `target` property.
+  // We do this in order to call the event handler directly, rather than
+  // using `target.dispatchEvent`. This makes catching the exception easier.
+  function createFakeEvent({ type, target }) {
+    return { type, target, preventDefault: sinon.stub() };
+  }
+
+  it('should throw if handler received non-"submit" event', () => {
+    function InvalidUsage() {
+      const onSubmit = useValidateOnSubmit(() => {});
+
+      // eslint-disable-next-line
+      return <form onClick={onSubmit} />;
+    }
+    const wrapper = mount(<InvalidUsage />);
+    assert.throws(() => {
+      const formEl = wrapper.find('form').getDOMNode();
+      const event = createFakeEvent({ type: 'click', target: formEl });
+      wrapper.find('form').prop('onClick')(event);
+    }, 'Event type is not "submit"');
+  });
+
+  it('should throw if handler is not a form', () => {
+    function InvalidUsage() {
+      const onSubmit = useValidateOnSubmit(() => {});
+
+      // eslint-disable-next-line
+      return <button onSubmit={onSubmit} type="button" />;
+    }
+    const wrapper = mount(<InvalidUsage />);
+    assert.throws(() => {
+      const buttonEl = wrapper.find('button').getDOMNode();
+      const event = createFakeEvent({ type: 'submit', target: buttonEl });
+      wrapper.find('button').prop('onSubmit')(event);
+    }, 'Event target is not a form');
+  });
+});

--- a/src/hooks/use-validate-on-submit.ts
+++ b/src/hooks/use-validate-on-submit.ts
@@ -1,0 +1,71 @@
+/**
+ * Return a form "submit" event handler that validates the form using
+ * {@link HTMLFormElement.checkValidity}.
+ *
+ * If the check passes, `onValid` is invoked. Otherwise the first control in
+ * {@link HTMLFormElement.elements} with an error is focused. This will allow
+ * the user to correct the error, and also cause screen readers to announce
+ * the current validation state and errors.
+ *
+ * This hook is useful for forms which want to display a custom presentation
+ * of validation errors. Forms using the browser's built-in validation error
+ * display do not need to use this.
+ *
+ * To show custom validation errors, the consumer should:
+ *
+ * - Ensure that all input controls validate their input on "change" events.
+ * - Ensure that validation errors are displayed for each control.  The input
+ *   fields must link their validation errors using `aria-describedby` and
+ *   indicate their state using `aria-invalid`.
+ * - Set the `noValidate` property on the `<form>` to disable the native
+ *   validation UI message
+ * - Call this hook to create a "submit" event handler and pass it to
+ *   the form's `submit` prop.
+ *
+ * See also https://react-spectrum.adobe.com/react-aria/forms.html.
+ */
+export function useValidateOnSubmit(
+  onValid: () => void,
+): (e: SubmitEvent) => void {
+  const onSubmit = (event: SubmitEvent) => {
+    if (event.type !== 'submit') {
+      throw new Error('Event type is not "submit"');
+    }
+    const formEl = event.target;
+    if (!(formEl instanceof HTMLFormElement)) {
+      throw new Error('Event target is not a form');
+    }
+
+    event.preventDefault();
+
+    if (formEl.checkValidity()) {
+      onValid();
+    } else {
+      // Focus first field wth an error if invalid. This matches the behavior
+      // of native form validation, allowing the user to correct the error
+      // and also announcing the problem to screen reader users.
+      let foundFirst = false;
+      for (const el of Array.from(formEl.elements) as Array<
+        HTMLElement | HTMLInputElement
+      >) {
+        if (!('validity' in el) || el.validity.valid) {
+          continue;
+        }
+
+        if (!foundFirst) {
+          el.focus();
+          foundFirst = true;
+        }
+
+        // If the user has focused an empty, required input field and
+        // triggered a submission by pressing Enter, that will not trigger
+        // a "change" event. Trigger this event to allow the input's "change"
+        // handler to update its custom error.
+        if (el.validity.valueMissing) {
+          el.dispatchEvent(new Event('change'));
+        }
+      }
+    }
+  };
+  return onSubmit;
+}

--- a/src/hooks/use-validation-error.ts
+++ b/src/hooks/use-validation-error.ts
@@ -1,0 +1,25 @@
+import type { RefObject } from 'preact';
+import { useLayoutEffect } from 'preact/hooks';
+
+export type InputLike = {
+  setCustomValidity(message: string): void;
+};
+
+/**
+ * Sync custom validation error messages to the browser's native validation
+ * state.
+ *
+ * @param ref - An `HTMLInputElement` or other element that supports the
+ *   Constraint Validation API
+ * @param error - The current error or undefined if the field input is valid
+ */
+export function useValidationError(
+  ref: RefObject<InputLike | undefined>,
+  error?: string,
+) {
+  // Sync errors to native form validation API. This will prevent submission
+  // of the form until the error is resolved.
+  useLayoutEffect(() => {
+    ref.current?.setCustomValidity(error ?? '');
+  }, [error, ref]);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ export { useOrderedRows } from './hooks/use-ordered-rows';
 export { useStableCallback } from './hooks/use-stable-callback';
 export { useSyncedRef } from './hooks/use-synced-ref';
 export { useToastMessages } from './hooks/use-toast-messages';
+export { useValidateOnSubmit } from './hooks/use-validate-on-submit';
 export type {
   ToastMessagesState,
   ToastMessageData,

--- a/src/pattern-library/components/patterns/input/InputPage.tsx
+++ b/src/pattern-library/components/patterns/input/InputPage.tsx
@@ -29,7 +29,7 @@ export default function InputPage() {
         </Library.Pattern>
 
         <Library.Pattern title="Working with Inputs">
-          <Library.Example title="Accessibility">
+          <Library.Example title="Labels">
             <p>
               Hypothesis does not currently have a design pattern for labeling
               text inputs. However, for accessibility, it is critical that an{' '}
@@ -61,6 +61,26 @@ export default function InputPage() {
               </div>
             </Library.Demo>
           </Library.Example>
+          <Library.Example title="Validation errors">
+            <p>
+              Validation errors can be triggered as a result of standard HTML
+              attributes such as <code>required</code> or a custom error set
+              using the <code>error</code> prop. Errors set using{' '}
+              <code>error</code> are synced to the browser via{' '}
+              <code>HTMLInputElement.setCustomValidity</code>. This allows the
+              browser to alert the user when they try to submit the containing
+              form.
+            </p>
+            <p>
+              If the input has custom validation checks, they should be
+              performed in the element&apos;s <code>onChange</code> handler.
+            </p>
+            <p>
+              If the form is using custom UI to present validation errors,
+              inputs must link to the element displaying their validation error
+              using <code>aria-describedby</code>.
+            </p>
+          </Library.Example>
         </Library.Pattern>
 
         <Library.Pattern title="Component API">
@@ -69,6 +89,23 @@ export default function InputPage() {
             presentational component props
           </Library.Link>
           .
+          <Library.Example title="error">
+            <Library.Info>
+              <Library.InfoItem label="description">
+                Set <code>error</code> to indicate a validation error. This
+                implicitly sets{' '}
+                <code>
+                  feedback={'"'}error{'"'}
+                </code>
+                . In addition to visually and semantically indicating the error
+                state, this will set a custom validation error on the input
+                using <code>HTMLInputElement.setCustomValidity</code>.
+              </Library.InfoItem>
+              <Library.InfoItem label="type">
+                <code>string</code>
+              </Library.InfoItem>
+            </Library.Info>
+          </Library.Example>
           <Library.Example title="feedback">
             <Library.Info>
               <Library.InfoItem label="description">

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,6 +12,30 @@ export type PresentationalProps = {
 };
 
 /**
+ * Common props for form controls.
+ */
+export type FormControlProps = {
+  /**
+   * The current validation error.
+   *
+   * If set, this will override `feedback` and set it to `error`. The validation
+   * error will be synced to the browser's native validation state via
+   * {@link HTMLInputElement.setCustomValidity}. This will prevent submission
+   * of the containing form.
+   */
+  error?: string;
+
+  /**
+   * Set the visual and semantic state (`aria-invalid`) of the control to
+   * indicate an error.
+   *
+   * Unlike {@link FormControlProps.error} this does not set a native validation
+   * error and as such, it won't prevent a containing form from being submitted.
+   */
+  feedback?: 'error' | 'warning';
+};
+
+/**
  * Props common to components that are opinionated compositions of other
  * components.
  */


### PR DESCRIPTION
This PR adds a couple of APIs designed to make handling custom validation errors and custom presentation of validation errors easier:

- The new `Input.error` prop specifies an error message that is synced to the underlying `<input>` DOM element using `HTMLInputElement.setCustomValidity`. This in turn will prevent submission of any containing form which has validation checks enabled (the default).
- For forms which want to control presentation of validation error messages, the new `useValidateOnSubmit` hook can be used together with a form's `noValidate` property. This hook implements the parts of native validation that are still useful when validation errors are presented in a custom way: checking the validation status using `HTMLFormElement.checkValidity` and focusing the first control with an error

See the tests for `useValidateOnSubmit` for a worked example of a simple form using both of these.

I plan to use these new changes downstream to resolve https://github.com/hypothesis/product-backlog/issues/1535. This PR only applies the change for `Input` components, but the same change should be applied to `Select` and `Textarea` in future.