### PR TITLE
Expose Select and MultiSelect aliases for SelectNext

### DIFF
--- a/src/components/input/SelectNext.tsx
+++ b/src/components/input/SelectNext.tsx
@@ -257,52 +257,57 @@ type MultiValueProps<T> = {
   onChange: (newValue: T[]) => void;
 };
 
-export type SelectProps<T> = CompositeProps &
-  (SingleValueProps<T> | MultiValueProps<T>) & {
-    buttonContent?: ComponentChildren;
-    disabled?: boolean;
+type BaseSelectProps = CompositeProps & {
+  buttonContent?: ComponentChildren;
+  disabled?: boolean;
 
-    /**
-     * Whether this select should allow multi-selection or not.
-     * When this is true, the listbox is kept open when an option is selected
-     * and the value must be an array.
-     * Defaults to false.
-     */
-    multiple?: boolean;
+  /**
+   * `id` attribute for the toggle button. This is useful to associate a label
+   * with the control.
+   */
+  buttonId?: string;
 
-    /**
-     * `id` attribute for the toggle button. This is useful to associate a label
-     * with the control.
-     */
-    buttonId?: string;
+  /** Additional classes to pass to container */
+  containerClasses?: string | string[];
+  /** Additional classes to pass to toggle button */
+  buttonClasses?: string | string[];
+  /** Additional classes to pass to listbox */
+  listboxClasses?: string | string[];
 
-    /** Additional classes to pass to container */
-    containerClasses?: string | string[];
-    /** Additional classes to pass to toggle button */
-    buttonClasses?: string | string[];
-    /** Additional classes to pass to listbox */
-    listboxClasses?: string | string[];
+  /**
+   * Align the listbox to the right.
+   * Useful when the listbox is bigger than the toggle button and this component
+   * is rendered next to the right side of the page/container.
+   * Defaults to false.
+   */
+  right?: boolean;
 
-    /**
-     * Align the listbox to the right.
-     * Useful when the listbox is bigger than the toggle button and this component
-     * is rendered next to the right side of the page/container.
-     * Defaults to false.
-     */
-    right?: boolean;
+  'aria-label'?: string;
+  'aria-labelledby'?: string;
 
-    'aria-label'?: string;
-    'aria-labelledby'?: string;
+  /**
+   * Used to determine if the listbox should use the popover API.
+   * Defaults to true, as long as the browser supports it.
+   */
+  listboxAsPopover?: boolean;
 
-    /**
-     * Used to determine if the listbox should use the popover API.
-     * Defaults to true, as long as the browser supports it.
-     */
-    listboxAsPopover?: boolean;
+  /** A callback passed to the listbox onScroll */
+  onListboxScroll?: JSX.HTMLAttributes<HTMLUListElement>['onScroll'];
+};
 
-    /** A callback passed to the listbox onScroll */
-    onListboxScroll?: JSX.HTMLAttributes<HTMLUListElement>['onScroll'];
-  };
+export type SelectProps<T> = BaseSelectProps & SingleValueProps<T>;
+
+export type MultiSelectProps<T> = BaseSelectProps & MultiValueProps<T>;
+
+export type SelectNextProps<T> = (SelectProps<T> | MultiSelectProps<T>) & {
+  /**
+   * Whether this select should allow multi-selection or not.
+   * When this is true, the listbox is kept open when an option is selected
+   * and the value must be an array.
+   * Defaults to false.
+   */
+  multiple?: boolean;
+};
 
 function SelectMain<T>({
   buttonContent,
@@ -322,7 +327,7 @@ function SelectMain<T>({
   'aria-labelledby': ariaLabelledBy,
   /* eslint-disable-next-line no-prototype-builtins */
   listboxAsPopover = HTMLElement.prototype.hasOwnProperty('popover'),
-}: SelectProps<T>) {
+}: SelectNextProps<T>) {
   if (multiple && !Array.isArray(value)) {
     throw new Error('When `multiple` is true, the value must be an array');
   }
@@ -474,8 +479,27 @@ function SelectMain<T>({
   );
 }
 
-SelectMain.displayName = 'SelectNext';
+export const SelectNext = Object.assign(SelectMain, {
+  Option: SelectOption,
+  displayName: 'SelectNext',
+});
 
-const SelectNext = Object.assign(SelectMain, { Option: SelectOption });
+export const Select = Object.assign(
+  function <T>(props: SelectProps<T>) {
+    // Calling the function directly instead of returning a JSX element, to
+    // avoid an unnecessary extra layer in the component tree
+    // eslint-disable-next-line new-cap
+    return SelectNext({ ...props, multiple: false });
+  },
+  { Option: SelectOption, displayName: 'Select' },
+);
 
-export default SelectNext;
+export const MultiSelect = Object.assign(
+  function <T>(props: MultiSelectProps<T>) {
+    // Calling the function directly instead of returning a JSX element, to
+    // avoid an unnecessary extra layer in the component tree
+    // eslint-disable-next-line new-cap
+    return SelectNext({ ...props, multiple: true });
+  },
+  { Option: SelectOption, displayName: 'MultiSelect' },
+);

--- a/src/components/input/index.ts
+++ b/src/components/input/index.ts
@@ -5,7 +5,7 @@ export { default as IconButton } from './IconButton';
 export { default as Input } from './Input';
 export { default as InputGroup } from './InputGroup';
 export { default as OptionButton } from './OptionButton';
-export { default as SelectNext } from './SelectNext';
+export { SelectNext, Select, MultiSelect } from './SelectNext';
 export { default as Textarea } from './Textarea';
 
 export type { ButtonProps } from './Button';
@@ -15,5 +15,9 @@ export type { IconButtonProps } from './IconButton';
 export type { InputProps } from './Input';
 export type { InputGroupProps } from './InputGroup';
 export type { OptionButtonProps } from './OptionButton';
-export type { SelectProps as SelectNextProps } from './SelectNext';
+export type {
+  MultiSelectProps,
+  SelectNextProps,
+  SelectProps,
+} from './SelectNext';
 export type { TextareaProps } from './Textarea';

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,7 +48,9 @@ export {
   IconButton,
   Input,
   InputGroup,
+  MultiSelect,
   OptionButton,
+  Select,
   SelectNext,
   Textarea,
 } from './components/input';
@@ -115,7 +117,9 @@ export type {
   IconButtonProps,
   InputProps,
   InputGroupProps,
+  MultiSelectProps,
   OptionButtonProps,
+  SelectProps,
   SelectNextProps,
   TextareaProps,
 } from './components/input';

--- a/src/pattern-library/components/patterns/prototype/SelectNextPage.tsx
+++ b/src/pattern-library/components/patterns/prototype/SelectNextPage.tsx
@@ -3,7 +3,7 @@ import { useId, useState } from 'preact/hooks';
 
 import { Link } from '../../../..';
 import type { SelectNextProps } from '../../../../components/input';
-import SelectNext from '../../../../components/input/SelectNext';
+import { SelectNext } from '../../../../components/input/SelectNext';
 import SelectNextInInputGroup from '../../../examples/select-next-in-input-group';
 import SelectNextWithManyOptions from '../../../examples/select-next-with-custom-options';
 import Library from '../../Library';
@@ -99,14 +99,15 @@ export default function SelectNextPage() {
       title="SelectNext"
       intro={
         <p>
-          <code>SelectNext</code> is a composite component which behaves like
+          <code>SelectNext</code> (and its aliases <code>Select</code> and{' '}
+          <code>MultiSelect</code>) are composite components which behave like
           the native <code>{'<select>'}</code> element.
         </p>
       }
     >
       <Library.Section>
         <Library.Pattern>
-          <Library.Usage componentName="SelectNext" />
+          <Library.Usage componentName="MultiSelect, Select, SelectNext" />
 
           <Library.Example>
             <Library.Demo
@@ -436,6 +437,11 @@ export default function SelectNextPage() {
                   be an array and <code>onChange</code> will receive an array as
                   an argument.
                 </p>
+                <p>
+                  This prop cannot be provided to the <code>Select</code> and{' '}
+                  <code>MultiSelect</code> aliases, where it is implicitly{' '}
+                  <code>false</code> and <code>true</code> respectively.
+                </p>
               </Library.InfoItem>
               <Library.InfoItem label="type">
                 <code>boolean</code>
@@ -447,6 +453,11 @@ export default function SelectNextPage() {
             <Library.Demo
               title="Multi-select listbox"
               exampleFile="select-next-multiple"
+              withSource
+            />
+            <Library.Demo
+              title="Using MultiSelect component"
+              exampleFile="select-next-multi-select"
               withSource
             />
           </Library.Example>

--- a/src/pattern-library/examples/select-next-basic.tsx
+++ b/src/pattern-library/examples/select-next-basic.tsx
@@ -1,6 +1,6 @@
 import { useId, useState } from 'preact/hooks';
 
-import { SelectNext } from '../..';
+import { Select } from '../..';
 
 const items = [
   { id: '1', name: 'All students' },
@@ -17,18 +17,18 @@ export default function App() {
   return (
     <div className="w-96 mx-auto">
       <label htmlFor={selectId}>Select a person</label>
-      <SelectNext
+      <Select
         value={value}
-        onChange={setSelected}
+        onChange={newValue => setSelected(newValue)}
         buttonId={selectId}
         buttonContent={value ? value.name : <>Select one…</>}
       >
         {items.map(item => (
-          <SelectNext.Option value={item} key={item.id}>
+          <Select.Option value={item} key={item.id}>
             {item.name}
-          </SelectNext.Option>
+          </Select.Option>
         ))}
-      </SelectNext>
+      </Select>
     </div>
   );
 }

--- a/src/pattern-library/examples/select-next-in-input-group.tsx
+++ b/src/pattern-library/examples/select-next-in-input-group.tsx
@@ -3,7 +3,7 @@ import { useCallback, useId, useMemo, useState } from 'preact/hooks';
 
 import { ArrowLeftIcon, ArrowRightIcon } from '../../components/icons';
 import { IconButton, InputGroup } from '../../components/input';
-import SelectNext from '../../components/input/SelectNext';
+import { SelectNext } from '../../components/input/SelectNext';
 
 const students = [
   { id: '1', name: 'All students' },

--- a/src/pattern-library/examples/select-next-multi-select.tsx
+++ b/src/pattern-library/examples/select-next-multi-select.tsx
@@ -1,0 +1,48 @@
+import { useId, useState } from 'preact/hooks';
+
+import { MultiSelect } from '../..';
+
+type ItemType = {
+  id: string;
+  name: string;
+};
+
+const items: ItemType[] = [
+  { id: '1', name: 'John Doe' },
+  { id: '2', name: 'Albert Banana' },
+  { id: '3', name: 'Bernard California' },
+  { id: '4', name: 'Cecelia Davenport' },
+  { id: '5', name: 'Doris Evanescence' },
+];
+
+export default function App() {
+  const [values, setSelected] = useState<ItemType[]>([items[0], items[3]]);
+  const selectId = useId();
+
+  return (
+    <div className="w-96 mx-auto">
+      <label htmlFor={selectId}>Select students</label>
+      <MultiSelect
+        value={values}
+        onChange={newStudents => setSelected(newStudents)}
+        buttonId={selectId}
+        buttonContent={
+          values.length === 0 ? (
+            <>All students</>
+          ) : values.length === 1 ? (
+            values[0].name
+          ) : (
+            <>{values.length} students selected</>
+          )
+        }
+      >
+        <MultiSelect.Option value={undefined}>All students</MultiSelect.Option>
+        {items.map(item => (
+          <MultiSelect.Option value={item} key={item.id}>
+            {item.name}
+          </MultiSelect.Option>
+        ))}
+      </MultiSelect>
+    </div>
+  );
+}


### PR DESCRIPTION
This PR exposes two new aliases for `SelectNext`, which are `Select` and `MultiSelect`. These two implicitly have `multiple={false}` and `multiple={true}` respectively, and do not allow the `multiple` prop to be provided.

This change serves two purposes:

* The main one is to solve an issue introduced in https://github.com/hypothesis/frontend-shared/pull/1601, which causes `onChange`'s argument type to no longer be inferred based on the type of `value`.
`Select` and `MultiSelect` are now enforcing one of the two type paths when `mutiple` is true or false, fixing the type inference.
For more context on the issue, check [this comment](https://github.com/hypothesis/lms/pull/6449#issuecomment-2230591951) and the ones below.
* Additionally, it creates new simpler component names, where `Select` can transparently replace existing `SelectNext` usages, allowing us to eventually drop the `SelectNext` symbol in the next major release.

I tried to find a solution to the type inference at pure types definition level, but didn't quite get it, even after making types more complex, so I think this option is better, specially taking into consideration to additional benefit explained above.

> [!NOTE]  
> This PR is easier to review [ignoring whitespaces](https://github.com/hypothesis/frontend-shared/pull/1619/files?w=1).

### TODO

- [x] Document new component aliases and use them in examples to prove they work.
- [x] Test `Select` and `MultiSelect` in client and LMS projects, where `<SelectNext />` and `<SelectNext multiple />` is used, to confirm they work.
  - EDIT: Exposed these changes via yalc, and imported them in client and LMS, then replaced all `SelectNext` with `Select`. Everything works after a manual test, tests pass with a few minor changes, and typechecks pass.

### Out of scope

We can probably replace all usages in this library of `SelectNext` with either `Select` or `MultiSelect`, as they will provide the same coverage, and promote their usage over `SelectNext`.

Additionally, we could even mark `SelectNext` as deprecated as a standalone component, and recommend using one of the other two.

All that will come in follow-up PRs, to avoid distractions from the new API being introduced here. 