### PR TITLE
Set full height to orderable table header buttons

### DIFF
--- a/src/components/data/DataTable.tsx
+++ b/src/components/data/DataTable.tsx
@@ -118,7 +118,7 @@ function HeaderComponent({ children, onClick, field }: HeaderComponentProps) {
   const commonClasses = 'flex justify-between items-center';
   return onClick ? (
     <Button
-      classes={`${commonClasses} w-full !p-3`}
+      classes={`${commonClasses} w-full h-full !p-3`}
       variant="custom"
       onClick={onClick}
       data-testid={`${field}-order-button`}


### PR DESCRIPTION
While testing the students table in LMS's dashboard, I realized the header was sometimes not fully "clickable" close to the cell edges.

After a bit of investigation I have realized that, depending on the site's font size, the button which is rendering the order icon can be slightly taller than the rest of buttons, causing this issue.

That is not reproducible in this page, but it is in LMS, due to the smaller base font size.

https://github.com/hypothesis/frontend-shared/assets/2719332/27d4dd96-59fa-485f-927c-b26a89d743be

This PR adds `h-full` to the header buttons, to make sure they all span to the height of the taller one.