### PR TITLE
Add popover capabilities to SelectNext listbox

### DIFF
--- a/src/components/input/SelectNext.tsx
+++ b/src/components/input/SelectNext.tsx
@@ -5,6 +5,7 @@ import {
   useContext,
   useId,
   useLayoutEffect,
+  useMemo,
   useRef,
   useState,
 } from 'preact/hooks';
@@ -15,6 +16,7 @@ import { useFocusAway } from '../../hooks/use-focus-away';
 import { useKeyPress } from '../../hooks/use-key-press';
 import { useSyncedRef } from '../../hooks/use-synced-ref';
 import type { CompositeProps } from '../../types';
+import { ListenerCollection } from '../../util/listener-collection';
 import { downcastRef } from '../../util/typing';
 import { MenuCollapseIcon, MenuExpandIcon } from '../icons';
 import { inputGroupStyles } from './InputGroup';
@@ -103,38 +105,115 @@ function SelectOption<T>({
 
 SelectOption.displayName = 'SelectNext.Option';
 
-function useShouldDropUp(
+/** Small space to apply between the toggle button and the listbox */
+const LISTBOX_TOGGLE_GAP = '.25rem';
+
+type ListboxCSSProps =
+  | 'top'
+  | 'left'
+  | 'minWidth'
+  | 'marginBottom'
+  | 'bottom'
+  | 'marginTop';
+
+/**
+ * Manages the listbox position manually to make sure it renders "next" to the
+ * toggle button (below or over). This is mainly needed when the listbox is used
+ * as a popover, as that makes it render in the top layer, making it impossible
+ * to position it relative to the toggle button via regular CSS.
+ */
+function useListboxPositioning(
   buttonRef: RefObject<HTMLElement | undefined>,
   listboxRef: RefObject<HTMLElement | null>,
   listboxOpen: boolean,
-): boolean {
-  const [shouldListboxDropUp, setShouldListboxDropUp] = useState(false);
+  asPopover: boolean,
+  right: boolean,
+) {
+  const adjustListboxPositioning = useCallback(() => {
+    const listboxEl = listboxRef.current;
+    const buttonEl = buttonRef.current;
 
-  useLayoutEffect(() => {
-    // Reset shouldListboxDropUp so that it does not affect calculations next
-    // time listbox opens
-    if (!buttonRef.current || !listboxRef.current || !listboxOpen) {
-      setShouldListboxDropUp(false);
-      return;
+    if (!buttonEl || !listboxEl || !listboxOpen) {
+      return () => {};
     }
 
+    /**
+     * We need to set the positioning styles synchronously (not via `style`
+     * prop and a piece of state), to make sure positioning happens before
+     * `useArrowKeyNavigation` runs, focusing the first option in the listbox.
+     */
+    const setListboxCSSProps = (
+      props: Partial<Record<ListboxCSSProps, string>>,
+    ) => {
+      Object.assign(listboxEl.style, props);
+      const keys = Object.keys(props) as ListboxCSSProps[];
+      return () => keys.map(prop => (listboxEl.style[prop] = ''));
+    };
+
     const viewportHeight = window.innerHeight;
-    const { top: buttonDistanceToTop, bottom: buttonBottom } =
-      buttonRef.current.getBoundingClientRect();
+    const {
+      top: buttonDistanceToTop,
+      bottom: buttonBottom,
+      left: buttonLeft,
+      height: buttonHeight,
+      width: buttonWidth,
+    } = buttonEl.getBoundingClientRect();
     const buttonDistanceToBottom = viewportHeight - buttonBottom;
-    const { bottom: listboxBottom } =
-      listboxRef.current.getBoundingClientRect();
-    const listboxDistanceToBottom = viewportHeight - listboxBottom;
+    const { height: listboxHeight, width: listboxWidth } =
+      listboxEl.getBoundingClientRect();
 
     // The listbox should drop up only if there's not enough space below to
-    // fit it, and there's also more absolute space above than below
-    setShouldListboxDropUp(
-      listboxDistanceToBottom < 0 &&
-        buttonDistanceToTop > buttonDistanceToBottom,
-    );
-  }, [buttonRef, listboxRef, listboxOpen]);
+    // fit it, and also, there's more absolute space above than below
+    const shouldListboxDropUp =
+      buttonDistanceToBottom < listboxHeight &&
+      buttonDistanceToTop > buttonDistanceToBottom;
 
-  return shouldListboxDropUp;
+    if (asPopover) {
+      const { top: bodyTop } = document.body.getBoundingClientRect();
+      const absBodyTop = Math.abs(bodyTop);
+
+      return setListboxCSSProps({
+        minWidth: `${buttonWidth}px`,
+        top: shouldListboxDropUp
+          ? `calc(${absBodyTop + buttonDistanceToTop - listboxHeight}px - ${LISTBOX_TOGGLE_GAP})`
+          : `calc(${absBodyTop + buttonDistanceToTop + buttonHeight}px + ${LISTBOX_TOGGLE_GAP})`,
+        left:
+          right && listboxWidth > buttonWidth
+            ? `${buttonLeft - (listboxWidth - buttonWidth)}px`
+            : `${buttonLeft}px`,
+      });
+    }
+
+    // Set styles for non-popover mode
+    if (shouldListboxDropUp) {
+      return setListboxCSSProps({
+        bottom: '100%',
+        marginBottom: LISTBOX_TOGGLE_GAP,
+      });
+    }
+
+    return setListboxCSSProps({ top: '100%', marginTop: LISTBOX_TOGGLE_GAP });
+  }, [asPopover, buttonRef, listboxOpen, listboxRef, right]);
+
+  useLayoutEffect(() => {
+    const cleanup = adjustListboxPositioning();
+
+    if (!asPopover) {
+      return cleanup;
+    }
+
+    // Readjust listbox position when any element scrolls, just in case that
+    // affected the toggle button position.
+    const listeners = new ListenerCollection();
+    listeners.add(document.body, 'scroll', adjustListboxPositioning, {
+      capture: true,
+    });
+
+    return () => {
+      cleanup();
+      listeners.removeAll();
+    };
+  }, [adjustListboxPositioning, asPopover]);
 }
 
 export type SelectProps<T> = CompositeProps & {
@@ -166,6 +245,12 @@ export type SelectProps<T> = CompositeProps & {
 
   'aria-label'?: string;
   'aria-labelledby'?: string;
+
+  /**
+   * Used to determine if the listbox should use the popover API.
+   * Defaults to true, as long as the browser supports it.
+   */
+  listboxAsPopover?: boolean;
 };
 
 function SelectMain<T>({
@@ -182,18 +267,36 @@ function SelectMain<T>({
   right = false,
   'aria-label': ariaLabel,
   'aria-labelledby': ariaLabelledBy,
+  /* eslint-disable-next-line no-prototype-builtins */
+  listboxAsPopover = HTMLElement.prototype.hasOwnProperty('popover'),
 }: SelectProps<T>) {
-  const [listboxOpen, setListboxOpen] = useState(false);
-  const closeListbox = useCallback(() => setListboxOpen(false), []);
   const wrapperRef = useRef<HTMLDivElement | null>(null);
   const listboxRef = useRef<HTMLUListElement | null>(null);
+  const [listboxOpen, setListboxOpen] = useState(false);
+  const toggleListbox = useCallback(
+    (open: boolean) => {
+      setListboxOpen(open);
+      if (listboxAsPopover) {
+        listboxRef.current?.togglePopover(open);
+      }
+    },
+    [listboxAsPopover],
+  );
+  const closeListbox = useCallback(() => toggleListbox(false), [toggleListbox]);
   const listboxId = useId();
   const buttonRef = useSyncedRef(elementRef);
   const defaultButtonId = useId();
-  const shouldListboxDropUp = useShouldDropUp(
+  const extraProps = useMemo(
+    () => (listboxAsPopover ? { popover: true } : {}),
+    [listboxAsPopover],
+  );
+
+  useListboxPositioning(
     buttonRef,
     listboxRef,
     listboxOpen,
+    listboxAsPopover,
+    right,
   );
 
   const selectValue = useCallback(
@@ -257,11 +360,11 @@ function SelectMain<T>({
         aria-label={ariaLabel}
         aria-labelledby={ariaLabelledBy}
         ref={downcastRef(buttonRef)}
-        onClick={() => setListboxOpen(prev => !prev)}
+        onClick={() => toggleListbox(!listboxOpen)}
         onKeyDown={e => {
           if (e.key === 'ArrowDown' && !listboxOpen) {
             e.preventDefault();
-            setListboxOpen(true);
+            toggleListbox(true);
           }
         }}
         data-testid="select-toggle-button"
@@ -273,18 +376,17 @@ function SelectMain<T>({
       </button>
       <SelectContext.Provider value={{ selectValue, value }}>
         <ul
+          {...extraProps}
           className={classnames(
-            'absolute z-5 min-w-full max-h-80 overflow-y-auto',
+            'absolute z-5 max-h-80 overflow-y-auto',
             'rounded border bg-white shadow hover:shadow-md focus-within:shadow-md',
-            {
-              'top-full mt-1': !shouldListboxDropUp,
-              'bottom-full mb-1': shouldListboxDropUp,
-              'right-0': right,
-
+            !listboxAsPopover && {
               // Hiding instead of unmounting to
               // * Ensure screen readers detect button as a listbox handler
               // * Listbox size can be computed to correctly drop up or down
               hidden: !listboxOpen,
+              'right-0': right,
+              'min-w-full': true,
             },
             listboxClasses,
           )}
@@ -294,6 +396,7 @@ function SelectMain<T>({
           aria-labelledby={buttonId ?? defaultButtonId}
           aria-orientation="vertical"
           data-testid="select-listbox"
+          data-listbox-open={listboxOpen}
         >
           {children}
         </ul>

--- a/src/components/input/test/SelectNext-test.js
+++ b/src/components/input/test/SelectNext-test.js
@@ -1,4 +1,4 @@
-import { checkAccessibility } from '@hypothesis/frontend-testing';
+import { checkAccessibility, waitFor } from '@hypothesis/frontend-testing';
 import { mount } from 'enzyme';
 
 import SelectNext from '../SelectNext';
@@ -21,12 +21,25 @@ describe('SelectNext', () => {
    *        Whether to renders SelectNext.Option children with callback notation.
    *        Used primarily to test and cover both branches.
    *        Defaults to true.
+   * @param {boolean} [options.defaultListboxAsPopover] -
+   *        Whether we should let the `listboxAsPopover` prop use default value
+   *        if not explicitly provided, or we should initialize it instead.
    */
   const createComponent = (props = {}, options = {}) => {
-    const { paddingTop = 0, optionsChildrenAsCallback = true } = options;
+    const {
+      paddingTop = 0,
+      optionsChildrenAsCallback = true,
+      defaultListboxAsPopover = false,
+    } = options;
     const container = document.createElement('div');
     container.style.paddingTop = `${paddingTop}px`;
     document.body.append(container);
+
+    // Explicitly disable listboxAsPopover, unless requested differently or a
+    // value has been provided
+    if (!defaultListboxAsPopover && !('listboxAsPopover' in props)) {
+      props.listboxAsPopover = false;
+    }
 
     const wrapper = mount(
       <SelectNext value={undefined} onChange={sinon.stub()} {...props}>
@@ -74,10 +87,18 @@ describe('SelectNext', () => {
   const getListbox = wrapper => wrapper.find('[data-testid="select-listbox"]');
 
   const isListboxClosed = wrapper =>
-    getListbox(wrapper).prop('className').includes('hidden');
+    getListbox(wrapper).prop('data-listbox-open') === false;
 
-  const listboxDidDropUp = wrapper =>
-    getListbox(wrapper).prop('className').includes('bottom-full');
+  const listboxDidDropUp = wrapper => {
+    const { top: listboxTop } = getListbox(wrapper)
+      .getDOMNode()
+      .getBoundingClientRect();
+    const { top: buttonTop } = getToggleButton(wrapper)
+      .getDOMNode()
+      .getBoundingClientRect();
+
+    return listboxTop < buttonTop;
+  };
 
   it('changes selected value when an option is clicked', () => {
     const onChange = sinon.stub();
@@ -261,11 +282,32 @@ describe('SelectNext', () => {
   });
 
   [
-    { containerPaddingTop: 0, shouldDropUp: false },
-    { containerPaddingTop: 1000, shouldDropUp: true },
-  ].forEach(({ containerPaddingTop, shouldDropUp }) => {
+    {
+      containerPaddingTop: 0,
+      shouldDropUp: false,
+      listboxAsPopover: true,
+    },
+    {
+      containerPaddingTop: 0,
+      shouldDropUp: false,
+      listboxAsPopover: false,
+    },
+    {
+      containerPaddingTop: 1000,
+      shouldDropUp: true,
+      listboxAsPopover: true,
+    },
+    {
+      containerPaddingTop: 1000,
+      shouldDropUp: true,
+      listboxAsPopover: false,
+    },
+  ].forEach(({ containerPaddingTop, shouldDropUp, listboxAsPopover }) => {
     it('makes listbox drop up or down based on available space below', () => {
-      const wrapper = createComponent({}, { paddingTop: containerPaddingTop });
+      const wrapper = createComponent(
+        { listboxAsPopover },
+        { paddingTop: containerPaddingTop },
+      );
       toggleListbox(wrapper);
 
       assert.equal(listboxDidDropUp(wrapper), shouldDropUp);
@@ -279,6 +321,74 @@ describe('SelectNext', () => {
           mount(<SelectNext.Option value="1">{() => '1'}</SelectNext.Option>),
         'Select.Option can only be used as Select child',
       );
+    });
+  });
+
+  context('when popover is supported', () => {
+    it('opens listbox via popover API', async () => {
+      const wrapper = createComponent({ listboxAsPopover: true });
+      let resolve;
+      const promise = new Promise(res => (resolve = res));
+
+      getListbox(wrapper).getDOMNode().addEventListener('toggle', resolve);
+      toggleListbox(wrapper);
+
+      // This test will timeout if the toggle event is not dispatched
+      await promise;
+    });
+  });
+
+  context('when listbox is bigger than toggle button', () => {
+    [
+      // Inferring listboxAsPopover based on browser support
+      {
+        listboxAsPopover: 'default',
+        getListboxLeft: wrapper => {
+          const leftStyle = getListbox(wrapper).getDOMNode().style.left;
+          // Remove `px` unit indicator
+          return Number(leftStyle.replace('px', ''));
+        },
+      },
+      // Explicitly enabling listboxAsPopover
+      {
+        listboxAsPopover: true,
+        getListboxLeft: wrapper => {
+          const leftStyle = getListbox(wrapper).getDOMNode().style.left;
+          // Remove `px` unit indicator
+          return Number(leftStyle.replace('px', ''));
+        },
+      },
+      // Explicitly disabling listboxAsPopover
+      {
+        listboxAsPopover: false,
+        getListboxLeft: wrapper =>
+          getListbox(wrapper).getDOMNode().getBoundingClientRect().left,
+      },
+    ].forEach(({ listboxAsPopover, getListboxLeft }) => {
+      it('aligns listbox to the right if `right` prop is true', async () => {
+        const wrapper = createComponent(
+          {
+            listboxAsPopover:
+              typeof listboxAsPopover === 'boolean'
+                ? listboxAsPopover
+                : undefined,
+            right: true,
+            buttonClasses: '!w-8', // Set a small width in the button
+          },
+          { defaultListboxAsPopover: listboxAsPopover === 'default' },
+        );
+        toggleListbox(wrapper);
+
+        // Wait for listbox to be open
+        await waitFor(() => !isListboxClosed(wrapper));
+
+        const { left: buttonLeft } = getToggleButton(wrapper)
+          .getDOMNode()
+          .getBoundingClientRect();
+        const listboxLeft = getListboxLeft(wrapper);
+
+        assert.isTrue(listboxLeft < buttonLeft);
+      });
     });
   });
 

--- a/src/pattern-library/components/patterns/prototype/SelectNextPage.tsx
+++ b/src/pattern-library/components/patterns/prototype/SelectNextPage.tsx
@@ -1,6 +1,7 @@
 import classnames from 'classnames';
 import { useCallback, useId, useMemo, useState } from 'preact/hooks';
 
+import { Link } from '../../../..';
 import { ArrowLeftIcon, ArrowRightIcon } from '../../../../components/icons';
 import type { SelectNextProps } from '../../../../components/input';
 import { IconButton, InputGroup } from '../../../../components/input';
@@ -35,6 +36,7 @@ function SelectExample({
   | 'listboxClasses'
   | 'disabled'
   | 'right'
+  | 'listboxAsPopover'
 > & {
   textOnly?: boolean;
   items?: ItemType[];
@@ -205,6 +207,23 @@ export default function SelectNextPage() {
           <p>
             <code>SelectNext</code> toggles a listbox where <code>Options</code>
             {"'"} UI can be customized and values can be objects.
+          </p>
+          <p>
+            In browsers that support it, the listbox uses the{' '}
+            <Link
+              target="_blank"
+              href="https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/popover"
+            >
+              <code>popover</code>
+            </Link>{' '}
+            attribute and gets toggled via{' '}
+            <Link
+              target="_blank"
+              href="https://developer.mozilla.org/en-US/docs/Web/API/Popover_API"
+            >
+              popover API
+            </Link>
+            . Otherwise, it is rendered as an absolute-positioned element.
           </p>
 
           <Library.Example title="Composing and styling Selects">
@@ -466,6 +485,39 @@ export default function SelectNextPage() {
             <Library.Demo title="Custom listbox">
               <div className="w-96 mx-auto">
                 <SelectExample listboxClasses="border-4 border-yellow-notice" />
+              </div>
+            </Library.Demo>
+          </Library.Example>
+          <Library.Example title="listboxAsPopover">
+            <Library.Info>
+              <Library.InfoItem label="description">
+                Determines if the listbox should be rendered using the{' '}
+                <Link
+                  target="_blank"
+                  href="https://developer.mozilla.org/en-US/docs/Web/API/Popover_API"
+                >
+                  popover API
+                </Link>
+                . It{"'"}s mainly used as a test seam, but can help explicitly
+                disabling this behavior if needed.
+              </Library.InfoItem>
+              <Library.InfoItem label="type">
+                <code>boolean</code>
+              </Library.InfoItem>
+              <Library.InfoItem label="default">
+                <code>true</code> if the browser supports <code>[popover]</code>
+                . Otherwise it is <code>false</code>
+              </Library.InfoItem>
+            </Library.Info>
+            <Library.Demo title="Non-popover listbox">
+              <div className="w-full">
+                <p>
+                  When not using the <code>popover</code> API, the listbox will
+                  be constrained by its container dimensions.
+                </p>
+                <div className="w-96 h-32 mx-auto overflow-auto">
+                  <SelectExample listboxAsPopover={false} />
+                </div>
               </div>
             </Library.Demo>
           </Library.Example>


### PR DESCRIPTION
Depends on https://github.com/hypothesis/frontend-shared/pull/1548

Add `popover` attribute to the `SelectNext` listbox, and open it via `element.togglePopover()` when the browser supports it.

For browsers not supporting the native popover, we continue to handle it as before.

### TODO

- [x] Test with a screen reader, making sure the use of `[popover]` does not have any side effects on how components are announced.
- [x] Add/fix tests
- [x] Update documentation mentioning the popover behavior of the listbox in browsers that support it.

### Considerations

- Adding the `popover` attribute to the listbox makes it render in the top layer, and therefore, it is no longer positioned relative to the toggle button.
    Because of that, we have to manually calculate where should it be based on some heuristics, and absolutely position it there.
- ~Related with the point above, and because of how `useArrowKeyNavigation` internally works, I had to disable the automatic option focusing that `useArrowKeyNavigation` provides, and add an extra `toggle` event listener that mimics that logic.~
   **EDIT:** This has been solved. See https://github.com/hypothesis/frontend-shared/pull/1540#issuecomment-2100546401
- ~Another side effect of rendering the listbox in the top layer, is that it won't be affected by scrolling on inner elements.~
    ~**EDIT:** This is now mitigated via `listboxAsPopover` prop. With that we can keep the listbox as is, and enable the "popover mode" only when really needed.~
    **EDIT 2:** Finally we are capturing the scroll event and re-adjust the listbox positioning dynamically.
- At some point, I considered creating a new `Popover` component, that can be used in other places, but this is complex enough, without having to think in more abstractions. I will delay that to after this PR has been merged, and we have at least other use case for a popover.