### PR TITLE
Allow dynamically loaded example files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ RUN rm -r /usr/share/nginx/html && rm /etc/nginx/conf.d/default.conf
 COPY --from=builder /frontend-shared/build /usr/share/nginx/html
 COPY ./templates/index.html /usr/share/nginx/html/index.html
 COPY ./images /usr/share/nginx/html/images
+COPY ./src/pattern-library/examples /usr/share/nginx/html/examples
 COPY conf/nginx.conf /etc/nginx/conf.d/default.conf
 
 EXPOSE 5001

--- a/README.md
+++ b/README.md
@@ -49,3 +49,4 @@ import { Link } from '@hypothesis/frontend-shared';
 
 - [Development guide](docs/developing.md)
 - [Release guide](docs/releases.md)
+- [Adding examples](docs/examples.md)

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,0 +1,28 @@
+# Adding code examples
+
+Component library documentation frequently needs to show interactive examples, along with the code for them.
+
+Manually writing those code snippets has some issues: they are not covered by your type checking and linting tasks, and they can accidentally get outdated.
+
+The web-based documentation included with this library allows to create example files which are both used as regular modules that can be imported for interactive examples, but also read as plain text to generate their corresponding code snippet.
+
+These files are type-checked, formatted and linted like any other source files, and the code snippet will always be in sync with the interactive example.
+
+## Using example files
+
+When you want to create a code example, add a file with the name of your choice inside `src/pattern-library/examples` directory.
+
+You can then reference this file from the web-based pattern library, passing the `exampleFile` prop to the `<Library.Demo />` component.
+
+```tsx
+<Library.Demo exampleFile="some-example-file-name" />
+```
+
+## Considerations
+
+There are some considerations and limitations when working with example files.
+
+- They all need to have the `tsx` extension.
+- Nested directories are not supported, so it's a good idea to add contextual prefixes to example files. For example, all files related with `SelectNext` can be prefixed with `select-next` to make sure they are all grouped together.
+- Example files need to have a Preact component as their default export.
+- When generating the source code snippet, import statements are stripped out, to avoid internal module references which are not relevant for the library consumers.

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@hypothesis/frontend-testing": "^1.2.2",
     "@rollup/plugin-babel": "^6.0.0",
     "@rollup/plugin-commonjs": "^25.0.0",
+    "@rollup/plugin-dynamic-import-vars": "^2.1.2",
     "@rollup/plugin-node-resolve": "^15.0.0",
     "@rollup/plugin-virtual": "^3.0.0",
     "@trivago/prettier-plugin-sort-imports": "^4.1.1",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,5 +1,6 @@
 import { babel } from '@rollup/plugin-babel';
 import commonjs from '@rollup/plugin-commonjs';
+import dynamicImportVars from '@rollup/plugin-dynamic-import-vars';
 import { nodeResolve } from '@rollup/plugin-node-resolve';
 import { string } from 'rollup-plugin-string';
 
@@ -27,6 +28,7 @@ function bundleConfig(name, entryFile) {
         exclude: 'node_modules/**',
         extensions: ['.js', '.ts', '.tsx'],
       }),
+      dynamicImportVars(),
       nodeResolve({ extensions: ['.js', '.ts', '.tsx'] }),
       commonjs({ include: 'node_modules/**' }),
       string({

--- a/scripts/serve-pattern-library.js
+++ b/scripts/serve-pattern-library.js
@@ -11,6 +11,10 @@ export function servePatternLibrary(port = 4001) {
   app.use('/scripts', express.static(path.join(dirname, '../build/scripts')));
   app.use('/styles', express.static(path.join(dirname, '../build/styles')));
   app.use('/images', express.static(path.join(dirname, '../images')));
+  app.use(
+    '/examples',
+    express.static(path.join(dirname, '../src/pattern-library/examples')),
+  );
 
   // For any other path, serve the index.html file to allow client-side routing
   app.get('/:path?', (req, res) => {

--- a/src/pattern-library/components/patterns/prototype/SelectNextPage.tsx
+++ b/src/pattern-library/components/patterns/prototype/SelectNextPage.tsx
@@ -195,11 +195,11 @@ export default function SelectNextPage() {
           <Library.Usage componentName="SelectNext" />
 
           <Library.Example>
-            <Library.Demo title="Basic Select">
-              <div className="w-96 mx-auto">
-                <SelectExample textOnly />
-              </div>
-            </Library.Demo>
+            <Library.Demo
+              title="Basic Select"
+              exampleFile="select-next-basic"
+              withSource
+            />
           </Library.Example>
         </Library.Pattern>
 
@@ -509,17 +509,11 @@ export default function SelectNextPage() {
                 . Otherwise it is <code>false</code>
               </Library.InfoItem>
             </Library.Info>
-            <Library.Demo title="Non-popover listbox">
-              <div className="w-full">
-                <p>
-                  When not using the <code>popover</code> API, the listbox will
-                  be constrained by its container dimensions.
-                </p>
-                <div className="w-96 h-32 mx-auto overflow-auto">
-                  <SelectExample listboxAsPopover={false} />
-                </div>
-              </div>
-            </Library.Demo>
+            <Library.Demo
+              title="Non-popover listbox"
+              exampleFile="select-next-non-popover-listbox"
+              withSource
+            />
           </Library.Example>
         </Library.Pattern>
 
@@ -570,51 +564,6 @@ export default function SelectNextPage() {
               </div>
             </Library.Demo>
           </Library.Example>
-        </Library.Pattern>
-
-        <Library.Pattern title="How to use it">
-          <p>
-            <code>SelectNext</code> is meant to be used as a controlled
-            component.
-          </p>
-
-          <Library.Code
-            content={`function App() {
-  const [value, setSelected] = useState<{ id: string; name: string }>();
-  return (
-    <SelectNext
-      value={value}
-      onChange={setSelected}
-      buttonContent={
-        value ? (
-          <>
-            {value.name}
-            <div className="rounded px-2 ml-2 bg-grey-7 text-white">
-              {value.id}
-            </div>
-          </>
-        ) : (
-          <>Select one…</>
-        )
-      }
-    >
-      {items.map(item => (
-        <SelectNext.Option value={item} key={item.id}>
-          {() => (
-            <>
-              {item.name}
-              <div className="grow" />
-              <div className="rounded px-2 bg-grey-7 text-white">
-                {item.id}
-              </div>
-            </>
-          )}
-        </SelectNext.Option>
-      ))}
-    </SelectNext>
-  );
-}`}
-          />
         </Library.Pattern>
       </Library.Section>
     </Library.Page>

--- a/src/pattern-library/examples/select-next-basic.tsx
+++ b/src/pattern-library/examples/select-next-basic.tsx
@@ -1,0 +1,34 @@
+import { useId, useState } from 'preact/hooks';
+
+import { SelectNext } from '../..';
+
+const items = [
+  { id: '1', name: 'All students' },
+  { id: '2', name: 'Albert Banana' },
+  { id: '3', name: 'Bernard California' },
+  { id: '4', name: 'Cecelia Davenport' },
+  { id: '5', name: 'Doris Evanescence' },
+];
+
+export default function App() {
+  const [value, setSelected] = useState<{ id: string; name: string }>();
+  const selectId = useId();
+
+  return (
+    <div className="w-96 mx-auto">
+      <label htmlFor={selectId}>Select a person</label>
+      <SelectNext
+        value={value}
+        onChange={setSelected}
+        buttonId={selectId}
+        buttonContent={value ? value.name : <>Select one…</>}
+      >
+        {items.map(item => (
+          <SelectNext.Option value={item} key={item.id}>
+            {item.name}
+          </SelectNext.Option>
+        ))}
+      </SelectNext>
+    </div>
+  );
+}

--- a/src/pattern-library/examples/select-next-non-popover-listbox.tsx
+++ b/src/pattern-library/examples/select-next-non-popover-listbox.tsx
@@ -1,0 +1,70 @@
+import { useId, useState } from 'preact/hooks';
+
+import { SelectNext } from '../..';
+
+type ItemType = {
+  id: string;
+  name: string;
+  disabled?: boolean;
+};
+
+const items: ItemType[] = [
+  { id: '1', name: 'All students' },
+  { id: '2', name: 'Albert Banana' },
+  { id: '3', name: 'Bernard California' },
+  { id: '4', name: 'Cecelia Davenport' },
+  { id: '5', name: 'Doris Evanescence' },
+];
+
+export default function App() {
+  const [value, setValue] = useState<ItemType>();
+  const buttonId = useId();
+
+  return (
+    <div className="w-full">
+      <p>
+        When not using the <code>popover</code> API, the listbox may be clipped
+        by parent elements that are styled to hide overflow.
+      </p>
+      <div className="w-96 h-32 mx-auto overflow-auto">
+        <>
+          <label htmlFor={buttonId}>Select a person</label>
+          <SelectNext
+            listboxAsPopover={false}
+            buttonId={buttonId}
+            value={value}
+            onChange={setValue}
+            buttonContent={
+              value ? (
+                <>
+                  <div className="flex">
+                    <div className="truncate">{value.name}</div>
+                    <div className="rounded px-2 ml-2 bg-grey-7 text-white">
+                      {value.id}
+                    </div>
+                  </div>
+                </>
+              ) : (
+                <>Select one…</>
+              )
+            }
+          >
+            {items.map(item => (
+              <SelectNext.Option
+                value={item}
+                key={item.id}
+                disabled={item.disabled}
+              >
+                {item.name}
+                <div className="grow" />
+                <div className="rounded px-2 ml-2 text-white bg-grey-7">
+                  {item.id}
+                </div>
+              </SelectNext.Option>
+            ))}
+          </SelectNext>
+        </>
+      </div>
+    </div>
+  );
+}

--- a/src/pattern-library/util/jsx-to-string.tsx
+++ b/src/pattern-library/util/jsx-to-string.tsx
@@ -1,5 +1,5 @@
 import hljs from 'highlight.js/lib/core';
-import hljsJavascriptLang from 'highlight.js/lib/languages/javascript';
+import hljsTypeScriptLang from 'highlight.js/lib/languages/typescript';
 import hljsXMLLang from 'highlight.js/lib/languages/xml';
 import { Fragment } from 'preact';
 import type { ComponentChildren, VNode } from 'preact';
@@ -156,20 +156,34 @@ export function jsxToString(vnode: ComponentChildren): string {
 }
 
 /**
- * Render a JSX expression as syntax-highlighted HTML markup.
+ * Render a code snippet as syntax-highlighted HTML markup.
  *
  * For the syntax highlighting to be visible, a Highlight.js CSS stylesheet must be
  * loaded on the page.
+ *
+ * The content returned by this function is sanitized and safe to use as
+ * `dangerouslySetInnerHTML` prop.
  */
-export function jsxToHTML(vnode: ComponentChildren): string {
-  // JSX support in Highlight.js involves a combination of the JS and XML
+export function highlightCode(code: string): string {
+  // JSX support in Highlight.js involves a combination of the TS and XML
   // languages, so we need to load both.
-  if (!hljs.getLanguage('javascript')) {
-    hljs.registerLanguage('javascript', hljsJavascriptLang);
+  if (!hljs.getLanguage('typescript')) {
+    hljs.registerLanguage('typescript', hljsTypeScriptLang);
   }
   if (!hljs.getLanguage('xml')) {
     hljs.registerLanguage('xml', hljsXMLLang);
   }
-  const code = jsxToString(vnode);
+
   return hljs.highlightAuto(code).value;
+}
+
+/**
+ * Render a JSX expression as syntax-highlighted HTML markup.
+ *
+ * The content returned by this function is sanitized and safe to use as
+ * `dangerouslySetInnerHTML` prop.
+ */
+export function jsxToHTML(vnode: ComponentChildren): string {
+  const code = jsxToString(vnode);
+  return highlightCode(code);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2148,6 +2148,7 @@ __metadata:
     "@hypothesis/frontend-testing": ^1.2.2
     "@rollup/plugin-babel": ^6.0.0
     "@rollup/plugin-commonjs": ^25.0.0
+    "@rollup/plugin-dynamic-import-vars": ^2.1.2
     "@rollup/plugin-node-resolve": ^15.0.0
     "@rollup/plugin-virtual": ^3.0.0
     "@trivago/prettier-plugin-sort-imports": ^4.1.1
@@ -2445,6 +2446,24 @@ __metadata:
     rollup:
       optional: true
   checksum: 052e11839a9edc556eda5dcc759ab816dcc57e9f0f905a1e6e14fff954eaa6b1e2d0d544f5bd18d863993c5eba43d8ac9c19d9bb53b1c3b1213f32cfc9d50b2e
+  languageName: node
+  linkType: hard
+
+"@rollup/plugin-dynamic-import-vars@npm:^2.1.2":
+  version: 2.1.2
+  resolution: "@rollup/plugin-dynamic-import-vars@npm:2.1.2"
+  dependencies:
+    "@rollup/pluginutils": ^5.0.1
+    astring: ^1.8.5
+    estree-walker: ^2.0.2
+    fast-glob: ^3.2.12
+    magic-string: ^0.30.3
+  peerDependencies:
+    rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
+  peerDependenciesMeta:
+    rollup:
+      optional: true
+  checksum: 355dfc42cf1b0ddd009393927cdb9ea1d24cb674a9cdda732d0cb1320bb747c2f6d8e68f4dcb8507e37314ac916e8859e722f583371228bede140b5b83b67549
   languageName: node
   linkType: hard
 
@@ -3352,6 +3371,15 @@ __metadata:
   version: 0.0.8
   resolution: "ast-types-flow@npm:0.0.8"
   checksum: 0a64706609a179233aac23817837abab614f3548c252a2d3d79ea1e10c74aa28a0846e11f466cf72771b6ed8713abc094dcf8c40c3ec4207da163efa525a94a8
+  languageName: node
+  linkType: hard
+
+"astring@npm:^1.8.5":
+  version: 1.8.6
+  resolution: "astring@npm:1.8.6"
+  bin:
+    astring: bin/astring
+  checksum: 6f034d2acef1dac8bb231e7cc26c573d3c14e1975ea6e04f20312b43d4f462f963209bc64187d25d477a182dc3c33277959a0156ab7a3617aa79b1eac4d88e1f
   languageName: node
   linkType: hard
 
@@ -5667,6 +5695,19 @@ __metadata:
   version: 1.3.2
   resolution: "fast-fifo@npm:1.3.2"
   checksum: 6bfcba3e4df5af7be3332703b69a7898a8ed7020837ec4395bb341bd96cc3a6d86c3f6071dd98da289618cf2234c70d84b2a6f09a33dd6f988b1ff60d8e54275
+  languageName: node
+  linkType: hard
+
+"fast-glob@npm:^3.2.12":
+  version: 3.3.2
+  resolution: "fast-glob@npm:3.3.2"
+  dependencies:
+    "@nodelib/fs.stat": ^2.0.2
+    "@nodelib/fs.walk": ^1.2.3
+    glob-parent: ^5.1.2
+    merge2: ^1.3.0
+    micromatch: ^4.0.4
+  checksum: 900e4979f4dbc3313840078419245621259f349950411ca2fa445a2f9a1a6d98c3b5e7e0660c5ccd563aa61abe133a21765c6c0dec8e57da1ba71d8000b05ec1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR adds support to  individual examples files that can be used in the pattern library docs both to generate actual working examples that are part of the bundle, while at the same time we load them as un-processed plain text that can be inlined as code snippets.

Those files are type-checked, linted and formatted, ensuring they are always up to date with the actual source code and they follow our standard rules.

In order to achieve this, this PR adds a new `examples` folder inside `src/pattern-library`. Files in this folder are statically exposed via express/nginx, so that we can do a `fetch('/examples/filename.tsx')` and load them as plain text.

At the same time, we can dynamically import those files in order to use the actual source code, with `import('/examples/filename.tsx')`.

This PR extends the `Library.Demo` component to accept an `exampleFile` prop, `<Library.Demo exampleFile="some-file" />`, which transparently does both things internally by loading the contents of the referenced example file.

Additionally, the existing `<Library.Code />` component has been enhanced to also allow an `exampleFile` prop instead of `content`, in order to load the source code from an external file.

This PR also adds a couple examples as a proof of concept of this new functionality.

### TODO

- [x] ~Consider caching/memoizing the content of examples that have already been `fetch`ed.~ I finally refactored a bit the logic, so that the file is loaded when `Demo` renders, not every time the tab changes. That way all files are only fetched once when the page loads.
- [x] Document limitations of the approach (extension must be `.tsx`, no nested dirs supported, recommendation to prefix file names, requirement of a default export, etc.)

### Considerations

Some alternative approach to get the static example file content could go into using some babel or rollup plugin that captures the use of `fs.readFileSync` or similar. I found a couple but they were mostly unmaintained and outdated, and I saw some reported issues regarding incompatibilities with modern practices, so I decided to go the `fetch` way instead.