### PR TITLE
Export usePopoverShouldClose from entry point

### DIFF
--- a/src/hooks/test/use-popover-should-close-test.js
+++ b/src/hooks/test/use-popover-should-close-test.js
@@ -1,7 +1,7 @@
 import { mount } from 'enzyme';
 import { useRef } from 'preact/hooks';
 
-import usePopoverShouldClose, { $imports } from '../use-popover-should-close';
+import { usePopoverShouldClose, $imports } from '../use-popover-should-close';
 
 describe('usePopoverShouldClose', () => {
   function FakeComponent({ closeHandler, options }) {

--- a/src/hooks/use-popover-should-close.ts
+++ b/src/hooks/use-popover-should-close.ts
@@ -20,7 +20,7 @@ export type UsePopoverShouldCloseOptions = {
  * @param handleClose - Callback invoked to close the popover
  * @param options
  */
-export default function usePopoverShouldClose(
+export function usePopoverShouldClose(
   popoverEl: RefObject<HTMLElement | undefined>,
   handleClose: () => void,
   options: UsePopoverShouldCloseOptions = {},

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ export { useClickAway } from './hooks/use-click-away';
 export { useFocusAway } from './hooks/use-focus-away';
 export { useKeyPress } from './hooks/use-key-press';
 export { useOrderedRows } from './hooks/use-ordered-rows';
+export { usePopoverShouldClose } from './hooks/use-popover-should-close';
 export { useStableCallback } from './hooks/use-stable-callback';
 export { useSyncedRef } from './hooks/use-synced-ref';
 export { useToastMessages } from './hooks/use-toast-messages';


### PR DESCRIPTION
After pointing out in https://github.com/hypothesis/frontend-shared/pull/1629#pullrequestreview-2191827532 the fact that I forgot to expose `usePopoverShouldClose` from the library's entry point, I ended up forgetting to update that PR before merging it.

This PR adds what was missing there.