### PR TITLE
Allow Select and MultiSelect listbox auto-closing to be configured

### DIFF
--- a/src/components/input/Select.tsx
+++ b/src/components/input/Select.tsx
@@ -293,6 +293,12 @@ type BaseSelectProps = CompositeProps & {
    */
   listboxAsPopover?: boolean;
 
+  /**
+   * Whether the listbox should automatically close after an option is selected.
+   * Defaults to true for Select and false for MultiSelect.
+   */
+  autoCloseListbox?: boolean;
+
   /** A callback passed to the listbox onScroll */
   onListboxScroll?: JSX.HTMLAttributes<HTMLUListElement>['onScroll'];
 };
@@ -325,6 +331,7 @@ function SelectMain<T>({
   onListboxScroll,
   right = false,
   multiple,
+  autoCloseListbox = !multiple,
   'aria-label': ariaLabel,
   'aria-labelledby': ariaLabelledBy,
   /* eslint-disable-next-line no-prototype-builtins */
@@ -358,12 +365,11 @@ function SelectMain<T>({
   const selectValue = useCallback(
     (value: unknown) => {
       onChange(value as any);
-      // In multi-select mode, keep list open when selecting values
-      if (!multiple) {
+      if (autoCloseListbox) {
         closeListbox();
       }
     },
-    [onChange, multiple, closeListbox],
+    [onChange, autoCloseListbox, closeListbox],
   );
 
   // When clicking away, focusing away or pressing `Esc`, close the listbox

--- a/src/components/input/test/Select-test.js
+++ b/src/components/input/test/Select-test.js
@@ -394,22 +394,58 @@ describe('Select', () => {
     });
   });
 
-  context('MultiSelect', () => {
-    it('keeps listbox open when an option is selected if multiple is true', async () => {
-      const wrapper = createComponent(
-        { value: [] },
-        { Component: MultiSelect },
-      );
+  describe('autoCloseListbox', () => {
+    [
+      {
+        autoCloseListbox: undefined,
+        component: MultiSelect,
+        shouldCloseListbox: false,
+      },
+      {
+        autoCloseListbox: undefined,
+        component: Select,
+        shouldCloseListbox: true,
+      },
+      {
+        autoCloseListbox: true,
+        component: MultiSelect,
+        shouldCloseListbox: true,
+      },
+      {
+        autoCloseListbox: true,
+        component: Select,
+        shouldCloseListbox: true,
+      },
+      {
+        autoCloseListbox: false,
+        component: MultiSelect,
+        shouldCloseListbox: false,
+      },
+      {
+        autoCloseListbox: false,
+        component: Select,
+        shouldCloseListbox: false,
+      },
+    ].forEach(({ autoCloseListbox, component, shouldCloseListbox }) => {
+      it('keeps listbox open when an option is selected if autoCloseListbox is false', async () => {
+        const wrapper = createComponent(
+          { value: [], autoCloseListbox },
+          { Component: component },
+        );
 
-      toggleListbox(wrapper);
-      assert.isFalse(isListboxClosed(wrapper));
+        toggleListbox(wrapper);
+        assert.isFalse(isListboxClosed(wrapper));
 
-      clickOption(wrapper, 1);
+        clickOption(wrapper, 1);
 
-      // After clicking an option, the listbox is still open
-      assert.isFalse(isListboxClosed(wrapper));
+        // After clicking an option, the listbox is still open if
+        // autoCloseListbox is false
+        assert.equal(isListboxClosed(wrapper), shouldCloseListbox);
+      });
     });
+  });
 
+  context('MultiSelect', () => {
     it('allows multiple items to be selected', () => {
       const onChange = sinon.stub();
       const wrapper = createComponent(

--- a/src/pattern-library/components/patterns/prototype/SelectPage.tsx
+++ b/src/pattern-library/components/patterns/prototype/SelectPage.tsx
@@ -426,6 +426,31 @@ export default function SelectPage() {
               withSource
             />
           </Library.Example>
+          <Library.Example title="autoCloseListbox">
+            <Library.Info>
+              <Library.InfoItem label="description">
+                Whether the listbox should automatically close after an option
+                is selected
+              </Library.InfoItem>
+              <Library.InfoItem label="type">
+                <code>boolean | undefined</code>
+              </Library.InfoItem>
+              <Library.InfoItem label="default">
+                <code>true</code> for <code>Select</code> and <code>false</code>
+                for <code>MultiSelect</code>.
+              </Library.InfoItem>
+            </Library.Info>
+            <Library.Demo
+              title="Select - keep-open listbox"
+              exampleFile="select-keep-open-listbox"
+              withSource
+            />
+            <Library.Demo
+              title="MultiSelect - auto-close listbox"
+              exampleFile="select-multi-auto-close-listbox"
+              withSource
+            />
+          </Library.Example>
           <Library.Example title="onListboxScroll">
             <Library.Info>
               <Library.InfoItem label="description">

--- a/src/pattern-library/examples/select-keep-open-listbox.tsx
+++ b/src/pattern-library/examples/select-keep-open-listbox.tsx
@@ -1,0 +1,40 @@
+import { useId, useState } from 'preact/hooks';
+
+import { Select } from '../..';
+
+type ItemType = {
+  id: string;
+  name: string;
+};
+
+const items: ItemType[] = [
+  { id: '1', name: 'All students' },
+  { id: '2', name: 'Albert Banana' },
+  { id: '3', name: 'Bernard California' },
+  { id: '4', name: 'Cecelia Davenport' },
+  { id: '5', name: 'Doris Evanescence' },
+];
+
+export default function App() {
+  const [value, setSelected] = useState<ItemType>();
+  const selectId = useId();
+
+  return (
+    <div className="w-96 mx-auto">
+      <label htmlFor={selectId}>Select one student</label>
+      <Select
+        autoCloseListbox={false}
+        value={value}
+        onChange={newValue => setSelected(newValue)}
+        buttonId={selectId}
+        buttonContent={value ? value.name : <>Select one…</>}
+      >
+        {items.map(item => (
+          <Select.Option value={item} key={item.id}>
+            {item.name}
+          </Select.Option>
+        ))}
+      </Select>
+    </div>
+  );
+}

--- a/src/pattern-library/examples/select-multi-auto-close-listbox.tsx
+++ b/src/pattern-library/examples/select-multi-auto-close-listbox.tsx
@@ -1,0 +1,48 @@
+import { useId, useState } from 'preact/hooks';
+
+import { MultiSelect } from '../..';
+
+type ItemType = {
+  id: string;
+  name: string;
+};
+
+const items: ItemType[] = [
+  { id: '1', name: 'All students' },
+  { id: '2', name: 'Albert Banana' },
+  { id: '3', name: 'Bernard California' },
+  { id: '4', name: 'Cecelia Davenport' },
+  { id: '5', name: 'Doris Evanescence' },
+];
+
+export default function App() {
+  const [values, setMultiSelected] = useState<ItemType[]>([]);
+  const selectId = useId();
+
+  return (
+    <div className="w-96 mx-auto">
+      <label htmlFor={selectId}>Select multiple students</label>
+      <MultiSelect
+        autoCloseListbox
+        value={values}
+        onChange={newValue => setMultiSelected(newValue)}
+        buttonId={selectId}
+        buttonContent={
+          values.length === 0 ? (
+            <>All students</>
+          ) : values.length === 1 ? (
+            values[0].name
+          ) : (
+            <>{values.length} students selected</>
+          )
+        }
+      >
+        {items.map(item => (
+          <MultiSelect.Option value={item} key={item.id}>
+            {item.name}
+          </MultiSelect.Option>
+        ))}
+      </MultiSelect>
+    </div>
+  );
+}


### PR DESCRIPTION
This PR adds a new optional `autoCloseListbox` prop to `Select` and `MultiSelect`, that can be used to decide if the listbox should automatically close after an option is selected.

Its default value is `true` for `Select` and `false` for `MultiSelect`, but in some cases, we may want the `MultiSelect` to auto-close the listbox.

It's probably less likely that we want the `Select`'s listbox to stay open, but providing the capability is cheap.

https://github.com/user-attachments/assets/4289140e-2901-4878-b631-21323c338d17
