### PR TITLE
Allow useOrderedRows to put all null elements at the bottom

### DIFF
--- a/src/hooks/use-ordered-rows.ts
+++ b/src/hooks/use-ordered-rows.ts
@@ -19,6 +19,9 @@ export function useOrderedRows<Row>(
       return rows;
     }
 
+    // Order nulls last by default
+    const { nullsLast = true } = order;
+
     return [...rows].sort(({ [order.field]: a }, { [order.field]: b }) => {
       const [x, y] = order.direction === 'ascending' ? [a, b] : [b, a];
 
@@ -28,6 +31,15 @@ export function useOrderedRows<Row>(
 
       if (x === y) {
         return 0;
+      }
+
+      // We check a/b instead of x/y because nulls should not be affected by the
+      // regular order direction.
+      if (a === null || a === undefined) {
+        return nullsLast ? 1 : -1;
+      }
+      if (b === null || b === undefined) {
+        return nullsLast ? -1 : 1;
       }
 
       return x > y ? 1 : -1;

--- a/src/types.ts
+++ b/src/types.ts
@@ -64,4 +64,11 @@ export type OrderDirection = 'ascending' | 'descending';
 export type Order<Field extends string | number | symbol> = {
   field: Field;
   direction: OrderDirection;
+
+  /**
+   * Indicates whether entries where the value for `field` is null/undefined
+   * should go last. Otherwise, they will go first.
+   * Defaults to true.
+   */
+  nullsLast?: boolean;
 };


### PR DESCRIPTION
This PR changes `useOrderedRows` so that it can make `null`/`undefined` values be put always at the bottom of the list, and makes this the default behavior.

This is done by adding a new `nullsLast` option to the `order` object, which is `true` by default.

Callers will need to explicitly switch from `nullsLast: true` to `nullsLast: false` if they want this to change as the order direction changes:

```tsx
const direction = 'descending';
const order = {
  field: 'display_name',
  direction,
  nullFirst: direction === 'descending',
}
```

Previously we were comparing nulls normally with other non-null values, which produced unintuitive results, because in JS both `'some string' > null` and `null > 'some string'` are `false`.