### PR TITLE
Do not allow text to be selected in Select options

### DIFF
--- a/src/components/input/Select.tsx
+++ b/src/components/input/Select.tsx
@@ -98,7 +98,7 @@ function SelectOption<T>({
   return (
     <li
       className={classnames(
-        'w-full ring-inset outline-none rounded-none',
+        'w-full ring-inset outline-none rounded-none select-none',
         'border-t first:border-t-0 whitespace-nowrap',
         {
           'text-grey-4': disabled,


### PR DESCRIPTION
Avoid text to be selectable in `Select.Option` components.

This is specially important as we plan to support selecting multiple options via <kbd>Shift</kbd> + click, which selects all text in between by default.

Before:

[Grabación de pantalla desde 2024-08-14 10-17-41.webm](https://github.com/user-attachments/assets/f912b72e-2bbb-4538-8bea-9f369c8ffcdf)

After:

[Grabación de pantalla desde 2024-08-14 10-18-09.webm](https://github.com/user-attachments/assets/41dca028-c538-4b7d-b952-0130ed085587)
