### PR TITLE
Make orderable icon darker on interactive tables

### DIFF
--- a/src/components/data/DataTable.tsx
+++ b/src/components/data/DataTable.tsx
@@ -380,7 +380,15 @@ export default function DataTable<Row>({
                           <ArrowDownIcon />
                         ))}
                       {!isActiveOrder && (
-                        <OrderableIcon className="text-grey-5" />
+                        <OrderableIcon
+                          className={classnames('text-grey-5', {
+                            // Interactive rows set a darker background color on
+                            // hover.
+                            // Setting a darker color on the icon when hovering
+                            // the row will ensure enough contrast.
+                            'group-hover:text-grey-7': interactive,
+                          })}
+                        />
                       )}
                     </div>
                   )}


### PR DESCRIPTION
This is a follow-up from https://github.com/hypothesis/frontend-shared/pull/1647, which makes the new orderable icon darker on the table header hover, when used on an interactive table.

This is needed because interactive tables have a darker background on row hover, which causes the contrast with the icon to be too low.

This is how it looks without the changes introduced here:

[Grabación de pantalla desde 2024-08-08 16-59-57.webm](https://github.com/user-attachments/assets/ea80fbb3-f85d-40a0-be7e-15491aeef2bc)

And this is how it looks with those changes:

[Grabación de pantalla desde 2024-08-08 16-59-12.webm](https://github.com/user-attachments/assets/48c0f0fa-a7df-4e00-ab85-257478c29f59)
