### PR TITLE
Allow to pass onListboxScroll callback to SelectNext

### DIFF
--- a/src/components/input/SelectNext.tsx
+++ b/src/components/input/SelectNext.tsx
@@ -1,5 +1,5 @@
 import classnames from 'classnames';
-import type { ComponentChildren, RefObject } from 'preact';
+import type { ComponentChildren, JSX, RefObject } from 'preact';
 import {
   useCallback,
   useContext,
@@ -298,6 +298,9 @@ export type SelectProps<T> = CompositeProps &
      * Defaults to true, as long as the browser supports it.
      */
     listboxAsPopover?: boolean;
+
+    /** A callback passed to the listbox onScroll */
+    onListboxScroll?: JSX.HTMLAttributes<HTMLUListElement>['onScroll'];
   };
 
 function SelectMain<T>({
@@ -311,6 +314,7 @@ function SelectMain<T>({
   buttonClasses,
   listboxClasses,
   containerClasses,
+  onListboxScroll,
   right = false,
   multiple = false,
   'aria-label': ariaLabel,
@@ -460,6 +464,7 @@ function SelectMain<T>({
           // handle boolean values correctly for this attribute (it will set
           // `popover="false"` instead of removing the attribute).
           popover={listboxAsPopover ? 'auto' : undefined}
+          onScroll={onListboxScroll}
         >
           {children}
         </ul>

--- a/src/pattern-library/components/patterns/prototype/SelectNextPage.tsx
+++ b/src/pattern-library/components/patterns/prototype/SelectNextPage.tsx
@@ -450,6 +450,21 @@ export default function SelectNextPage() {
               withSource
             />
           </Library.Example>
+          <Library.Example title="onListboxScroll">
+            <Library.Info>
+              <Library.InfoItem label="description">
+                A callback passed to the listbox <code>onScroll</code>.
+              </Library.InfoItem>
+              <Library.InfoItem label="type">
+                <code>
+                  () {'=>'} void {'|'} undefined
+                </code>
+              </Library.InfoItem>
+              <Library.InfoItem label="default">
+                <code>undefined</code>
+              </Library.InfoItem>
+            </Library.Info>
+          </Library.Example>
         </Library.Pattern>
 
         <Library.Pattern title="SelectNext.Option component API">


### PR DESCRIPTION
This PR adds a new `onListboxScroll` prop to `SelectNext`, which is basically a callback that gets propagated to the listbox `onScroll`.

We'll use this to dynamically update the options in the list when loading long lists in chunks.

I considered making this smarter, but then I thought there's too many possible requirements that could come from this, and finally decided to make it a dumb callback and let consumers implement the whole logic for now.