### PR TITLE
Revert "Add fill attribute to pointer-up and pointer-down icons"

### DIFF
--- a/images/icons/pointer-down.svg
+++ b/images/icons/pointer-down.svg
@@ -1,5 +1,5 @@
 <svg width="16" height="9" xmlns="http://www.w3.org/2000/svg" xmlns:svg="http://www.w3.org/2000/svg">
  <g>
-  <path d="m0.5,8l7,-8l8,8" stroke="currentColor" fill="currentColor" transform="rotate(180 8 4)" />
+  <path d="m0.5,8l7,-8l8,8" stroke="currentColor" transform="rotate(180 8 4)"/>
  </g>
 </svg>

--- a/images/icons/pointer-up.svg
+++ b/images/icons/pointer-up.svg
@@ -1,5 +1,5 @@
 <svg width="16" height="9" xmlns="http://www.w3.org/2000/svg" xmlns:svg="http://www.w3.org/2000/svg">
  <g>
-  <path d="m0.5,9l7,-8l8,8" stroke="currentColor" fill="currentColor" />
+  <path d="m0.5,9l7,-8l8,8" stroke="currentColor"/>
  </g>
 </svg>

--- a/src/components/icons/PointerDown.tsx
+++ b/src/components/icons/PointerDown.tsx
@@ -15,7 +15,7 @@ export default function PointerDownIcon(props: PointerDownIconProps) {
       data-component="PointerDownIcon"
       {...props}
     >
-      <path fill="currentColor" stroke="currentColor" d="m15.5 0-7 8-8-8" />
+      <path stroke="currentColor" d="m15.5 0-7 8-8-8" />
     </svg>
   );
 }

--- a/src/components/icons/PointerUp.tsx
+++ b/src/components/icons/PointerUp.tsx
@@ -15,7 +15,7 @@ export default function PointerUpIcon(props: PointerUpIconProps) {
       data-component="PointerUpIcon"
       {...props}
     >
-      <path fill="currentColor" stroke="currentColor" d="m.5 9 7-8 8 8" />
+      <path stroke="currentColor" d="m.5 9 7-8 8 8" />
     </svg>
   );
 }


### PR DESCRIPTION
Reverts hypothesis/frontend-shared#1586.

This broke rendering of the adder toolbar in the client. It turns out the `fill` attribute was intentionally omitted for this particular icon, with the idea being that the caller can set it on a parent DOM element and have it inherited.

Before:

<img width="175" alt="Screenshot 2024-06-24 at 12 57 36" src="https://github.com/hypothesis/frontend-shared/assets/2458/e3527165-177a-409a-9932-48df1b773eb0">

After:

<img width="317" alt="Screenshot 2024-06-24 at 12 55 16" src="https://github.com/hypothesis/frontend-shared/assets/2458/bd845951-06a1-4b8c-a892-16cf92a177b1">

Slack thread: https://hypothes-is.slack.com/archives/C1M8NH76X/p1719230027843259