### PR TITLE
Add fill attribute to pointer-up and pointer-down icons

### DIFF
--- a/images/icons/pointer-down.svg
+++ b/images/icons/pointer-down.svg
@@ -1,5 +1,5 @@
 <svg width="16" height="9" xmlns="http://www.w3.org/2000/svg" xmlns:svg="http://www.w3.org/2000/svg">
  <g>
-  <path d="m0.5,8l7,-8l8,8" stroke="currentColor" transform="rotate(180 8 4)"/>
+  <path d="m0.5,8l7,-8l8,8" stroke="currentColor" fill="currentColor" transform="rotate(180 8 4)" />
  </g>
 </svg>

--- a/images/icons/pointer-up.svg
+++ b/images/icons/pointer-up.svg
@@ -1,5 +1,5 @@
 <svg width="16" height="9" xmlns="http://www.w3.org/2000/svg" xmlns:svg="http://www.w3.org/2000/svg">
  <g>
-  <path d="m0.5,9l7,-8l8,8" stroke="currentColor"/>
+  <path d="m0.5,9l7,-8l8,8" stroke="currentColor" fill="currentColor" />
  </g>
 </svg>

--- a/src/components/icons/PointerDown.tsx
+++ b/src/components/icons/PointerDown.tsx
@@ -15,7 +15,7 @@ export default function PointerDownIcon(props: PointerDownIconProps) {
       data-component="PointerDownIcon"
       {...props}
     >
-      <path stroke="currentColor" d="m15.5 0-7 8-8-8" />
+      <path fill="currentColor" stroke="currentColor" d="m15.5 0-7 8-8-8" />
     </svg>
   );
 }

--- a/src/components/icons/PointerUp.tsx
+++ b/src/components/icons/PointerUp.tsx
@@ -15,7 +15,7 @@ export default function PointerUpIcon(props: PointerUpIconProps) {
       data-component="PointerUpIcon"
       {...props}
     >
-      <path stroke="currentColor" d="m.5 9 7-8 8 8" />
+      <path fill="currentColor" stroke="currentColor" d="m.5 9 7-8 8 8" />
     </svg>
   );
 }


### PR DESCRIPTION
Add a missing `fill="currentColor"` attribute to `PointerUp` and `PointerDown` colors. I added it to the svg files, and then regenerated icons.

Notice the color difference of the two bottom-left icons compored to the rest.

Before:

![Captura desde 2024-06-19 09-04-09](https://github.com/hypothesis/frontend-shared/assets/2719332/c6d999c7-0108-4be3-8238-a29066575858)

After:

![Captura desde 2024-06-19 09-04-15](https://github.com/hypothesis/frontend-shared/assets/2719332/5b7eb529-798f-4bdd-ae85-afd4d8fe5963)