### PR TITLE
Add API reference documentation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,8 @@ FROM node:19.8.1-alpine as builder
 COPY . /frontend-shared
 RUN cd /frontend-shared && \
     yarn install --frozen-lockfile && \
-    yarn build-pattern-lib
+    yarn build-pattern-lib && \
+    yarn apidoc
 
 
 FROM nginx:1.24.0-alpine

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "sinon": "^17.0.0",
     "svgo": "^3.0.0",
     "tailwindcss": "3.4.3",
+    "typedoc": "^0.25.13",
     "typescript": "^5.0.2",
     "yalc": "^1.0.0-pre.50"
   },
@@ -61,6 +62,7 @@
     "preact": "^10.4.0"
   },
   "scripts": {
+    "apidoc": "typedoc --out build/api --tsconfig src/tsconfig.json src/index.ts",
     "build-lib": "babel src/ --out-dir lib/ --extensions '.js,.ts,.tsx' --source-maps --ignore '**/test' --ignore '**/karma.config.js'",
     "build": "yarn build-lib && tsc --build src/tsconfig.json",
     "build-pattern-lib": "yarn gulp bundle-css && yarn rollup -c rollup.config.js",

--- a/scripts/generate-icons.js
+++ b/scripts/generate-icons.js
@@ -61,12 +61,10 @@ function generateIcon(name, src, inputFileName) {
 ${AUTO_GENERATED_COMMENT}
 import type { JSX } from 'preact';
 
-export type ${name}Props = JSX.SVGAttributes<SVGSVGElement>;
-
 /**
  * Icon generated from ${inputFileName}
  */
-export default function ${name}(props:${name}Props) {
+export default function ${name}(props: JSX.SVGAttributes<SVGSVGElement>) {
   return ${content};
 }
 `;

--- a/scripts/serve-pattern-library.js
+++ b/scripts/serve-pattern-library.js
@@ -8,6 +8,7 @@ export function servePatternLibrary(port = 4001) {
   const app = express();
 
   // Map paths from which we serve static files
+  app.use('/api', express.static(path.join(dirname, '../build/api')));
   app.use('/scripts', express.static(path.join(dirname, '../build/scripts')));
   app.use('/styles', express.static(path.join(dirname, '../build/styles')));
   app.use('/images', express.static(path.join(dirname, '../images')));

--- a/src/components/data/DataTable.tsx
+++ b/src/components/data/DataTable.tsx
@@ -23,73 +23,68 @@ export type TableColumn<Field> = {
   classes?: string;
 };
 
-type ComponentProps<Row> = Pick<
-  TableProps,
-  'borderless' | 'title' | 'striped' | 'grid'
-> & {
-  rows: Row[];
-  columns: TableColumn<keyof Row>[];
-
-  /** Content to render if rows is empty (and not in a loading state) */
-  emptyMessage?: ComponentChildren;
-  loading?: boolean;
-  selectedRow?: Row | null;
-
-  /**
-   * Callback when a row is "selected" by click or key press.
-   *
-   * If using multi-selection (see {@link ComponentProps.selectedRows}) this
-   * will be passed only the most recently selected row. Use
-   * {@link ComponentProps.onSelectRows} to receive the full selection.
-   */
-  onSelectRow?: (r: Row) => void;
-
-  /**
-   * Selected rows. If this property is set it enables multi-selection. The
-   * user will be able to select a contiguous range of rows via shift+click or
-   * shift + arrow keys.
-   */
-  selectedRows?: Row[];
-
-  /**
-   * Callback when rows are selected by click or key press.
-   *
-   * If multi-selection is enabled, this may have multiple entries (see
-   * {@link ComponentProps.selectedRows} otherwise it will have one entry.
-   */
-  onSelectRows?: (r: Row[]) => void;
-
-  /**
-   * Callback when a row is "confirmed" by double-click or pressing "Enter"
-   */
-  onConfirmRow?: (r: Row) => void;
-
-  /** Current sort order */
-  order?: Order<keyof Row>;
-
-  /**
-   * Callback invoked when user clicks a column header to change the sort order.
-   * When a header is clicked, if that's not the active order, it is set with
-   * order='ascending'.
-   * If the active header is clicked consecutively, direction toggles between
-   * 'ascending' and 'descending'.
-   */
-  onOrderChange?: (order: Order<keyof Row>) => void;
-
-  /**
-   * Columns that can be used to order the table. Ignored if `onOrderChange` is
-   * not provided.
-   * No columns will be orderable if this is not provided.
-   */
-  orderableColumns?: Array<keyof Row>;
-
-  /** Callback to render an individual table cell */
-  renderItem?: (r: Row, field: keyof Row) => ComponentChildren;
-};
-
 export type DataTableProps<Row> = CompositeProps &
-  ComponentProps<Row> &
-  Omit<JSX.HTMLAttributes<HTMLElement>, 'size' | 'rows' | 'role' | 'loading'>;
+  Omit<JSX.HTMLAttributes<HTMLElement>, 'size' | 'rows' | 'role' | 'loading'> &
+  Pick<TableProps, 'borderless' | 'title' | 'striped' | 'grid'> & {
+    rows: Row[];
+    columns: TableColumn<keyof Row>[];
+
+    /** Content to render if rows is empty (and not in a loading state) */
+    emptyMessage?: ComponentChildren;
+    loading?: boolean;
+    selectedRow?: Row | null;
+
+    /**
+     * Callback when a row is "selected" by click or key press.
+     *
+     * If using multi-selection (see {@link DataTableProps.selectedRows}) this
+     * will be passed only the most recently selected row. Use
+     * {@link DataTableProps.onSelectRows} to receive the full selection.
+     */
+    onSelectRow?: (r: Row) => void;
+
+    /**
+     * Selected rows. If this property is set it enables multi-selection. The
+     * user will be able to select a contiguous range of rows via shift+click or
+     * shift + arrow keys.
+     */
+    selectedRows?: Row[];
+
+    /**
+     * Callback when rows are selected by click or key press.
+     *
+     * If multi-selection is enabled, this may have multiple entries (see
+     * {@link DataTableProps.selectedRows} otherwise it will have one entry.
+     */
+    onSelectRows?: (r: Row[]) => void;
+
+    /**
+     * Callback when a row is "confirmed" by double-click or pressing "Enter"
+     */
+    onConfirmRow?: (r: Row) => void;
+
+    /** Current sort order */
+    order?: Order<keyof Row>;
+
+    /**
+     * Callback invoked when user clicks a column header to change the sort order.
+     * When a header is clicked, if that's not the active order, it is set with
+     * order='ascending'.
+     * If the active header is clicked consecutively, direction toggles between
+     * 'ascending' and 'descending'.
+     */
+    onOrderChange?: (order: Order<keyof Row>) => void;
+
+    /**
+     * Columns that can be used to order the table. Ignored if `onOrderChange` is
+     * not provided.
+     * No columns will be orderable if this is not provided.
+     */
+    orderableColumns?: Array<keyof Row>;
+
+    /** Callback to render an individual table cell */
+    renderItem?: (r: Row, field: keyof Row) => ComponentChildren;
+  };
 
 function defaultRenderItem<Row>(r: Row, field: keyof Row): ComponentChildren {
   return r[field] as ComponentChildren;
@@ -132,6 +127,8 @@ function HeaderComponent({ children, onClick, field }: HeaderComponentProps) {
 
 /**
  * An interactive table of rows and columns with a sticky header.
+ *
+ * @param props
  */
 export default function DataTable<Row>({
   children,

--- a/src/components/icons/Annotate.tsx
+++ b/src/components/icons/Annotate.tsx
@@ -1,12 +1,10 @@
 // This file was auto-generated using scripts/generate-icons.js
 import type { JSX } from 'preact';
 
-export type AnnotateIconProps = JSX.SVGAttributes<SVGSVGElement>;
-
 /**
  * Icon generated from annotate.svg
  */
-export default function AnnotateIcon(props: AnnotateIconProps) {
+export default function AnnotateIcon(props: JSX.SVGAttributes<SVGSVGElement>) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/src/components/icons/AnnotateAlt.tsx
+++ b/src/components/icons/AnnotateAlt.tsx
@@ -1,12 +1,12 @@
 // This file was auto-generated using scripts/generate-icons.js
 import type { JSX } from 'preact';
 
-export type AnnotateAltIconProps = JSX.SVGAttributes<SVGSVGElement>;
-
 /**
  * Icon generated from annotate-alt.svg
  */
-export default function AnnotateAltIcon(props: AnnotateAltIconProps) {
+export default function AnnotateAltIcon(
+  props: JSX.SVGAttributes<SVGSVGElement>,
+) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/src/components/icons/ArrowDown.tsx
+++ b/src/components/icons/ArrowDown.tsx
@@ -1,12 +1,10 @@
 // This file was auto-generated using scripts/generate-icons.js
 import type { JSX } from 'preact';
 
-export type ArrowDownIconProps = JSX.SVGAttributes<SVGSVGElement>;
-
 /**
  * Icon generated from arrow-down.svg
  */
-export default function ArrowDownIcon(props: ArrowDownIconProps) {
+export default function ArrowDownIcon(props: JSX.SVGAttributes<SVGSVGElement>) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/src/components/icons/ArrowLeft.tsx
+++ b/src/components/icons/ArrowLeft.tsx
@@ -1,12 +1,10 @@
 // This file was auto-generated using scripts/generate-icons.js
 import type { JSX } from 'preact';
 
-export type ArrowLeftIconProps = JSX.SVGAttributes<SVGSVGElement>;
-
 /**
  * Icon generated from arrow-left.svg
  */
-export default function ArrowLeftIcon(props: ArrowLeftIconProps) {
+export default function ArrowLeftIcon(props: JSX.SVGAttributes<SVGSVGElement>) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/src/components/icons/ArrowRight.tsx
+++ b/src/components/icons/ArrowRight.tsx
@@ -1,12 +1,12 @@
 // This file was auto-generated using scripts/generate-icons.js
 import type { JSX } from 'preact';
 
-export type ArrowRightIconProps = JSX.SVGAttributes<SVGSVGElement>;
-
 /**
  * Icon generated from arrow-right.svg
  */
-export default function ArrowRightIcon(props: ArrowRightIconProps) {
+export default function ArrowRightIcon(
+  props: JSX.SVGAttributes<SVGSVGElement>,
+) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/src/components/icons/ArrowUp.tsx
+++ b/src/components/icons/ArrowUp.tsx
@@ -1,12 +1,10 @@
 // This file was auto-generated using scripts/generate-icons.js
 import type { JSX } from 'preact';
 
-export type ArrowUpIconProps = JSX.SVGAttributes<SVGSVGElement>;
-
 /**
  * Icon generated from arrow-up.svg
  */
-export default function ArrowUpIcon(props: ArrowUpIconProps) {
+export default function ArrowUpIcon(props: JSX.SVGAttributes<SVGSVGElement>) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/src/components/icons/Bookmark.tsx
+++ b/src/components/icons/Bookmark.tsx
@@ -1,12 +1,10 @@
 // This file was auto-generated using scripts/generate-icons.js
 import type { JSX } from 'preact';
 
-export type BookmarkIconProps = JSX.SVGAttributes<SVGSVGElement>;
-
 /**
  * Icon generated from bookmark.svg
  */
-export default function BookmarkIcon(props: BookmarkIconProps) {
+export default function BookmarkIcon(props: JSX.SVGAttributes<SVGSVGElement>) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/src/components/icons/BookmarkFilled.tsx
+++ b/src/components/icons/BookmarkFilled.tsx
@@ -1,12 +1,12 @@
 // This file was auto-generated using scripts/generate-icons.js
 import type { JSX } from 'preact';
 
-export type BookmarkFilledIconProps = JSX.SVGAttributes<SVGSVGElement>;
-
 /**
  * Icon generated from bookmark-filled.svg
  */
-export default function BookmarkFilledIcon(props: BookmarkFilledIconProps) {
+export default function BookmarkFilledIcon(
+  props: JSX.SVGAttributes<SVGSVGElement>,
+) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/src/components/icons/Cancel.tsx
+++ b/src/components/icons/Cancel.tsx
@@ -1,12 +1,10 @@
 // This file was auto-generated using scripts/generate-icons.js
 import type { JSX } from 'preact';
 
-export type CancelIconProps = JSX.SVGAttributes<SVGSVGElement>;
-
 /**
  * Icon generated from cancel.svg
  */
-export default function CancelIcon(props: CancelIconProps) {
+export default function CancelIcon(props: JSX.SVGAttributes<SVGSVGElement>) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/src/components/icons/CaretDown.tsx
+++ b/src/components/icons/CaretDown.tsx
@@ -1,12 +1,10 @@
 // This file was auto-generated using scripts/generate-icons.js
 import type { JSX } from 'preact';
 
-export type CaretDownIconProps = JSX.SVGAttributes<SVGSVGElement>;
-
 /**
  * Icon generated from caret-down.svg
  */
-export default function CaretDownIcon(props: CaretDownIconProps) {
+export default function CaretDownIcon(props: JSX.SVGAttributes<SVGSVGElement>) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/src/components/icons/CaretLeft.tsx
+++ b/src/components/icons/CaretLeft.tsx
@@ -1,12 +1,10 @@
 // This file was auto-generated using scripts/generate-icons.js
 import type { JSX } from 'preact';
 
-export type CaretLeftIconProps = JSX.SVGAttributes<SVGSVGElement>;
-
 /**
  * Icon generated from caret-left.svg
  */
-export default function CaretLeftIcon(props: CaretLeftIconProps) {
+export default function CaretLeftIcon(props: JSX.SVGAttributes<SVGSVGElement>) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/src/components/icons/CaretRight.tsx
+++ b/src/components/icons/CaretRight.tsx
@@ -1,12 +1,12 @@
 // This file was auto-generated using scripts/generate-icons.js
 import type { JSX } from 'preact';
 
-export type CaretRightIconProps = JSX.SVGAttributes<SVGSVGElement>;
-
 /**
  * Icon generated from caret-right.svg
  */
-export default function CaretRightIcon(props: CaretRightIconProps) {
+export default function CaretRightIcon(
+  props: JSX.SVGAttributes<SVGSVGElement>,
+) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/src/components/icons/CaretUp.tsx
+++ b/src/components/icons/CaretUp.tsx
@@ -1,12 +1,10 @@
 // This file was auto-generated using scripts/generate-icons.js
 import type { JSX } from 'preact';
 
-export type CaretUpIconProps = JSX.SVGAttributes<SVGSVGElement>;
-
 /**
  * Icon generated from caret-up.svg
  */
-export default function CaretUpIcon(props: CaretUpIconProps) {
+export default function CaretUpIcon(props: JSX.SVGAttributes<SVGSVGElement>) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/src/components/icons/Caution.tsx
+++ b/src/components/icons/Caution.tsx
@@ -1,12 +1,10 @@
 // This file was auto-generated using scripts/generate-icons.js
 import type { JSX } from 'preact';
 
-export type CautionIconProps = JSX.SVGAttributes<SVGSVGElement>;
-
 /**
  * Icon generated from caution.svg
  */
-export default function CautionIcon(props: CautionIconProps) {
+export default function CautionIcon(props: JSX.SVGAttributes<SVGSVGElement>) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/src/components/icons/CcStd.tsx
+++ b/src/components/icons/CcStd.tsx
@@ -1,12 +1,10 @@
 // This file was auto-generated using scripts/generate-icons.js
 import type { JSX } from 'preact';
 
-export type CcStdIconProps = JSX.SVGAttributes<SVGSVGElement>;
-
 /**
  * Icon generated from cc-std.svg
  */
-export default function CcStdIcon(props: CcStdIconProps) {
+export default function CcStdIcon(props: JSX.SVGAttributes<SVGSVGElement>) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/src/components/icons/CcStdFilled.tsx
+++ b/src/components/icons/CcStdFilled.tsx
@@ -1,12 +1,12 @@
 // This file was auto-generated using scripts/generate-icons.js
 import type { JSX } from 'preact';
 
-export type CcStdFilledIconProps = JSX.SVGAttributes<SVGSVGElement>;
-
 /**
  * Icon generated from cc-std-filled.svg
  */
-export default function CcStdFilledIcon(props: CcStdFilledIconProps) {
+export default function CcStdFilledIcon(
+  props: JSX.SVGAttributes<SVGSVGElement>,
+) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/src/components/icons/CcZero.tsx
+++ b/src/components/icons/CcZero.tsx
@@ -1,12 +1,10 @@
 // This file was auto-generated using scripts/generate-icons.js
 import type { JSX } from 'preact';
 
-export type CcZeroIconProps = JSX.SVGAttributes<SVGSVGElement>;
-
 /**
  * Icon generated from cc-zero.svg
  */
-export default function CcZeroIcon(props: CcZeroIconProps) {
+export default function CcZeroIcon(props: JSX.SVGAttributes<SVGSVGElement>) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/src/components/icons/CcZeroFilled.tsx
+++ b/src/components/icons/CcZeroFilled.tsx
@@ -1,12 +1,12 @@
 // This file was auto-generated using scripts/generate-icons.js
 import type { JSX } from 'preact';
 
-export type CcZeroFilledIconProps = JSX.SVGAttributes<SVGSVGElement>;
-
 /**
  * Icon generated from cc-zero-filled.svg
  */
-export default function CcZeroFilledIcon(props: CcZeroFilledIconProps) {
+export default function CcZeroFilledIcon(
+  props: JSX.SVGAttributes<SVGSVGElement>,
+) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/src/components/icons/Check.tsx
+++ b/src/components/icons/Check.tsx
@@ -1,12 +1,10 @@
 // This file was auto-generated using scripts/generate-icons.js
 import type { JSX } from 'preact';
 
-export type CheckIconProps = JSX.SVGAttributes<SVGSVGElement>;
-
 /**
  * Icon generated from check.svg
  */
-export default function CheckIcon(props: CheckIconProps) {
+export default function CheckIcon(props: JSX.SVGAttributes<SVGSVGElement>) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/src/components/icons/Checkbox.tsx
+++ b/src/components/icons/Checkbox.tsx
@@ -1,12 +1,10 @@
 // This file was auto-generated using scripts/generate-icons.js
 import type { JSX } from 'preact';
 
-export type CheckboxIconProps = JSX.SVGAttributes<SVGSVGElement>;
-
 /**
  * Icon generated from checkbox.svg
  */
-export default function CheckboxIcon(props: CheckboxIconProps) {
+export default function CheckboxIcon(props: JSX.SVGAttributes<SVGSVGElement>) {
   return (
     <svg
       width="16"

--- a/src/components/icons/CheckboxChecked.tsx
+++ b/src/components/icons/CheckboxChecked.tsx
@@ -1,12 +1,12 @@
 // This file was auto-generated using scripts/generate-icons.js
 import type { JSX } from 'preact';
 
-export type CheckboxCheckedIconProps = JSX.SVGAttributes<SVGSVGElement>;
-
 /**
  * Icon generated from checkbox-checked.svg
  */
-export default function CheckboxCheckedIcon(props: CheckboxCheckedIconProps) {
+export default function CheckboxCheckedIcon(
+  props: JSX.SVGAttributes<SVGSVGElement>,
+) {
   return (
     <svg
       width="16"

--- a/src/components/icons/CheckboxOutline.tsx
+++ b/src/components/icons/CheckboxOutline.tsx
@@ -1,12 +1,12 @@
 // This file was auto-generated using scripts/generate-icons.js
 import type { JSX } from 'preact';
 
-export type CheckboxOutlineIconProps = JSX.SVGAttributes<SVGSVGElement>;
-
 /**
  * Icon generated from checkbox-outline.svg
  */
-export default function CheckboxOutlineIcon(props: CheckboxOutlineIconProps) {
+export default function CheckboxOutlineIcon(
+  props: JSX.SVGAttributes<SVGSVGElement>,
+) {
   return (
     <svg
       width="16"

--- a/src/components/icons/Code.tsx
+++ b/src/components/icons/Code.tsx
@@ -1,12 +1,10 @@
 // This file was auto-generated using scripts/generate-icons.js
 import type { JSX } from 'preact';
 
-export type CodeIconProps = JSX.SVGAttributes<SVGSVGElement>;
-
 /**
  * Icon generated from code.svg
  */
-export default function CodeIcon(props: CodeIconProps) {
+export default function CodeIcon(props: JSX.SVGAttributes<SVGSVGElement>) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/src/components/icons/Collapse.tsx
+++ b/src/components/icons/Collapse.tsx
@@ -1,12 +1,10 @@
 // This file was auto-generated using scripts/generate-icons.js
 import type { JSX } from 'preact';
 
-export type CollapseIconProps = JSX.SVGAttributes<SVGSVGElement>;
-
 /**
  * Icon generated from collapse.svg
  */
-export default function CollapseIcon(props: CollapseIconProps) {
+export default function CollapseIcon(props: JSX.SVGAttributes<SVGSVGElement>) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/src/components/icons/Contrast.tsx
+++ b/src/components/icons/Contrast.tsx
@@ -1,12 +1,10 @@
 // This file was auto-generated using scripts/generate-icons.js
 import type { JSX } from 'preact';
 
-export type ContrastIconProps = JSX.SVGAttributes<SVGSVGElement>;
-
 /**
  * Icon generated from contrast.svg
  */
-export default function ContrastIcon(props: ContrastIconProps) {
+export default function ContrastIcon(props: JSX.SVGAttributes<SVGSVGElement>) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/src/components/icons/Copy.tsx
+++ b/src/components/icons/Copy.tsx
@@ -1,12 +1,10 @@
 // This file was auto-generated using scripts/generate-icons.js
 import type { JSX } from 'preact';
 
-export type CopyIconProps = JSX.SVGAttributes<SVGSVGElement>;
-
 /**
  * Icon generated from copy.svg
  */
-export default function CopyIcon(props: CopyIconProps) {
+export default function CopyIcon(props: JSX.SVGAttributes<SVGSVGElement>) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/src/components/icons/CopyFilled.tsx
+++ b/src/components/icons/CopyFilled.tsx
@@ -1,12 +1,12 @@
 // This file was auto-generated using scripts/generate-icons.js
 import type { JSX } from 'preact';
 
-export type CopyFilledIconProps = JSX.SVGAttributes<SVGSVGElement>;
-
 /**
  * Icon generated from copy-filled.svg
  */
-export default function CopyFilledIcon(props: CopyFilledIconProps) {
+export default function CopyFilledIcon(
+  props: JSX.SVGAttributes<SVGSVGElement>,
+) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/src/components/icons/Download.tsx
+++ b/src/components/icons/Download.tsx
@@ -1,12 +1,10 @@
 // This file was auto-generated using scripts/generate-icons.js
 import type { JSX } from 'preact';
 
-export type DownloadIconProps = JSX.SVGAttributes<SVGSVGElement>;
-
 /**
  * Icon generated from download.svg
  */
-export default function DownloadIcon(props: DownloadIconProps) {
+export default function DownloadIcon(props: JSX.SVGAttributes<SVGSVGElement>) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/src/components/icons/Edit.tsx
+++ b/src/components/icons/Edit.tsx
@@ -1,12 +1,10 @@
 // This file was auto-generated using scripts/generate-icons.js
 import type { JSX } from 'preact';
 
-export type EditIconProps = JSX.SVGAttributes<SVGSVGElement>;
-
 /**
  * Icon generated from edit.svg
  */
-export default function EditIcon(props: EditIconProps) {
+export default function EditIcon(props: JSX.SVGAttributes<SVGSVGElement>) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/src/components/icons/EditorLatex.tsx
+++ b/src/components/icons/EditorLatex.tsx
@@ -1,12 +1,12 @@
 // This file was auto-generated using scripts/generate-icons.js
 import type { JSX } from 'preact';
 
-export type EditorLatexIconProps = JSX.SVGAttributes<SVGSVGElement>;
-
 /**
  * Icon generated from editor-latex.svg
  */
-export default function EditorLatexIcon(props: EditorLatexIconProps) {
+export default function EditorLatexIcon(
+  props: JSX.SVGAttributes<SVGSVGElement>,
+) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/src/components/icons/EditorQuote.tsx
+++ b/src/components/icons/EditorQuote.tsx
@@ -1,12 +1,12 @@
 // This file was auto-generated using scripts/generate-icons.js
 import type { JSX } from 'preact';
 
-export type EditorQuoteIconProps = JSX.SVGAttributes<SVGSVGElement>;
-
 /**
  * Icon generated from editor-quote.svg
  */
-export default function EditorQuoteIcon(props: EditorQuoteIconProps) {
+export default function EditorQuoteIcon(
+  props: JSX.SVGAttributes<SVGSVGElement>,
+) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/src/components/icons/EditorTextBold.tsx
+++ b/src/components/icons/EditorTextBold.tsx
@@ -1,12 +1,12 @@
 // This file was auto-generated using scripts/generate-icons.js
 import type { JSX } from 'preact';
 
-export type EditorTextBoldIconProps = JSX.SVGAttributes<SVGSVGElement>;
-
 /**
  * Icon generated from editor-text-bold.svg
  */
-export default function EditorTextBoldIcon(props: EditorTextBoldIconProps) {
+export default function EditorTextBoldIcon(
+  props: JSX.SVGAttributes<SVGSVGElement>,
+) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/src/components/icons/EditorTextItalic.tsx
+++ b/src/components/icons/EditorTextItalic.tsx
@@ -1,12 +1,12 @@
 // This file was auto-generated using scripts/generate-icons.js
 import type { JSX } from 'preact';
 
-export type EditorTextItalicIconProps = JSX.SVGAttributes<SVGSVGElement>;
-
 /**
  * Icon generated from editor-text-italic.svg
  */
-export default function EditorTextItalicIcon(props: EditorTextItalicIconProps) {
+export default function EditorTextItalicIcon(
+  props: JSX.SVGAttributes<SVGSVGElement>,
+) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/src/components/icons/Ellipsis.tsx
+++ b/src/components/icons/Ellipsis.tsx
@@ -1,12 +1,10 @@
 // This file was auto-generated using scripts/generate-icons.js
 import type { JSX } from 'preact';
 
-export type EllipsisIconProps = JSX.SVGAttributes<SVGSVGElement>;
-
 /**
  * Icon generated from ellipsis.svg
  */
-export default function EllipsisIcon(props: EllipsisIconProps) {
+export default function EllipsisIcon(props: JSX.SVGAttributes<SVGSVGElement>) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/src/components/icons/Email.tsx
+++ b/src/components/icons/Email.tsx
@@ -1,12 +1,10 @@
 // This file was auto-generated using scripts/generate-icons.js
 import type { JSX } from 'preact';
 
-export type EmailIconProps = JSX.SVGAttributes<SVGSVGElement>;
-
 /**
  * Icon generated from email.svg
  */
-export default function EmailIcon(props: EmailIconProps) {
+export default function EmailIcon(props: JSX.SVGAttributes<SVGSVGElement>) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/src/components/icons/EmailFilled.tsx
+++ b/src/components/icons/EmailFilled.tsx
@@ -1,12 +1,12 @@
 // This file was auto-generated using scripts/generate-icons.js
 import type { JSX } from 'preact';
 
-export type EmailFilledIconProps = JSX.SVGAttributes<SVGSVGElement>;
-
 /**
  * Icon generated from email-filled.svg
  */
-export default function EmailFilledIcon(props: EmailFilledIconProps) {
+export default function EmailFilledIcon(
+  props: JSX.SVGAttributes<SVGSVGElement>,
+) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/src/components/icons/Expand.tsx
+++ b/src/components/icons/Expand.tsx
@@ -1,12 +1,10 @@
 // This file was auto-generated using scripts/generate-icons.js
 import type { JSX } from 'preact';
 
-export type ExpandIconProps = JSX.SVGAttributes<SVGSVGElement>;
-
 /**
  * Icon generated from expand.svg
  */
-export default function ExpandIcon(props: ExpandIconProps) {
+export default function ExpandIcon(props: JSX.SVGAttributes<SVGSVGElement>) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/src/components/icons/External.tsx
+++ b/src/components/icons/External.tsx
@@ -1,12 +1,10 @@
 // This file was auto-generated using scripts/generate-icons.js
 import type { JSX } from 'preact';
 
-export type ExternalIconProps = JSX.SVGAttributes<SVGSVGElement>;
-
 /**
  * Icon generated from external.svg
  */
-export default function ExternalIcon(props: ExternalIconProps) {
+export default function ExternalIcon(props: JSX.SVGAttributes<SVGSVGElement>) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/src/components/icons/FileCode.tsx
+++ b/src/components/icons/FileCode.tsx
@@ -1,12 +1,10 @@
 // This file was auto-generated using scripts/generate-icons.js
 import type { JSX } from 'preact';
 
-export type FileCodeIconProps = JSX.SVGAttributes<SVGSVGElement>;
-
 /**
  * Icon generated from file-code.svg
  */
-export default function FileCodeIcon(props: FileCodeIconProps) {
+export default function FileCodeIcon(props: JSX.SVGAttributes<SVGSVGElement>) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/src/components/icons/FileCodeFilled.tsx
+++ b/src/components/icons/FileCodeFilled.tsx
@@ -1,12 +1,12 @@
 // This file was auto-generated using scripts/generate-icons.js
 import type { JSX } from 'preact';
 
-export type FileCodeFilledIconProps = JSX.SVGAttributes<SVGSVGElement>;
-
 /**
  * Icon generated from file-code-filled.svg
  */
-export default function FileCodeFilledIcon(props: FileCodeFilledIconProps) {
+export default function FileCodeFilledIcon(
+  props: JSX.SVGAttributes<SVGSVGElement>,
+) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/src/components/icons/FileGeneric.tsx
+++ b/src/components/icons/FileGeneric.tsx
@@ -1,12 +1,12 @@
 // This file was auto-generated using scripts/generate-icons.js
 import type { JSX } from 'preact';
 
-export type FileGenericIconProps = JSX.SVGAttributes<SVGSVGElement>;
-
 /**
  * Icon generated from file-generic.svg
  */
-export default function FileGenericIcon(props: FileGenericIconProps) {
+export default function FileGenericIcon(
+  props: JSX.SVGAttributes<SVGSVGElement>,
+) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/src/components/icons/FileGenericFilled.tsx
+++ b/src/components/icons/FileGenericFilled.tsx
@@ -1,13 +1,11 @@
 // This file was auto-generated using scripts/generate-icons.js
 import type { JSX } from 'preact';
 
-export type FileGenericFilledIconProps = JSX.SVGAttributes<SVGSVGElement>;
-
 /**
  * Icon generated from file-generic-filled.svg
  */
 export default function FileGenericFilledIcon(
-  props: FileGenericFilledIconProps,
+  props: JSX.SVGAttributes<SVGSVGElement>,
 ) {
   return (
     <svg

--- a/src/components/icons/FileImage.tsx
+++ b/src/components/icons/FileImage.tsx
@@ -1,12 +1,10 @@
 // This file was auto-generated using scripts/generate-icons.js
 import type { JSX } from 'preact';
 
-export type FileImageIconProps = JSX.SVGAttributes<SVGSVGElement>;
-
 /**
  * Icon generated from file-image.svg
  */
-export default function FileImageIcon(props: FileImageIconProps) {
+export default function FileImageIcon(props: JSX.SVGAttributes<SVGSVGElement>) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/src/components/icons/FileImageFilled.tsx
+++ b/src/components/icons/FileImageFilled.tsx
@@ -1,12 +1,12 @@
 // This file was auto-generated using scripts/generate-icons.js
 import type { JSX } from 'preact';
 
-export type FileImageFilledIconProps = JSX.SVGAttributes<SVGSVGElement>;
-
 /**
  * Icon generated from file-image-filled.svg
  */
-export default function FileImageFilledIcon(props: FileImageFilledIconProps) {
+export default function FileImageFilledIcon(
+  props: JSX.SVGAttributes<SVGSVGElement>,
+) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/src/components/icons/FilePdf.tsx
+++ b/src/components/icons/FilePdf.tsx
@@ -1,12 +1,10 @@
 // This file was auto-generated using scripts/generate-icons.js
 import type { JSX } from 'preact';
 
-export type FilePdfIconProps = JSX.SVGAttributes<SVGSVGElement>;
-
 /**
  * Icon generated from file-pdf.svg
  */
-export default function FilePdfIcon(props: FilePdfIconProps) {
+export default function FilePdfIcon(props: JSX.SVGAttributes<SVGSVGElement>) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/src/components/icons/FilePdfFilled.tsx
+++ b/src/components/icons/FilePdfFilled.tsx
@@ -1,12 +1,12 @@
 // This file was auto-generated using scripts/generate-icons.js
 import type { JSX } from 'preact';
 
-export type FilePdfFilledIconProps = JSX.SVGAttributes<SVGSVGElement>;
-
 /**
  * Icon generated from file-pdf-filled.svg
  */
-export default function FilePdfFilledIcon(props: FilePdfFilledIconProps) {
+export default function FilePdfFilledIcon(
+  props: JSX.SVGAttributes<SVGSVGElement>,
+) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/src/components/icons/Filter.tsx
+++ b/src/components/icons/Filter.tsx
@@ -1,12 +1,10 @@
 // This file was auto-generated using scripts/generate-icons.js
 import type { JSX } from 'preact';
 
-export type FilterIconProps = JSX.SVGAttributes<SVGSVGElement>;
-
 /**
  * Icon generated from filter.svg
  */
-export default function FilterIcon(props: FilterIconProps) {
+export default function FilterIcon(props: JSX.SVGAttributes<SVGSVGElement>) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/src/components/icons/Flag.tsx
+++ b/src/components/icons/Flag.tsx
@@ -1,12 +1,10 @@
 // This file was auto-generated using scripts/generate-icons.js
 import type { JSX } from 'preact';
 
-export type FlagIconProps = JSX.SVGAttributes<SVGSVGElement>;
-
 /**
  * Icon generated from flag.svg
  */
-export default function FlagIcon(props: FlagIconProps) {
+export default function FlagIcon(props: JSX.SVGAttributes<SVGSVGElement>) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/src/components/icons/FlagFilled.tsx
+++ b/src/components/icons/FlagFilled.tsx
@@ -1,12 +1,12 @@
 // This file was auto-generated using scripts/generate-icons.js
 import type { JSX } from 'preact';
 
-export type FlagFilledIconProps = JSX.SVGAttributes<SVGSVGElement>;
-
 /**
  * Icon generated from flag-filled.svg
  */
-export default function FlagFilledIcon(props: FlagFilledIconProps) {
+export default function FlagFilledIcon(
+  props: JSX.SVGAttributes<SVGSVGElement>,
+) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/src/components/icons/Folder.tsx
+++ b/src/components/icons/Folder.tsx
@@ -1,12 +1,10 @@
 // This file was auto-generated using scripts/generate-icons.js
 import type { JSX } from 'preact';
 
-export type FolderIconProps = JSX.SVGAttributes<SVGSVGElement>;
-
 /**
  * Icon generated from folder.svg
  */
-export default function FolderIcon(props: FolderIconProps) {
+export default function FolderIcon(props: JSX.SVGAttributes<SVGSVGElement>) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/src/components/icons/FolderFilled.tsx
+++ b/src/components/icons/FolderFilled.tsx
@@ -1,12 +1,12 @@
 // This file was auto-generated using scripts/generate-icons.js
 import type { JSX } from 'preact';
 
-export type FolderFilledIconProps = JSX.SVGAttributes<SVGSVGElement>;
-
 /**
  * Icon generated from folder-filled.svg
  */
-export default function FolderFilledIcon(props: FolderFilledIconProps) {
+export default function FolderFilledIcon(
+  props: JSX.SVGAttributes<SVGSVGElement>,
+) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/src/components/icons/FolderOpen.tsx
+++ b/src/components/icons/FolderOpen.tsx
@@ -1,12 +1,12 @@
 // This file was auto-generated using scripts/generate-icons.js
 import type { JSX } from 'preact';
 
-export type FolderOpenIconProps = JSX.SVGAttributes<SVGSVGElement>;
-
 /**
  * Icon generated from folder-open.svg
  */
-export default function FolderOpenIcon(props: FolderOpenIconProps) {
+export default function FolderOpenIcon(
+  props: JSX.SVGAttributes<SVGSVGElement>,
+) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/src/components/icons/FolderOpenFilled.tsx
+++ b/src/components/icons/FolderOpenFilled.tsx
@@ -1,12 +1,12 @@
 // This file was auto-generated using scripts/generate-icons.js
 import type { JSX } from 'preact';
 
-export type FolderOpenFilledIconProps = JSX.SVGAttributes<SVGSVGElement>;
-
 /**
  * Icon generated from folder-open-filled.svg
  */
-export default function FolderOpenFilledIcon(props: FolderOpenFilledIconProps) {
+export default function FolderOpenFilledIcon(
+  props: JSX.SVGAttributes<SVGSVGElement>,
+) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/src/components/icons/Globe.tsx
+++ b/src/components/icons/Globe.tsx
@@ -1,12 +1,10 @@
 // This file was auto-generated using scripts/generate-icons.js
 import type { JSX } from 'preact';
 
-export type GlobeIconProps = JSX.SVGAttributes<SVGSVGElement>;
-
 /**
  * Icon generated from globe.svg
  */
-export default function GlobeIcon(props: GlobeIconProps) {
+export default function GlobeIcon(props: JSX.SVGAttributes<SVGSVGElement>) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/src/components/icons/GlobeAlt.tsx
+++ b/src/components/icons/GlobeAlt.tsx
@@ -1,12 +1,10 @@
 // This file was auto-generated using scripts/generate-icons.js
 import type { JSX } from 'preact';
 
-export type GlobeAltIconProps = JSX.SVGAttributes<SVGSVGElement>;
-
 /**
  * Icon generated from globe-alt.svg
  */
-export default function GlobeAltIcon(props: GlobeAltIconProps) {
+export default function GlobeAltIcon(props: JSX.SVGAttributes<SVGSVGElement>) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/src/components/icons/GoogleDrive.tsx
+++ b/src/components/icons/GoogleDrive.tsx
@@ -1,12 +1,12 @@
 // This file was auto-generated using scripts/generate-icons.js
 import type { JSX } from 'preact';
 
-export type GoogleDriveIconProps = JSX.SVGAttributes<SVGSVGElement>;
-
 /**
  * Icon generated from google-drive.svg
  */
-export default function GoogleDriveIcon(props: GoogleDriveIconProps) {
+export default function GoogleDriveIcon(
+  props: JSX.SVGAttributes<SVGSVGElement>,
+) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/src/components/icons/Groups.tsx
+++ b/src/components/icons/Groups.tsx
@@ -1,12 +1,10 @@
 // This file was auto-generated using scripts/generate-icons.js
 import type { JSX } from 'preact';
 
-export type GroupsIconProps = JSX.SVGAttributes<SVGSVGElement>;
-
 /**
  * Icon generated from groups.svg
  */
-export default function GroupsIcon(props: GroupsIconProps) {
+export default function GroupsIcon(props: JSX.SVGAttributes<SVGSVGElement>) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/src/components/icons/GroupsFilled.tsx
+++ b/src/components/icons/GroupsFilled.tsx
@@ -1,12 +1,12 @@
 // This file was auto-generated using scripts/generate-icons.js
 import type { JSX } from 'preact';
 
-export type GroupsFilledIconProps = JSX.SVGAttributes<SVGSVGElement>;
-
 /**
  * Icon generated from groups-filled.svg
  */
-export default function GroupsFilledIcon(props: GroupsFilledIconProps) {
+export default function GroupsFilledIcon(
+  props: JSX.SVGAttributes<SVGSVGElement>,
+) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/src/components/icons/Help.tsx
+++ b/src/components/icons/Help.tsx
@@ -1,12 +1,10 @@
 // This file was auto-generated using scripts/generate-icons.js
 import type { JSX } from 'preact';
 
-export type HelpIconProps = JSX.SVGAttributes<SVGSVGElement>;
-
 /**
  * Icon generated from help.svg
  */
-export default function HelpIcon(props: HelpIconProps) {
+export default function HelpIcon(props: JSX.SVGAttributes<SVGSVGElement>) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/src/components/icons/Hide.tsx
+++ b/src/components/icons/Hide.tsx
@@ -1,12 +1,10 @@
 // This file was auto-generated using scripts/generate-icons.js
 import type { JSX } from 'preact';
 
-export type HideIconProps = JSX.SVGAttributes<SVGSVGElement>;
-
 /**
  * Icon generated from hide.svg
  */
-export default function HideIcon(props: HideIconProps) {
+export default function HideIcon(props: JSX.SVGAttributes<SVGSVGElement>) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/src/components/icons/HideFilled.tsx
+++ b/src/components/icons/HideFilled.tsx
@@ -1,12 +1,12 @@
 // This file was auto-generated using scripts/generate-icons.js
 import type { JSX } from 'preact';
 
-export type HideFilledIconProps = JSX.SVGAttributes<SVGSVGElement>;
-
 /**
  * Icon generated from hide-filled.svg
  */
-export default function HideFilledIcon(props: HideFilledIconProps) {
+export default function HideFilledIcon(
+  props: JSX.SVGAttributes<SVGSVGElement>,
+) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/src/components/icons/Highlight.tsx
+++ b/src/components/icons/Highlight.tsx
@@ -1,12 +1,10 @@
 // This file was auto-generated using scripts/generate-icons.js
 import type { JSX } from 'preact';
 
-export type HighlightIconProps = JSX.SVGAttributes<SVGSVGElement>;
-
 /**
  * Icon generated from highlight.svg
  */
-export default function HighlightIcon(props: HighlightIconProps) {
+export default function HighlightIcon(props: JSX.SVGAttributes<SVGSVGElement>) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/src/components/icons/Image.tsx
+++ b/src/components/icons/Image.tsx
@@ -1,12 +1,10 @@
 // This file was auto-generated using scripts/generate-icons.js
 import type { JSX } from 'preact';
 
-export type ImageIconProps = JSX.SVGAttributes<SVGSVGElement>;
-
 /**
  * Icon generated from image.svg
  */
-export default function ImageIcon(props: ImageIconProps) {
+export default function ImageIcon(props: JSX.SVGAttributes<SVGSVGElement>) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/src/components/icons/ImageFilled.tsx
+++ b/src/components/icons/ImageFilled.tsx
@@ -1,12 +1,12 @@
 // This file was auto-generated using scripts/generate-icons.js
 import type { JSX } from 'preact';
 
-export type ImageFilledIconProps = JSX.SVGAttributes<SVGSVGElement>;
-
 /**
  * Icon generated from image-filled.svg
  */
-export default function ImageFilledIcon(props: ImageFilledIconProps) {
+export default function ImageFilledIcon(
+  props: JSX.SVGAttributes<SVGSVGElement>,
+) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/src/components/icons/Info.tsx
+++ b/src/components/icons/Info.tsx
@@ -1,12 +1,10 @@
 // This file was auto-generated using scripts/generate-icons.js
 import type { JSX } from 'preact';
 
-export type InfoIconProps = JSX.SVGAttributes<SVGSVGElement>;
-
 /**
  * Icon generated from info.svg
  */
-export default function InfoIcon(props: InfoIconProps) {
+export default function InfoIcon(props: JSX.SVGAttributes<SVGSVGElement>) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/src/components/icons/Leave.tsx
+++ b/src/components/icons/Leave.tsx
@@ -1,12 +1,10 @@
 // This file was auto-generated using scripts/generate-icons.js
 import type { JSX } from 'preact';
 
-export type LeaveIconProps = JSX.SVGAttributes<SVGSVGElement>;
-
 /**
  * Icon generated from leave.svg
  */
-export default function LeaveIcon(props: LeaveIconProps) {
+export default function LeaveIcon(props: JSX.SVGAttributes<SVGSVGElement>) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/src/components/icons/LeaveFilled.tsx
+++ b/src/components/icons/LeaveFilled.tsx
@@ -1,12 +1,12 @@
 // This file was auto-generated using scripts/generate-icons.js
 import type { JSX } from 'preact';
 
-export type LeaveFilledIconProps = JSX.SVGAttributes<SVGSVGElement>;
-
 /**
  * Icon generated from leave-filled.svg
  */
-export default function LeaveFilledIcon(props: LeaveFilledIconProps) {
+export default function LeaveFilledIcon(
+  props: JSX.SVGAttributes<SVGSVGElement>,
+) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/src/components/icons/Link.tsx
+++ b/src/components/icons/Link.tsx
@@ -1,12 +1,10 @@
 // This file was auto-generated using scripts/generate-icons.js
 import type { JSX } from 'preact';
 
-export type LinkIconProps = JSX.SVGAttributes<SVGSVGElement>;
-
 /**
  * Icon generated from link.svg
  */
-export default function LinkIcon(props: LinkIconProps) {
+export default function LinkIcon(props: JSX.SVGAttributes<SVGSVGElement>) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/src/components/icons/List.tsx
+++ b/src/components/icons/List.tsx
@@ -1,12 +1,10 @@
 // This file was auto-generated using scripts/generate-icons.js
 import type { JSX } from 'preact';
 
-export type ListIconProps = JSX.SVGAttributes<SVGSVGElement>;
-
 /**
  * Icon generated from list.svg
  */
-export default function ListIcon(props: ListIconProps) {
+export default function ListIcon(props: JSX.SVGAttributes<SVGSVGElement>) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/src/components/icons/ListOrdered.tsx
+++ b/src/components/icons/ListOrdered.tsx
@@ -1,12 +1,12 @@
 // This file was auto-generated using scripts/generate-icons.js
 import type { JSX } from 'preact';
 
-export type ListOrderedIconProps = JSX.SVGAttributes<SVGSVGElement>;
-
 /**
  * Icon generated from list-ordered.svg
  */
-export default function ListOrderedIcon(props: ListOrderedIconProps) {
+export default function ListOrderedIcon(
+  props: JSX.SVGAttributes<SVGSVGElement>,
+) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/src/components/icons/ListUnordered.tsx
+++ b/src/components/icons/ListUnordered.tsx
@@ -1,12 +1,12 @@
 // This file was auto-generated using scripts/generate-icons.js
 import type { JSX } from 'preact';
 
-export type ListUnorderedIconProps = JSX.SVGAttributes<SVGSVGElement>;
-
 /**
  * Icon generated from list-unordered.svg
  */
-export default function ListUnorderedIcon(props: ListUnorderedIconProps) {
+export default function ListUnorderedIcon(
+  props: JSX.SVGAttributes<SVGSVGElement>,
+) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/src/components/icons/Lock.tsx
+++ b/src/components/icons/Lock.tsx
@@ -1,12 +1,10 @@
 // This file was auto-generated using scripts/generate-icons.js
 import type { JSX } from 'preact';
 
-export type LockIconProps = JSX.SVGAttributes<SVGSVGElement>;
-
 /**
  * Icon generated from lock.svg
  */
-export default function LockIcon(props: LockIconProps) {
+export default function LockIcon(props: JSX.SVGAttributes<SVGSVGElement>) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/src/components/icons/LockAlt.tsx
+++ b/src/components/icons/LockAlt.tsx
@@ -1,12 +1,10 @@
 // This file was auto-generated using scripts/generate-icons.js
 import type { JSX } from 'preact';
 
-export type LockAltIconProps = JSX.SVGAttributes<SVGSVGElement>;
-
 /**
  * Icon generated from lock-alt.svg
  */
-export default function LockAltIcon(props: LockAltIconProps) {
+export default function LockAltIcon(props: JSX.SVGAttributes<SVGSVGElement>) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/src/components/icons/LockAltFilled.tsx
+++ b/src/components/icons/LockAltFilled.tsx
@@ -1,12 +1,12 @@
 // This file was auto-generated using scripts/generate-icons.js
 import type { JSX } from 'preact';
 
-export type LockAltFilledIconProps = JSX.SVGAttributes<SVGSVGElement>;
-
 /**
  * Icon generated from lock-alt-filled.svg
  */
-export default function LockAltFilledIcon(props: LockAltFilledIconProps) {
+export default function LockAltFilledIcon(
+  props: JSX.SVGAttributes<SVGSVGElement>,
+) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/src/components/icons/Logo.tsx
+++ b/src/components/icons/Logo.tsx
@@ -1,12 +1,10 @@
 // This file was auto-generated using scripts/generate-icons.js
 import type { JSX } from 'preact';
 
-export type LogoIconProps = JSX.SVGAttributes<SVGSVGElement>;
-
 /**
  * Icon generated from logo.svg
  */
-export default function LogoIcon(props: LogoIconProps) {
+export default function LogoIcon(props: JSX.SVGAttributes<SVGSVGElement>) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/src/components/icons/Logout.tsx
+++ b/src/components/icons/Logout.tsx
@@ -1,12 +1,10 @@
 // This file was auto-generated using scripts/generate-icons.js
 import type { JSX } from 'preact';
 
-export type LogoutIconProps = JSX.SVGAttributes<SVGSVGElement>;
-
 /**
  * Icon generated from logout.svg
  */
-export default function LogoutIcon(props: LogoutIconProps) {
+export default function LogoutIcon(props: JSX.SVGAttributes<SVGSVGElement>) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/src/components/icons/MenuCollapse.tsx
+++ b/src/components/icons/MenuCollapse.tsx
@@ -1,12 +1,12 @@
 // This file was auto-generated using scripts/generate-icons.js
 import type { JSX } from 'preact';
 
-export type MenuCollapseIconProps = JSX.SVGAttributes<SVGSVGElement>;
-
 /**
  * Icon generated from menu-collapse.svg
  */
-export default function MenuCollapseIcon(props: MenuCollapseIconProps) {
+export default function MenuCollapseIcon(
+  props: JSX.SVGAttributes<SVGSVGElement>,
+) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/src/components/icons/MenuExpand.tsx
+++ b/src/components/icons/MenuExpand.tsx
@@ -1,12 +1,12 @@
 // This file was auto-generated using scripts/generate-icons.js
 import type { JSX } from 'preact';
 
-export type MenuExpandIconProps = JSX.SVGAttributes<SVGSVGElement>;
-
 /**
  * Icon generated from menu-expand.svg
  */
-export default function MenuExpandIcon(props: MenuExpandIconProps) {
+export default function MenuExpandIcon(
+  props: JSX.SVGAttributes<SVGSVGElement>,
+) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/src/components/icons/Minus.tsx
+++ b/src/components/icons/Minus.tsx
@@ -1,12 +1,10 @@
 // This file was auto-generated using scripts/generate-icons.js
 import type { JSX } from 'preact';
 
-export type MinusIconProps = JSX.SVGAttributes<SVGSVGElement>;
-
 /**
  * Icon generated from minus.svg
  */
-export default function MinusIcon(props: MinusIconProps) {
+export default function MinusIcon(props: JSX.SVGAttributes<SVGSVGElement>) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/src/components/icons/Note.tsx
+++ b/src/components/icons/Note.tsx
@@ -1,12 +1,10 @@
 // This file was auto-generated using scripts/generate-icons.js
 import type { JSX } from 'preact';
 
-export type NoteIconProps = JSX.SVGAttributes<SVGSVGElement>;
-
 /**
  * Icon generated from note.svg
  */
-export default function NoteIcon(props: NoteIconProps) {
+export default function NoteIcon(props: JSX.SVGAttributes<SVGSVGElement>) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/src/components/icons/NoteFilled.tsx
+++ b/src/components/icons/NoteFilled.tsx
@@ -1,12 +1,12 @@
 // This file was auto-generated using scripts/generate-icons.js
 import type { JSX } from 'preact';
 
-export type NoteFilledIconProps = JSX.SVGAttributes<SVGSVGElement>;
-
 /**
  * Icon generated from note-filled.svg
  */
-export default function NoteFilledIcon(props: NoteFilledIconProps) {
+export default function NoteFilledIcon(
+  props: JSX.SVGAttributes<SVGSVGElement>,
+) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/src/components/icons/OneDrive.tsx
+++ b/src/components/icons/OneDrive.tsx
@@ -1,12 +1,10 @@
 // This file was auto-generated using scripts/generate-icons.js
 import type { JSX } from 'preact';
 
-export type OneDriveIconProps = JSX.SVGAttributes<SVGSVGElement>;
-
 /**
  * Icon generated from one-drive.svg
  */
-export default function OneDriveIcon(props: OneDriveIconProps) {
+export default function OneDriveIcon(props: JSX.SVGAttributes<SVGSVGElement>) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/src/components/icons/Pin.tsx
+++ b/src/components/icons/Pin.tsx
@@ -1,12 +1,10 @@
 // This file was auto-generated using scripts/generate-icons.js
 import type { JSX } from 'preact';
 
-export type PinIconProps = JSX.SVGAttributes<SVGSVGElement>;
-
 /**
  * Icon generated from pin.svg
  */
-export default function PinIcon(props: PinIconProps) {
+export default function PinIcon(props: JSX.SVGAttributes<SVGSVGElement>) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/src/components/icons/Plus.tsx
+++ b/src/components/icons/Plus.tsx
@@ -1,12 +1,10 @@
 // This file was auto-generated using scripts/generate-icons.js
 import type { JSX } from 'preact';
 
-export type PlusIconProps = JSX.SVGAttributes<SVGSVGElement>;
-
 /**
  * Icon generated from plus.svg
  */
-export default function PlusIcon(props: PlusIconProps) {
+export default function PlusIcon(props: JSX.SVGAttributes<SVGSVGElement>) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/src/components/icons/PointerDown.tsx
+++ b/src/components/icons/PointerDown.tsx
@@ -1,12 +1,12 @@
 // This file was auto-generated using scripts/generate-icons.js
 import type { JSX } from 'preact';
 
-export type PointerDownIconProps = JSX.SVGAttributes<SVGSVGElement>;
-
 /**
  * Icon generated from pointer-down.svg
  */
-export default function PointerDownIcon(props: PointerDownIconProps) {
+export default function PointerDownIcon(
+  props: JSX.SVGAttributes<SVGSVGElement>,
+) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/src/components/icons/PointerUp.tsx
+++ b/src/components/icons/PointerUp.tsx
@@ -1,12 +1,10 @@
 // This file was auto-generated using scripts/generate-icons.js
 import type { JSX } from 'preact';
 
-export type PointerUpIconProps = JSX.SVGAttributes<SVGSVGElement>;
-
 /**
  * Icon generated from pointer-up.svg
  */
-export default function PointerUpIcon(props: PointerUpIconProps) {
+export default function PointerUpIcon(props: JSX.SVGAttributes<SVGSVGElement>) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/src/components/icons/Preview.tsx
+++ b/src/components/icons/Preview.tsx
@@ -1,12 +1,10 @@
 // This file was auto-generated using scripts/generate-icons.js
 import type { JSX } from 'preact';
 
-export type PreviewIconProps = JSX.SVGAttributes<SVGSVGElement>;
-
 /**
  * Icon generated from preview.svg
  */
-export default function PreviewIcon(props: PreviewIconProps) {
+export default function PreviewIcon(props: JSX.SVGAttributes<SVGSVGElement>) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/src/components/icons/PreviewFilled.tsx
+++ b/src/components/icons/PreviewFilled.tsx
@@ -1,12 +1,12 @@
 // This file was auto-generated using scripts/generate-icons.js
 import type { JSX } from 'preact';
 
-export type PreviewFilledIconProps = JSX.SVGAttributes<SVGSVGElement>;
-
 /**
  * Icon generated from preview-filled.svg
  */
-export default function PreviewFilledIcon(props: PreviewFilledIconProps) {
+export default function PreviewFilledIcon(
+  props: JSX.SVGAttributes<SVGSVGElement>,
+) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/src/components/icons/Profile.tsx
+++ b/src/components/icons/Profile.tsx
@@ -1,12 +1,10 @@
 // This file was auto-generated using scripts/generate-icons.js
 import type { JSX } from 'preact';
 
-export type ProfileIconProps = JSX.SVGAttributes<SVGSVGElement>;
-
 /**
  * Icon generated from profile.svg
  */
-export default function ProfileIcon(props: ProfileIconProps) {
+export default function ProfileIcon(props: JSX.SVGAttributes<SVGSVGElement>) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/src/components/icons/ProfileFilled.tsx
+++ b/src/components/icons/ProfileFilled.tsx
@@ -1,12 +1,12 @@
 // This file was auto-generated using scripts/generate-icons.js
 import type { JSX } from 'preact';
 
-export type ProfileFilledIconProps = JSX.SVGAttributes<SVGSVGElement>;
-
 /**
  * Icon generated from profile-filled.svg
  */
-export default function ProfileFilledIcon(props: ProfileFilledIconProps) {
+export default function ProfileFilledIcon(
+  props: JSX.SVGAttributes<SVGSVGElement>,
+) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/src/components/icons/Refresh.tsx
+++ b/src/components/icons/Refresh.tsx
@@ -1,12 +1,10 @@
 // This file was auto-generated using scripts/generate-icons.js
 import type { JSX } from 'preact';
 
-export type RefreshIconProps = JSX.SVGAttributes<SVGSVGElement>;
-
 /**
  * Icon generated from refresh.svg
  */
-export default function RefreshIcon(props: RefreshIconProps) {
+export default function RefreshIcon(props: JSX.SVGAttributes<SVGSVGElement>) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/src/components/icons/Reply.tsx
+++ b/src/components/icons/Reply.tsx
@@ -1,12 +1,10 @@
 // This file was auto-generated using scripts/generate-icons.js
 import type { JSX } from 'preact';
 
-export type ReplyIconProps = JSX.SVGAttributes<SVGSVGElement>;
-
 /**
  * Icon generated from reply.svg
  */
-export default function ReplyIcon(props: ReplyIconProps) {
+export default function ReplyIcon(props: JSX.SVGAttributes<SVGSVGElement>) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/src/components/icons/ReplyAlt.tsx
+++ b/src/components/icons/ReplyAlt.tsx
@@ -1,12 +1,10 @@
 // This file was auto-generated using scripts/generate-icons.js
 import type { JSX } from 'preact';
 
-export type ReplyAltIconProps = JSX.SVGAttributes<SVGSVGElement>;
-
 /**
  * Icon generated from reply-alt.svg
  */
-export default function ReplyAltIcon(props: ReplyAltIconProps) {
+export default function ReplyAltIcon(props: JSX.SVGAttributes<SVGSVGElement>) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/src/components/icons/Restricted.tsx
+++ b/src/components/icons/Restricted.tsx
@@ -1,12 +1,12 @@
 // This file was auto-generated using scripts/generate-icons.js
 import type { JSX } from 'preact';
 
-export type RestrictedIconProps = JSX.SVGAttributes<SVGSVGElement>;
-
 /**
  * Icon generated from restricted.svg
  */
-export default function RestrictedIcon(props: RestrictedIconProps) {
+export default function RestrictedIcon(
+  props: JSX.SVGAttributes<SVGSVGElement>,
+) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/src/components/icons/Search.tsx
+++ b/src/components/icons/Search.tsx
@@ -1,12 +1,10 @@
 // This file was auto-generated using scripts/generate-icons.js
 import type { JSX } from 'preact';
 
-export type SearchIconProps = JSX.SVGAttributes<SVGSVGElement>;
-
 /**
  * Icon generated from search.svg
  */
-export default function SearchIcon(props: SearchIconProps) {
+export default function SearchIcon(props: JSX.SVGAttributes<SVGSVGElement>) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/src/components/icons/Settings.tsx
+++ b/src/components/icons/Settings.tsx
@@ -1,12 +1,10 @@
 // This file was auto-generated using scripts/generate-icons.js
 import type { JSX } from 'preact';
 
-export type SettingsIconProps = JSX.SVGAttributes<SVGSVGElement>;
-
 /**
  * Icon generated from settings.svg
  */
-export default function SettingsIcon(props: SettingsIconProps) {
+export default function SettingsIcon(props: JSX.SVGAttributes<SVGSVGElement>) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/src/components/icons/Share.tsx
+++ b/src/components/icons/Share.tsx
@@ -1,12 +1,10 @@
 // This file was auto-generated using scripts/generate-icons.js
 import type { JSX } from 'preact';
 
-export type ShareIconProps = JSX.SVGAttributes<SVGSVGElement>;
-
 /**
  * Icon generated from share.svg
  */
-export default function ShareIcon(props: ShareIconProps) {
+export default function ShareIcon(props: JSX.SVGAttributes<SVGSVGElement>) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/src/components/icons/Show.tsx
+++ b/src/components/icons/Show.tsx
@@ -1,12 +1,10 @@
 // This file was auto-generated using scripts/generate-icons.js
 import type { JSX } from 'preact';
 
-export type ShowIconProps = JSX.SVGAttributes<SVGSVGElement>;
-
 /**
  * Icon generated from show.svg
  */
-export default function ShowIcon(props: ShowIconProps) {
+export default function ShowIcon(props: JSX.SVGAttributes<SVGSVGElement>) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/src/components/icons/ShowFilled.tsx
+++ b/src/components/icons/ShowFilled.tsx
@@ -1,12 +1,12 @@
 // This file was auto-generated using scripts/generate-icons.js
 import type { JSX } from 'preact';
 
-export type ShowFilledIconProps = JSX.SVGAttributes<SVGSVGElement>;
-
 /**
  * Icon generated from show-filled.svg
  */
-export default function ShowFilledIcon(props: ShowFilledIconProps) {
+export default function ShowFilledIcon(
+  props: JSX.SVGAttributes<SVGSVGElement>,
+) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/src/components/icons/SocialFacebook.tsx
+++ b/src/components/icons/SocialFacebook.tsx
@@ -1,12 +1,12 @@
 // This file was auto-generated using scripts/generate-icons.js
 import type { JSX } from 'preact';
 
-export type SocialFacebookIconProps = JSX.SVGAttributes<SVGSVGElement>;
-
 /**
  * Icon generated from social-facebook.svg
  */
-export default function SocialFacebookIcon(props: SocialFacebookIconProps) {
+export default function SocialFacebookIcon(
+  props: JSX.SVGAttributes<SVGSVGElement>,
+) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/src/components/icons/SocialTwitter.tsx
+++ b/src/components/icons/SocialTwitter.tsx
@@ -1,12 +1,12 @@
 // This file was auto-generated using scripts/generate-icons.js
 import type { JSX } from 'preact';
 
-export type SocialTwitterIconProps = JSX.SVGAttributes<SVGSVGElement>;
-
 /**
  * Icon generated from social-twitter.svg
  */
-export default function SocialTwitterIcon(props: SocialTwitterIconProps) {
+export default function SocialTwitterIcon(
+  props: JSX.SVGAttributes<SVGSVGElement>,
+) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/src/components/icons/Sort.tsx
+++ b/src/components/icons/Sort.tsx
@@ -1,12 +1,10 @@
 // This file was auto-generated using scripts/generate-icons.js
 import type { JSX } from 'preact';
 
-export type SortIconProps = JSX.SVGAttributes<SVGSVGElement>;
-
 /**
  * Icon generated from sort.svg
  */
-export default function SortIcon(props: SortIconProps) {
+export default function SortIcon(props: JSX.SVGAttributes<SVGSVGElement>) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/src/components/icons/SortAlt.tsx
+++ b/src/components/icons/SortAlt.tsx
@@ -1,12 +1,10 @@
 // This file was auto-generated using scripts/generate-icons.js
 import type { JSX } from 'preact';
 
-export type SortAltIconProps = JSX.SVGAttributes<SVGSVGElement>;
-
 /**
  * Icon generated from sort-alt.svg
  */
-export default function SortAltIcon(props: SortAltIconProps) {
+export default function SortAltIcon(props: JSX.SVGAttributes<SVGSVGElement>) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/src/components/icons/SpinnerCircle.tsx
+++ b/src/components/icons/SpinnerCircle.tsx
@@ -1,12 +1,12 @@
 // This file was auto-generated using scripts/generate-icons.js
 import type { JSX } from 'preact';
 
-export type SpinnerCircleIconProps = JSX.SVGAttributes<SVGSVGElement>;
-
 /**
  * Icon generated from spinner--circle.svg
  */
-export default function SpinnerCircleIcon(props: SpinnerCircleIconProps) {
+export default function SpinnerCircleIcon(
+  props: JSX.SVGAttributes<SVGSVGElement>,
+) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/src/components/icons/SpinnerSpokes.tsx
+++ b/src/components/icons/SpinnerSpokes.tsx
@@ -1,12 +1,12 @@
 // This file was auto-generated using scripts/generate-icons.js
 import type { JSX } from 'preact';
 
-export type SpinnerSpokesIconProps = JSX.SVGAttributes<SVGSVGElement>;
-
 /**
  * Icon generated from spinner--spokes.svg
  */
-export default function SpinnerSpokesIcon(props: SpinnerSpokesIconProps) {
+export default function SpinnerSpokesIcon(
+  props: JSX.SVGAttributes<SVGSVGElement>,
+) {
   return (
     <svg
       width="16"

--- a/src/components/icons/Tag.tsx
+++ b/src/components/icons/Tag.tsx
@@ -1,12 +1,10 @@
 // This file was auto-generated using scripts/generate-icons.js
 import type { JSX } from 'preact';
 
-export type TagIconProps = JSX.SVGAttributes<SVGSVGElement>;
-
 /**
  * Icon generated from tag.svg
  */
-export default function TagIcon(props: TagIconProps) {
+export default function TagIcon(props: JSX.SVGAttributes<SVGSVGElement>) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/src/components/icons/TagAlt.tsx
+++ b/src/components/icons/TagAlt.tsx
@@ -1,12 +1,10 @@
 // This file was auto-generated using scripts/generate-icons.js
 import type { JSX } from 'preact';
 
-export type TagAltIconProps = JSX.SVGAttributes<SVGSVGElement>;
-
 /**
  * Icon generated from tag-alt.svg
  */
-export default function TagAltIcon(props: TagAltIconProps) {
+export default function TagAltIcon(props: JSX.SVGAttributes<SVGSVGElement>) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/src/components/icons/TagAltFilled.tsx
+++ b/src/components/icons/TagAltFilled.tsx
@@ -1,12 +1,12 @@
 // This file was auto-generated using scripts/generate-icons.js
 import type { JSX } from 'preact';
 
-export type TagAltFilledIconProps = JSX.SVGAttributes<SVGSVGElement>;
-
 /**
  * Icon generated from tag-alt-filled.svg
  */
-export default function TagAltFilledIcon(props: TagAltFilledIconProps) {
+export default function TagAltFilledIcon(
+  props: JSX.SVGAttributes<SVGSVGElement>,
+) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/src/components/icons/TagFilled.tsx
+++ b/src/components/icons/TagFilled.tsx
@@ -1,12 +1,10 @@
 // This file was auto-generated using scripts/generate-icons.js
 import type { JSX } from 'preact';
 
-export type TagFilledIconProps = JSX.SVGAttributes<SVGSVGElement>;
-
 /**
  * Icon generated from tag-filled.svg
  */
-export default function TagFilledIcon(props: TagFilledIconProps) {
+export default function TagFilledIcon(props: JSX.SVGAttributes<SVGSVGElement>) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/src/components/icons/Theme.tsx
+++ b/src/components/icons/Theme.tsx
@@ -1,12 +1,10 @@
 // This file was auto-generated using scripts/generate-icons.js
 import type { JSX } from 'preact';
 
-export type ThemeIconProps = JSX.SVGAttributes<SVGSVGElement>;
-
 /**
  * Icon generated from theme.svg
  */
-export default function ThemeIcon(props: ThemeIconProps) {
+export default function ThemeIcon(props: JSX.SVGAttributes<SVGSVGElement>) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/src/components/icons/Trash.tsx
+++ b/src/components/icons/Trash.tsx
@@ -1,12 +1,10 @@
 // This file was auto-generated using scripts/generate-icons.js
 import type { JSX } from 'preact';
 
-export type TrashIconProps = JSX.SVGAttributes<SVGSVGElement>;
-
 /**
  * Icon generated from trash.svg
  */
-export default function TrashIcon(props: TrashIconProps) {
+export default function TrashIcon(props: JSX.SVGAttributes<SVGSVGElement>) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/src/components/icons/TrashFilled.tsx
+++ b/src/components/icons/TrashFilled.tsx
@@ -1,12 +1,12 @@
 // This file was auto-generated using scripts/generate-icons.js
 import type { JSX } from 'preact';
 
-export type TrashFilledIconProps = JSX.SVGAttributes<SVGSVGElement>;
-
 /**
  * Icon generated from trash-filled.svg
  */
-export default function TrashFilledIcon(props: TrashFilledIconProps) {
+export default function TrashFilledIcon(
+  props: JSX.SVGAttributes<SVGSVGElement>,
+) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/src/components/icons/VitalSource.tsx
+++ b/src/components/icons/VitalSource.tsx
@@ -1,12 +1,12 @@
 // This file was auto-generated using scripts/generate-icons.js
 import type { JSX } from 'preact';
 
-export type VitalSourceIconProps = JSX.SVGAttributes<SVGSVGElement>;
-
 /**
  * Icon generated from vital-source.svg
  */
-export default function VitalSourceIcon(props: VitalSourceIconProps) {
+export default function VitalSourceIcon(
+  props: JSX.SVGAttributes<SVGSVGElement>,
+) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/src/hooks/use-click-away.ts
+++ b/src/hooks/use-click-away.ts
@@ -3,7 +3,7 @@ import { useEffect } from 'preact/hooks';
 
 import { ListenerCollection } from '../util/listener-collection';
 
-type UseClickAwayOptions = {
+export type UseClickAwayOptions = {
   /** Enable listening for away-click events? Can be set to false to disable */
   enabled?: boolean;
 };
@@ -16,8 +16,10 @@ type UseClickAwayOptions = {
 export function useClickAway(
   container: RefObject<HTMLElement | undefined>,
   callback: (e: Event) => void,
-  { enabled = true }: UseClickAwayOptions = {},
+  options: UseClickAwayOptions = {},
 ) {
+  const { enabled = true } = options;
+
   useEffect(() => {
     if (!enabled) {
       return () => {};

--- a/src/hooks/use-focus-away.ts
+++ b/src/hooks/use-focus-away.ts
@@ -3,7 +3,7 @@ import { useEffect } from 'preact/hooks';
 
 import { ListenerCollection } from '../util/listener-collection';
 
-type UseFocusAwayOptions = {
+export type UseFocusAwayOptions = {
   /** Enable listening for focusout events in `container`? */
   enabled?: boolean;
 };
@@ -16,8 +16,10 @@ type UseFocusAwayOptions = {
 export function useFocusAway(
   container: RefObject<HTMLElement | undefined>,
   callback: (e: FocusEvent) => void,
-  { enabled = true }: UseFocusAwayOptions = {},
+  options: UseFocusAwayOptions = {},
 ) {
+  const { enabled = true } = options;
+
   useEffect(() => {
     if (!enabled || !container.current) {
       return () => {};

--- a/src/hooks/use-key-press.ts
+++ b/src/hooks/use-key-press.ts
@@ -2,7 +2,7 @@ import { useEffect } from 'preact/hooks';
 
 import { ListenerCollection } from '../util/listener-collection';
 
-type UseKeyPressOptions = {
+export type UseKeyPressOptions = {
   /** Enable listening for key events? Can be set to false to disable */
   enabled?: boolean;
 };
@@ -16,8 +16,10 @@ type UseKeyPressOptions = {
 export function useKeyPress(
   keys: string[],
   callback: (e: KeyboardEvent) => void,
-  { enabled = true }: UseKeyPressOptions = {},
+  options: UseKeyPressOptions = {},
 ) {
+  const { enabled = true } = options;
+
   useEffect(() => {
     if (!enabled) {
       return () => {};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,12 @@
 // Hooks
 export { useArrowKeyNavigation } from './hooks/use-arrow-key-navigation';
+export type { UseArrowKeyNavigationOptions } from './hooks/use-arrow-key-navigation';
 export { useClickAway } from './hooks/use-click-away';
+export type { UseClickAwayOptions } from './hooks/use-click-away';
 export { useFocusAway } from './hooks/use-focus-away';
+export type { UseFocusAwayOptions } from './hooks/use-focus-away';
 export { useKeyPress } from './hooks/use-key-press';
+export type { UseKeyPressOptions } from './hooks/use-key-press';
 export { useOrderedRows } from './hooks/use-ordered-rows';
 export { useStableCallback } from './hooks/use-stable-callback';
 export { useSyncedRef } from './hooks/use-synced-ref';

--- a/src/pattern-library/components/Library.tsx
+++ b/src/pattern-library/components/Library.tsx
@@ -21,6 +21,12 @@ import { jsxToHTML } from '../util/jsx-to-string';
 type LibraryElementAttributes = Omit<JSX.HTMLAttributes<HTMLElement>, 'title'>;
 
 export type LibraryPageProps = {
+  /**
+   * Link to the API reference for the main entity described on this page.
+   *
+   * This has the form `{symbolType}/{name}`, eg. `functions/Button`.
+   */
+  apiReference?: string;
   children?: ComponentChildren;
   intro?: ComponentChildren;
   title?: string;
@@ -29,16 +35,21 @@ export type LibraryPageProps = {
 /**
  * Render content for a pattern-library page
  */
-function Page({ children, intro, title }: LibraryPageProps) {
+function Page({ apiReference, children, intro, title }: LibraryPageProps) {
   return (
     <section className="styled-text text-stone-600">
       <div className="px-8 py-4">
         <h1 className="text-3xl text-slate-600 font-bold" id="page-header">
           {title}
         </h1>
-        {intro && (
+        {(intro || apiReference) && (
           <div className="my-8 pb-8 border-b space-y-4 font-light text-xl leading-relaxed">
             {intro}
+            {apiReference && (
+              <div>
+                <a href={`/api/${apiReference}.html`}>API reference</a>
+              </div>
+            )}
           </div>
         )}
         {children}

--- a/src/pattern-library/components/PlaygroundApp.tsx
+++ b/src/pattern-library/components/PlaygroundApp.tsx
@@ -84,6 +84,33 @@ function NavLink({ route }: { route: PlaygroundRoute }) {
   );
 }
 
+function ExternalNavLink({
+  children,
+  href,
+}: {
+  children: ComponentChildren;
+  href: string;
+}) {
+  const isActive = false;
+  return (
+    <li className="-ml-[2px]">
+      <Link
+        classes={classnames(
+          'pl-4 rounded-l-none w-full border-l-2 hover:border-l-brand',
+
+          {
+            'border-l-2 border-brand font-semibold': isActive,
+            'border-transparent': !isActive,
+          },
+        )}
+        href={href}
+      >
+        {children}
+      </Link>
+    </li>
+  );
+}
+
 /**
  * Render web content for the playground application. This includes the "frame"
  * around the page and a navigation channel, as well as the content rendered
@@ -170,6 +197,12 @@ export default function PlaygroundApp({
                 <Scroll>
                   <ScrollContent classes="bg-stone-400/10">
                     <nav id="nav" className="pb-16 space-y-4 mr-4">
+                      <NavHeader>Reference</NavHeader>
+                      <NavList>
+                        <ExternalNavLink href={baseURL + '/api'}>
+                          API reference
+                        </ExternalNavLink>
+                      </NavList>
                       <NavHeader>Foundations</NavHeader>
                       <NavList>
                         {getRoutes('foundations').map(route => (

--- a/src/pattern-library/components/patterns/data/AspectRatioPage.tsx
+++ b/src/pattern-library/components/patterns/data/AspectRatioPage.tsx
@@ -11,6 +11,7 @@ export default function AspectRatioPage() {
           aspect ratio of its first direct child, with a default ratio of 16:9.
         </p>
       }
+      apiReference="functions/AspectRatio"
     >
       <Library.Section>
         <Library.Pattern>

--- a/src/pattern-library/components/patterns/data/DataTablePage.tsx
+++ b/src/pattern-library/components/patterns/data/DataTablePage.tsx
@@ -116,6 +116,7 @@ export default function DataTablePage() {
           the <code>Table</code> family of presentational components.
         </p>
       }
+      apiReference="functions/DataTable"
     >
       <Library.Section>
         <Library.Pattern>

--- a/src/pattern-library/components/patterns/data/ScrollBoxPage.tsx
+++ b/src/pattern-library/components/patterns/data/ScrollBoxPage.tsx
@@ -18,6 +18,7 @@ export default function ScrollBoxPage() {
           are available for additional customization if needed.
         </p>
       }
+      apiReference="functions/ScrollBox"
     >
       <Library.Section
         title="ScrollBox"

--- a/src/pattern-library/components/patterns/data/TablePage.tsx
+++ b/src/pattern-library/components/patterns/data/TablePage.tsx
@@ -20,6 +20,7 @@ export default function TablePage() {
           components for rendering table content.
         </p>
       }
+      apiReference="functions/Table"
     >
       <Library.Section title="Table">
         <Library.Pattern>

--- a/src/pattern-library/components/patterns/data/ThumbnailPage.tsx
+++ b/src/pattern-library/components/patterns/data/ThumbnailPage.tsx
@@ -16,6 +16,7 @@ export default function ThumbnailPage() {
           .
         </p>
       }
+      apiReference="functions/Thumbnail"
     >
       <Library.Section>
         <Library.Pattern>

--- a/src/pattern-library/components/patterns/feedback/CalloutPage.tsx
+++ b/src/pattern-library/components/patterns/feedback/CalloutPage.tsx
@@ -11,6 +11,7 @@ export default function CalloutPage() {
           banners or toast messages.
         </p>
       }
+      apiReference="functions/Callout"
     >
       <Library.Section>
         <Library.Pattern>

--- a/src/pattern-library/components/patterns/feedback/DialogPage.tsx
+++ b/src/pattern-library/components/patterns/feedback/DialogPage.tsx
@@ -207,6 +207,7 @@ export default function DialogPage() {
           <code>Panel</code> layout.
         </p>
       }
+      apiReference="functions/Dialog"
     >
       <Library.Section
         id="dialog"

--- a/src/pattern-library/components/patterns/feedback/SpinnerPage.tsx
+++ b/src/pattern-library/components/patterns/feedback/SpinnerPage.tsx
@@ -20,6 +20,7 @@ export default function SpinnerPage() {
           </p>
         </>
       }
+      apiReference="functions/Spinner"
     >
       <Library.Section
         title="Spinner"

--- a/src/pattern-library/components/patterns/feedback/ToastMessagesPage.tsx
+++ b/src/pattern-library/components/patterns/feedback/ToastMessagesPage.tsx
@@ -125,6 +125,7 @@ export default function ToastMessagesPage() {
           transitions and message positioning.
         </p>
       }
+      apiReference="functions/ToastMessages"
     >
       <Library.Section>
         <Library.Pattern>

--- a/src/pattern-library/components/patterns/input/ButtonPage.tsx
+++ b/src/pattern-library/components/patterns/input/ButtonPage.tsx
@@ -19,6 +19,7 @@ export default function ButtonPage() {
           <code>button</code> elements.
         </p>
       }
+      apiReference="functions/Button"
     >
       <Library.Section title="Button">
         <Library.Pattern>

--- a/src/pattern-library/components/patterns/input/CheckboxPage.tsx
+++ b/src/pattern-library/components/patterns/input/CheckboxPage.tsx
@@ -18,6 +18,7 @@ export default function CheckboxPage() {
           checkbox input and label.
         </p>
       }
+      apiReference="functions/Checkbox"
     >
       <Library.Pattern>
         <Library.Usage componentName="Checkbox" />

--- a/src/pattern-library/components/patterns/input/CloseButtonPage.tsx
+++ b/src/pattern-library/components/patterns/input/CloseButtonPage.tsx
@@ -41,6 +41,7 @@ export default function CloseButtonPage() {
           context.
         </p>
       }
+      apiReference="functions/CloseButton"
     >
       <Library.Section>
         <Library.Pattern>

--- a/src/pattern-library/components/patterns/input/InputGroupPage.tsx
+++ b/src/pattern-library/components/patterns/input/InputGroupPage.tsx
@@ -19,6 +19,7 @@ export default function InputGroupPage() {
           layout and styling for groups of input components.
         </p>
       }
+      apiReference="functions/InputGroup"
     >
       <Library.Section>
         <Library.Pattern>

--- a/src/pattern-library/components/patterns/input/InputPage.tsx
+++ b/src/pattern-library/components/patterns/input/InputPage.tsx
@@ -11,6 +11,7 @@ export default function InputPage() {
           <code>input</code> elements.
         </p>
       }
+      apiReference="functions/Input"
     >
       <Library.Section>
         <Library.Pattern>

--- a/src/pattern-library/components/patterns/input/OptionButtonPage.tsx
+++ b/src/pattern-library/components/patterns/input/OptionButtonPage.tsx
@@ -18,6 +18,7 @@ export default function OptionButtonPage() {
           .
         </p>
       }
+      apiReference="functions/OptionButton"
     >
       <Library.Section>
         <Library.Pattern>

--- a/src/pattern-library/components/patterns/input/SelectPage.tsx
+++ b/src/pattern-library/components/patterns/input/SelectPage.tsx
@@ -39,6 +39,7 @@ export default function SelectPage() {
           </p>
         </>
       }
+      apiReference="functions/Select"
     >
       <Library.Section>
         <Library.Pattern>

--- a/src/pattern-library/components/patterns/input/TextareaPage.tsx
+++ b/src/pattern-library/components/patterns/input/TextareaPage.tsx
@@ -11,6 +11,7 @@ export default function TextareaPage() {
           <code>textarea</code> elements.
         </p>
       }
+      apiReference="functions/Textarea"
     >
       <Library.Section>
         <Library.Pattern>

--- a/src/pattern-library/components/patterns/layout/CardPage.tsx
+++ b/src/pattern-library/components/patterns/layout/CardPage.tsx
@@ -19,6 +19,7 @@ export default function CardPage() {
           support for laying out content in a card-like interface.
         </p>
       }
+      apiReference="functions/Card"
     >
       <Library.Section
         title="Card"

--- a/src/pattern-library/components/patterns/layout/OverlayPage.tsx
+++ b/src/pattern-library/components/patterns/layout/OverlayPage.tsx
@@ -22,6 +22,7 @@ export default function OverlayPage() {
           full-screen backdrops for use during loading or as a modal backdrop.
         </p>
       }
+      apiReference="functions/Overlay"
     >
       <Library.Section title="Overlay">
         <Library.Pattern>

--- a/src/pattern-library/components/patterns/layout/PanelPage.tsx
+++ b/src/pattern-library/components/patterns/layout/PanelPage.tsx
@@ -14,6 +14,7 @@ export default function PanelPage() {
           and its allies.
         </p>
       }
+      apiReference="functions/Panel"
     >
       <Library.Section>
         <Library.Pattern>

--- a/src/pattern-library/components/patterns/navigation/LinkButtonPage.tsx
+++ b/src/pattern-library/components/patterns/navigation/LinkButtonPage.tsx
@@ -11,6 +11,7 @@ export default function LinkButtonPage() {
           to style a button to appear as a link.
         </p>
       }
+      apiReference="functions/LinkButton"
     >
       <Library.Section>
         <Library.Pattern>

--- a/src/pattern-library/components/patterns/navigation/LinkPage.tsx
+++ b/src/pattern-library/components/patterns/navigation/LinkPage.tsx
@@ -11,6 +11,7 @@ export default function LinkPage() {
           and common behavior for anchor (<code>a</code>) elements.
         </p>
       }
+      apiReference="functions/Link"
     >
       <Library.Section title="Link">
         <Library.Pattern>

--- a/src/pattern-library/components/patterns/navigation/PointerButtonPage.tsx
+++ b/src/pattern-library/components/patterns/navigation/PointerButtonPage.tsx
@@ -21,6 +21,7 @@ export default function PointerButtonPage() {
           </p>
         </>
       }
+      apiReference="functions/PointerButton"
     >
       <Library.Section>
         <Library.Pattern>

--- a/src/pattern-library/components/patterns/navigation/TabPage.tsx
+++ b/src/pattern-library/components/patterns/navigation/TabPage.tsx
@@ -17,6 +17,7 @@ export default function TabPage() {
   const [sidebarPanel2, setSidebarPanel2] = useState('annotations');
   const [sidebarPanel3, setSidebarPanel3] = useState('annotations');
   const [verticalPanel, setVerticalPanel] = useState('notifications');
+
   return (
     <Library.Page
       title="Tabs"
@@ -26,6 +27,7 @@ export default function TabPage() {
           components for rendering accessible tabs.
         </p>
       }
+      apiReference="functions/Tab"
     >
       <Library.Section
         title="Tab"

--- a/src/pattern-library/components/patterns/prototype/SelectNextPage.tsx
+++ b/src/pattern-library/components/patterns/prototype/SelectNextPage.tsx
@@ -187,6 +187,7 @@ export default function SelectNextPage() {
           the native <code>{'<select>'}</code> element.
         </p>
       }
+      apiReference="functions/SelectNext"
     >
       <Library.Section>
         <Library.Pattern>

--- a/src/pattern-library/components/patterns/transition/SliderPage.tsx
+++ b/src/pattern-library/components/patterns/transition/SliderPage.tsx
@@ -55,6 +55,7 @@ export default function SliderPage() {
           </p>
         </>
       }
+      apiReference="functions/Slider"
     >
       <Library.Section>
         <Library.Pattern>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2104,6 +2104,7 @@ __metadata:
     sinon: ^17.0.0
     svgo: ^3.0.0
     tailwindcss: 3.4.3
+    typedoc: ^0.25.13
     typescript: ^5.0.2
     wouter-preact: ^3.0.0
     yalc: ^1.0.0-pre.50
@@ -2955,6 +2956,13 @@ __metadata:
   version: 6.0.1
   resolution: "ansi-regex@npm:6.0.1"
   checksum: 1ff8b7667cded1de4fa2c9ae283e979fc87036864317da86a2e546725f96406746411d0d85e87a2d12fa5abd715d90006de7fa4fa0477c92321ad3b4c7d4e169
+  languageName: node
+  linkType: hard
+
+"ansi-sequence-parser@npm:^1.1.0":
+  version: 1.1.1
+  resolution: "ansi-sequence-parser@npm:1.1.1"
+  checksum: ead5b15c596e8e85ca02951a844366c6776769dcc9fd1bd3a0db11bb21364554822c6a439877fb599e7e1ffa0b5f039f1e5501423950457f3dcb2f480c30b188
   languageName: node
   linkType: hard
 
@@ -7612,6 +7620,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jsonc-parser@npm:^3.2.0":
+  version: 3.2.1
+  resolution: "jsonc-parser@npm:3.2.1"
+  checksum: 656d9027b91de98d8ab91b3aa0d0a4cab7dc798a6830845ca664f3e76c82d46b973675bbe9b500fae1de37fd3e81aceacbaa2a57884bf2f8f29192150d2d1ef7
+  languageName: node
+  linkType: hard
+
 "jsonfile@npm:^4.0.0":
   version: 4.0.0
   resolution: "jsonfile@npm:4.0.0"
@@ -8015,6 +8030,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lunr@npm:^2.3.9":
+  version: 2.3.9
+  resolution: "lunr@npm:2.3.9"
+  checksum: 176719e24fcce7d3cf1baccce9dd5633cd8bdc1f41ebe6a180112e5ee99d80373fe2454f5d4624d437e5a8319698ca6837b9950566e15d2cae5f2a543a3db4b8
+  languageName: node
+  linkType: hard
+
 "magic-string@npm:^0.30.3":
   version: 0.30.5
   resolution: "magic-string@npm:0.30.5"
@@ -8079,6 +8101,15 @@ __metadata:
   version: 0.2.2
   resolution: "map-cache@npm:0.2.2"
   checksum: 3067cea54285c43848bb4539f978a15dedc63c03022abeec6ef05c8cb6829f920f13b94bcaf04142fc6a088318e564c4785704072910d120d55dbc2e0c421969
+  languageName: node
+  linkType: hard
+
+"marked@npm:^4.3.0":
+  version: 4.3.0
+  resolution: "marked@npm:4.3.0"
+  bin:
+    marked: bin/marked.js
+  checksum: 0db6817893952c3ec710eb9ceafb8468bf5ae38cb0f92b7b083baa13d70b19774674be04db5b817681fa7c5c6a088f61300815e4dd75a59696f4716ad69f6260
   languageName: node
   linkType: hard
 
@@ -8217,6 +8248,15 @@ __metadata:
   dependencies:
     brace-expansion: ^2.0.1
   checksum: 97f5f5284bb57dc65b9415dec7f17a0f6531a33572193991c60ff18450dcfad5c2dad24ffeaf60b5261dccd63aae58cc3306e2209d57e7f88c51295a532d8ec3
+  languageName: node
+  linkType: hard
+
+"minimatch@npm:^9.0.3":
+  version: 9.0.4
+  resolution: "minimatch@npm:9.0.4"
+  dependencies:
+    brace-expansion: ^2.0.1
+  checksum: cf717f597ec3eed7dabc33153482a2e8d49f4fd3c26e58fd9c71a94c5029a0838728841b93f46bf1263b65a8010e2ee800d0dc9b004ab8ba8b6d1ec07cc115b5
   languageName: node
   linkType: hard
 
@@ -10310,6 +10350,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"shiki@npm:^0.14.7":
+  version: 0.14.7
+  resolution: "shiki@npm:0.14.7"
+  dependencies:
+    ansi-sequence-parser: ^1.1.0
+    jsonc-parser: ^3.2.0
+    vscode-oniguruma: ^1.7.0
+    vscode-textmate: ^8.0.0
+  checksum: 2aec3b3519df977c4391df9e1825cb496e9a4d7e11395f05a0da77e4fa2f7c3d9d6e6ee94029ac699533017f2b25637ee68f6d39f05f311535c2704d0329b520
+  languageName: node
+  linkType: hard
+
 "side-channel@npm:^1.0.4":
   version: 1.0.4
   resolution: "side-channel@npm:1.0.4"
@@ -11179,6 +11231,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"typedoc@npm:^0.25.13":
+  version: 0.25.13
+  resolution: "typedoc@npm:0.25.13"
+  dependencies:
+    lunr: ^2.3.9
+    marked: ^4.3.0
+    minimatch: ^9.0.3
+    shiki: ^0.14.7
+  peerDependencies:
+    typescript: 4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x
+  bin:
+    typedoc: bin/typedoc
+  checksum: 703d1f48137300b0ef3df1998a25ae745db3ca0b126f8dd1f7262918f11243a94d24dfc916cdba2baeb5a7d85d5a94faac811caf7f4fa6b7d07144dc02f7639f
+  languageName: node
+  linkType: hard
+
 "typescript@npm:^5.0.2":
   version: 5.4.5
   resolution: "typescript@npm:5.4.5"
@@ -11495,6 +11563,20 @@ __metadata:
   version: 2.0.1
   resolution: "void-elements@npm:2.0.1"
   checksum: 700c07ba9cfa2dff88bb23974b3173118f9ad8107143db9e5d753552be15cf93380954d4e7f7d7bc80e7306c35c3a7fb83ab0ce4d4dcc18abf90ca8b31452126
+  languageName: node
+  linkType: hard
+
+"vscode-oniguruma@npm:^1.7.0":
+  version: 1.7.0
+  resolution: "vscode-oniguruma@npm:1.7.0"
+  checksum: 53519d91d90593e6fb080260892e87d447e9b200c4964d766772b5053f5699066539d92100f77f1302c91e8fc5d9c772fbe40fe4c90f3d411a96d5a9b1e63f42
+  languageName: node
+  linkType: hard
+
+"vscode-textmate@npm:^8.0.0":
+  version: 8.0.0
+  resolution: "vscode-textmate@npm:8.0.0"
+  checksum: 127780dfea89559d70b8326df6ec344cfd701312dd7f3f591a718693812b7852c30b6715e3cfc8b3200a4e2515b4c96f0843c0eacc0a3020969b5de262c2a4bb
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR adds API reference documentation to the pattern library website, built using TypeDoc.

The docs are built by running `yarn apidoc`, which will generate them in `build/api/`. The contents of this directory are exposed under the `/api` path on the website. There is a link to the main page of the API reference in the left navigation bar, plus links to corresponding pages at the top of each component page.

The generated documentation has some issues:

- The index page is very noisy because of all the near-identical `{IconName}Props` types for icons, and the `{ComponentName}Props` type for each component. I think ideally we just want the actual functions on the entry page, and these will link to relevant types.
- The types for components are comprised of a union of several subtypes. One of the most important of these is `ComponentProps`, which contains the props unique to a particular component, but this is not exported. This means the component-specific props are missing. One way to fix this would be to revise the pattern so that the `ComponentProps` type is inlined into the `{ComponentName}Props` type.
- References to external types from Preact are not links
- Each component's `props` argument is named `__namedParameters` in the docs, because no formal name is specified. This can be fixed by adding a `@param` tag, or by giving the parameter a proper name and destructuring into props inside the function.

Part of https://github.com/hypothesis/frontend-shared/issues/1532.