### PR TITLE
Allow multiple selection in SelectNext

### DIFF
--- a/src/components/input/SelectContext.ts
+++ b/src/components/input/SelectContext.ts
@@ -1,9 +1,20 @@
 import { createContext } from 'preact';
 
-export type SelectContextType<T = unknown> = {
+type SingleSelectContext<T> = {
   selectValue: (newValue: T) => void;
   value: T;
+  multiple: false;
 };
+
+type MultiSelectContext<T> = {
+  selectValue: (newValue: T[]) => void;
+  value: T[];
+  multiple: true;
+};
+
+export type SelectContextType<T = unknown> =
+  | SingleSelectContext<T>
+  | MultiSelectContext<T>;
 
 const SelectContext = createContext<SelectContextType | null>(null);
 

--- a/src/pattern-library/components/patterns/prototype/SelectNextPage.tsx
+++ b/src/pattern-library/components/patterns/prototype/SelectNextPage.tsx
@@ -425,6 +425,31 @@ export default function SelectNextPage() {
               withSource
             />
           </Library.Example>
+          <Library.Example title="multiple">
+            <Library.Info>
+              <Library.InfoItem label="description">
+                Determines if more than one item can be selected at once,
+                causing the listbox to stay open when an option is selected on
+                it.
+                <p>
+                  When multi-selection is enabled, the <code>value</code> must
+                  be an array and <code>onChange</code> will receive an array as
+                  an argument.
+                </p>
+              </Library.InfoItem>
+              <Library.InfoItem label="type">
+                <code>boolean</code>
+              </Library.InfoItem>
+              <Library.InfoItem label="default">
+                <code>false</code>
+              </Library.InfoItem>
+            </Library.Info>
+            <Library.Demo
+              title="Multi-select listbox"
+              exampleFile="select-next-multiple"
+              withSource
+            />
+          </Library.Example>
         </Library.Pattern>
 
         <Library.Pattern title="SelectNext.Option component API">

--- a/src/pattern-library/examples/select-next-multiple.tsx
+++ b/src/pattern-library/examples/select-next-multiple.tsx
@@ -1,0 +1,49 @@
+import { useId, useState } from 'preact/hooks';
+
+import { SelectNext } from '../..';
+
+type ItemType = {
+  id: string;
+  name: string;
+};
+
+const items: ItemType[] = [
+  { id: '1', name: 'John Doe' },
+  { id: '2', name: 'Albert Banana' },
+  { id: '3', name: 'Bernard California' },
+  { id: '4', name: 'Cecelia Davenport' },
+  { id: '5', name: 'Doris Evanescence' },
+];
+
+export default function App() {
+  const [values, setSelected] = useState<ItemType[]>([items[0], items[3]]);
+  const selectId = useId();
+
+  return (
+    <div className="w-96 mx-auto">
+      <label htmlFor={selectId}>Select students</label>
+      <SelectNext
+        multiple
+        value={values}
+        onChange={setSelected}
+        buttonId={selectId}
+        buttonContent={
+          values.length === 0 ? (
+            <>All students</>
+          ) : values.length === 1 ? (
+            values[0].name
+          ) : (
+            <>{values.length} students selected</>
+          )
+        }
+      >
+        <SelectNext.Option value={undefined}>All students</SelectNext.Option>
+        {items.map(item => (
+          <SelectNext.Option value={item} key={item.id}>
+            {item.name}
+          </SelectNext.Option>
+        ))}
+      </SelectNext>
+    </div>
+  );
+}


### PR DESCRIPTION
This PR extends `SelectNext` so that it supports multiple items to be selected at once.

It does it by allowing `value` to be an array of items instead of a single item. When that happens, items in the list do not set themselves as selected, but they toggle themselves from that list instead.

Additionally, it adds a new `multiple` prop to be passed, which causes the listbox to be kept open when selecting options from the list.

State management is delegated to consumers, simplifying the implementation.

The implementation is inspired in how [HeadlessUI](https://headlessui.com/react/listbox#selecting-multiple-values) does it.

https://github.com/hypothesis/frontend-shared/assets/2719332/6c4a859b-5330-4652-80f0-ab6f9911a379

### TODO

- [x] Add tests
- [x] Check if there's any a11y implication to take into consideration.