### PR TITLE
Allow OrderDirection type to be imported from the main entry point

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -76,6 +76,7 @@ export type {
   CompositeProps,
   IconComponent,
   Order,
+  OrderDirection,
   PresentationalProps,
   TransitionComponent,
 } from './types';


### PR DESCRIPTION
This was an overlook in https://github.com/hypothesis/frontend-shared/pull/1564.

Exporting `OrderDirection` type in a way that it can be imported as `import type { OrderDirection } from '@hypothesis/frontend-shared'`.