### PR TITLE
Do not call onConfirmRow when Enter is pressed in DataTable row children

### DIFF
--- a/src/components/data/DataTable.tsx
+++ b/src/components/data/DataTable.tsx
@@ -247,7 +247,9 @@ export default function DataTable<Row>({
 
   const handleKeyDown = useCallback(
     (event: KeyboardEvent, row: Row) => {
-      if (event.key === 'Enter') {
+      // Avoid preventing Enter key interactions in children elements by
+      // ignoring events not triggered by the row element itself
+      if (event.key === 'Enter' && event.target === event.currentTarget) {
         confirmRow(row);
         event.preventDefault();
         event.stopPropagation();

--- a/src/components/data/test/DataTable-test.js
+++ b/src/components/data/test/DataTable-test.js
@@ -273,6 +273,18 @@ describe('DataTable', () => {
 
       assert.calledWith(onConfirmRow, fakeRows[0]);
     });
+
+    it("does not invoke `onConfirmRow` callback when `Enter` is pressed on a row's child", () => {
+      const onConfirmRow = sinon.stub();
+      const wrapper = createComponent({
+        onConfirmRow,
+        renderItem: (row, field) => <a href="/">{field}</a>,
+      });
+
+      wrapper.find('tbody tr a').first().simulate('keydown', { key: 'Enter' });
+
+      assert.notCalled(onConfirmRow);
+    });
   });
 
   context('when loading', () => {


### PR DESCRIPTION
This PR fixes a bug where elements that can be interacted with <kbd>Enter</kbd> key would stop the event propagation when rendered inside a `DataTable` row, via `renderItem`.