### PR TITLE
Use `popover=""` instead of `popover={true}` in SelectNext

### DIFF
--- a/src/components/input/SelectNext.tsx
+++ b/src/components/input/SelectNext.tsx
@@ -287,7 +287,7 @@ function SelectMain<T>({
   const buttonRef = useSyncedRef(elementRef);
   const defaultButtonId = useId();
   const extraProps = useMemo(
-    () => (listboxAsPopover ? { popover: true } : {}),
+    () => (listboxAsPopover ? { popover: '' } : {}),
     [listboxAsPopover],
   );
 


### PR DESCRIPTION
Since preact does not yet fully support the `popover` attribute, setting it as `popover=""` instead of `popover={true}` to avoid this warning in Chrome:

![image](https://github.com/hypothesis/frontend-shared/assets/2719332/de43e116-a1e5-4b2e-a619-f7740db86617)