### PR TITLE
Add darker background to selected options in SelectNext

### DIFF
--- a/src/components/input/SelectNext.tsx
+++ b/src/components/input/SelectNext.tsx
@@ -97,10 +97,11 @@ function SelectOption<T>({
     <li
       className={classnames(
         'w-full ring-inset outline-none rounded-none',
-        'border-t first:border-t-0 transition-colors whitespace-nowrap',
+        'border-t first:border-t-0 whitespace-nowrap',
         {
           'text-grey-4': disabled,
           'cursor-pointer focus-visible-ring hover:bg-grey-1': !disabled,
+          'bg-grey-1 hover:bg-grey-2': selected,
         },
         classes,
       )}


### PR DESCRIPTION
This PR tries to improve how selected options are highlighted in `SelectNext`, by adding a light grey background that makes them more prominent.

Additionally, it removes color transitions, which mainly affect the background color applied on hover, which feels more responsive without the transition.

https://github.com/hypothesis/frontend-shared/assets/2719332/27f8c1f1-62d5-477b-aeba-02b47287c77b
