### PR TITLE
Use placehold.co to generate placeholder images

### DIFF
--- a/src/components/data/test/AspectRatio-test.js
+++ b/src/components/data/test/AspectRatio-test.js
@@ -12,11 +12,11 @@ describe('AspectRatio', () => {
 
   it('applies bottom-padding to container based on `ratio` value', () => {
     const wrapper16_9 = createComponent(AspectRatio, {
-      children: <img src="https://placekitten.com/400/400" alt="kitty" />,
+      children: <img src="https://placehold.co/400x400" alt="placeholder" />,
     });
 
     const wrapper4_3 = createComponent(AspectRatio, {
-      children: <img src="https://placekitten.com/400/400" alt="kitty" />,
+      children: <img src="https://placehold.co/400x400" alt="placeholder" />,
       ratio: '4/3',
     });
 
@@ -41,8 +41,8 @@ describe('AspectRatio', () => {
     const wrapper = createComponent(AspectRatio, {
       children: (
         <img
-          src="https://placekitten.com/400/400"
-          alt="kitty"
+          src="https://placehold.co/400x400"
+          alt="placeholder"
           className="object-top"
         />
       ),

--- a/src/components/data/test/Thumbnail-test.js
+++ b/src/components/data/test/Thumbnail-test.js
@@ -43,7 +43,7 @@ describe('Thumbnail', () => {
 
   it('sets ratio on content', () => {
     const wrapper = createComponent(Thumbnail, {
-      children: <img src="https://placekitten.com/300/300" alt="kitty" />,
+      children: <img src="https://placehold.co/300x300" alt="placeholder" />,
       ratio: '4/3',
     });
 

--- a/src/pattern-library/components/patterns/data/AspectRatioPage.tsx
+++ b/src/pattern-library/components/patterns/data/AspectRatioPage.tsx
@@ -19,7 +19,7 @@ export default function AspectRatioPage() {
             <Library.Demo title="Basic AspectRatio" withSource>
               <div className="w-[350px]">
                 <AspectRatio>
-                  <img src="https://placekitten.com/400/400" alt="kitty" />
+                  <img src="https://placehold.co/400x400" alt="placeholder" />
                 </AspectRatio>
               </div>
             </Library.Demo>
@@ -75,8 +75,8 @@ export default function AspectRatioPage() {
               <div className="w-[350px]">
                 <AspectRatio>
                   <img
-                    src="https://placekitten.com/400/400"
-                    alt="kitty"
+                    src="https://placehold.co/400x400"
+                    alt="placeholder"
                     className="object-top"
                   />
                 </AspectRatio>
@@ -137,7 +137,7 @@ export default function AspectRatioPage() {
             <Library.Demo title="objectFit:'cover' (default)" withSource>
               <div className="w-[350px] border rounded-md">
                 <AspectRatio objectFit="cover">
-                  <img src="https://placekitten.com/400/400" alt="kitty" />
+                  <img src="https://placehold.co/400x400" alt="placeholder" />
                 </AspectRatio>
               </div>
             </Library.Demo>
@@ -145,7 +145,7 @@ export default function AspectRatioPage() {
             <Library.Demo title="objectFit:'contain'" withSource>
               <div className="w-[350px] border rounded-md">
                 <AspectRatio objectFit="contain">
-                  <img src="https://placekitten.com/400/400" alt="kitty" />
+                  <img src="https://placehold.co/400x400" alt="placeholder" />
                 </AspectRatio>
               </div>
             </Library.Demo>
@@ -153,7 +153,7 @@ export default function AspectRatioPage() {
             <Library.Demo title="objectFit:'fill'" withSource>
               <div className="w-[350px] border rounded-md">
                 <AspectRatio objectFit="fill">
-                  <img src="https://placekitten.com/400/400" alt="kitty" />
+                  <img src="https://placehold.co/400x400" alt="placeholder" />
                 </AspectRatio>
               </div>
             </Library.Demo>
@@ -161,7 +161,7 @@ export default function AspectRatioPage() {
             <Library.Demo title="objectFit:'scale-down'" withSource>
               <div className="w-[350px] border rounded-md">
                 <AspectRatio objectFit="scale-down">
-                  <img src="https://placekitten.com/400/400" alt="kitty" />
+                  <img src="https://placehold.co/400x400" alt="placeholder" />
                 </AspectRatio>
               </div>
             </Library.Demo>
@@ -169,7 +169,7 @@ export default function AspectRatioPage() {
             <Library.Demo title="objectFit:'none'" withSource>
               <div className="w-[350px] border rounded-md">
                 <AspectRatio objectFit="none">
-                  <img src="https://placekitten.com/400/400" alt="kitty" />
+                  <img src="https://placehold.co/400x400" alt="placeholder" />
                 </AspectRatio>
               </div>
             </Library.Demo>

--- a/src/pattern-library/components/patterns/data/ThumbnailPage.tsx
+++ b/src/pattern-library/components/patterns/data/ThumbnailPage.tsx
@@ -24,7 +24,7 @@ export default function ThumbnailPage() {
           <Library.Demo title="Basic Thumbnail" withSource>
             <div className="w-[250px]">
               <Thumbnail>
-                <img src="https://placekitten.com/400/400" alt="kitty" />
+                <img src="https://placehold.co/400x400" alt="placeholder" />
               </Thumbnail>
             </div>
           </Library.Demo>
@@ -35,7 +35,7 @@ export default function ThumbnailPage() {
             <Library.Demo withSource title="Loading state">
               <div className="w-[250px]">
                 <Thumbnail loading>
-                  <img src="https://placekitten.com/400/400" alt="kitty" />
+                  <img src="https://placehold.co/400x400" alt="placeholder" />
                 </Thumbnail>
               </div>
             </Library.Demo>
@@ -57,7 +57,7 @@ export default function ThumbnailPage() {
             <Library.Demo title="Extra available vertical space" withSource>
               <div className="w-[250px] h-[300px]">
                 <Thumbnail>
-                  <img src="https://placekitten.com/400/400" alt="kitty" />
+                  <img src="https://placehold.co/400x400" alt="placeholder" />
                 </Thumbnail>
               </div>
             </Library.Demo>
@@ -72,9 +72,9 @@ export default function ThumbnailPage() {
               <div className="w-[350px] h-[150px]">
                 <Thumbnail>
                   <img
-                    src="https://placekitten.com/400/400"
+                    src="https://placehold.co/400x400"
                     className="object-top"
-                    alt="kitty"
+                    alt="placeholder"
                   />
                 </Thumbnail>
               </div>
@@ -110,7 +110,7 @@ export default function ThumbnailPage() {
               <div className="space-y-4">
                 <div className="w-[200px]">
                   <Thumbnail borderless>
-                    <img src="https://placekitten.com/400/400" alt="kitty" />
+                    <img src="https://placehold.co/400x400" alt="placeholder" />
                   </Thumbnail>
                 </div>
                 <div className="w-[200px]">
@@ -195,7 +195,7 @@ export default function ThumbnailPage() {
             <Library.Demo title="ratio: '4/3'" withSource>
               <div className="w-[250px]">
                 <Thumbnail ratio="4/3">
-                  <img src="https://placekitten.com/400/400" alt="kitty" />
+                  <img src="https://placehold.co/400x400" alt="placeholder" />
                 </Thumbnail>
               </div>
             </Library.Demo>
@@ -224,7 +224,7 @@ export default function ThumbnailPage() {
               <div className="flex gap-x-4">
                 <div className="w-[200px]">
                   <Thumbnail size="sm">
-                    <img src="https://placekitten.com/400/400" alt="kitty" />
+                    <img src="https://placehold.co/400x400" alt="placeholder" />
                   </Thumbnail>
                 </div>
 
@@ -242,7 +242,7 @@ export default function ThumbnailPage() {
               <div className="flex gap-x-4">
                 <div className="w-[200px]">
                   <Thumbnail size="md">
-                    <img src="https://placekitten.com/400/400" alt="kitty" />
+                    <img src="https://placehold.co/400x400" alt="placeholder" />
                   </Thumbnail>
                 </div>
 
@@ -260,7 +260,7 @@ export default function ThumbnailPage() {
               <div className="flex gap-x-4">
                 <div className="w-[200px]">
                   <Thumbnail size="lg">
-                    <img src="https://placekitten.com/400/400" alt="kitty" />
+                    <img src="https://placehold.co/400x400" alt="placeholder" />
                   </Thumbnail>
                 </div>
 

--- a/src/pattern-library/components/patterns/layout/CardPage.tsx
+++ b/src/pattern-library/components/patterns/layout/CardPage.tsx
@@ -52,8 +52,8 @@ export default function CardPage() {
               <Card>
                 <img
                   className="rounded-t-[inherit]"
-                  src="https://placekitten.com/1000/250"
-                  alt="kitty"
+                  src="https://placehold.co/1000/250"
+                  alt="placeholder"
                 />
                 <CardContent>
                   <LoremIpsum size="xs" />


### PR DESCRIPTION
We were using `placekitten.com` to generate placeholder images, but the service is no longer available.

This PR replaces that service with https://placehold.co, which generates a bit more boring images, but should work as a valid replacement.