### PR TITLE
Adjust Select selected options UI

### DIFF
--- a/src/components/input/Select.tsx
+++ b/src/components/input/Select.tsx
@@ -17,7 +17,7 @@ import { useSyncedRef } from '../../hooks/use-synced-ref';
 import type { CompositeProps } from '../../types';
 import { ListenerCollection } from '../../util/listener-collection';
 import { downcastRef } from '../../util/typing';
-import { MenuCollapseIcon, MenuExpandIcon } from '../icons';
+import { CheckIcon, MenuCollapseIcon, MenuExpandIcon } from '../icons';
 import { inputGroupStyles } from './InputGroup';
 import SelectContext from './SelectContext';
 
@@ -99,11 +99,10 @@ function SelectOption<T>({
     <li
       className={classnames(
         'w-full ring-inset outline-none rounded-none select-none',
-        'border-t first:border-t-0 whitespace-nowrap',
+        'px-1 mb-1 first:mt-1 whitespace-nowrap group',
         {
           'text-grey-4': disabled,
-          'cursor-pointer focus-visible-ring hover:bg-grey-1': !disabled,
-          'bg-grey-1 hover:bg-grey-2': selected,
+          'cursor-pointer': !disabled,
         },
         classes,
       )}
@@ -125,12 +124,24 @@ function SelectOption<T>({
       tabIndex={-1}
     >
       <div
-        className={classnames('flex w-full p-1.5 border-l-4', {
-          'border-l-transparent': !selected,
-          'border-l-brand font-medium': selected,
-        })}
+        className={classnames(
+          'w-full flex justify-between items-center gap-2',
+          'rounded py-2 px-3',
+          {
+            'hover:bg-grey-1 group-focus-visible:ring': !disabled,
+            'bg-grey-1 hover:bg-grey-2': selected,
+          },
+        )}
       >
         {optionChildren(children, { selected, disabled })}
+        <CheckIcon
+          className={classnames('text-grey-6 scale-125', {
+            // Make the icon visible/invisible, instead of conditionally
+            // rendering it, to ensure consistent spacing among selected and
+            // non-selected options
+            'opacity-0': !selected,
+          })}
+        />
       </div>
     </li>
   );

--- a/src/pattern-library/components/patterns/prototype/SelectPage.tsx
+++ b/src/pattern-library/components/patterns/prototype/SelectPage.tsx
@@ -50,10 +50,10 @@ function SelectExample({
               {textOnly && value.name}
               {!textOnly && (
                 <div className="flex">
-                  <div className="truncate">{value.name}</div>
-                  <div className="rounded px-2 ml-2 bg-grey-7 text-white">
+                  <div className="rounded px-2 mr-2 bg-grey-7 text-white">
                     {value.id}
                   </div>
+                  <div className="truncate">{value.name}</div>
                 </div>
               )}
             </>
@@ -68,18 +68,17 @@ function SelectExample({
               textOnly ? (
                 item.name
               ) : (
-                <>
-                  {item.name}
-                  <div className="grow" />
+                <div className="flex">
                   <div
-                    className={classnames('rounded px-2 ml-2 text-white', {
+                    className={classnames('rounded px-2 mr-2 text-white', {
                       'bg-grey-7': !disabled,
                       'bg-grey-4': disabled,
                     })}
                   >
                     {item.id}
                   </div>
-                </>
+                  <div className="truncate">{item.name}</div>
+                </div>
               )
             }
           </Select.Option>

--- a/src/pattern-library/examples/select-in-input-group.tsx
+++ b/src/pattern-library/examples/select-in-input-group.tsx
@@ -1,4 +1,3 @@
-import classnames from 'classnames';
 import { useCallback, useId, useMemo, useState } from 'preact/hooks';
 
 import { ArrowLeftIcon, ArrowRightIcon } from '../../components/icons';
@@ -13,6 +12,17 @@ const students = [
   { id: '5', name: 'Doris Evanescence' },
 ];
 
+type Student = (typeof students)[number];
+
+function StudentContainer({ student }: { student: Student }) {
+  return (
+    <div className="flex">
+      <div className="rounded px-2 mr-2 bg-grey-7 text-white">{student.id}</div>
+      <div className="truncate">{student.name}</div>
+    </div>
+  );
+}
+
 export default function App({
   buttonClasses,
   wrapperClasses = 'w-96',
@@ -20,7 +30,7 @@ export default function App({
   buttonClasses?: string;
   wrapperClasses?: string;
 }) {
-  const [selected, setSelected] = useState<(typeof students)[number]>();
+  const [selected, setSelected] = useState<Student>();
   const selectedIndex = useMemo(
     () => (!selected ? -1 : students.findIndex(item => item === selected)),
     [selected],
@@ -53,12 +63,7 @@ export default function App({
           buttonClasses={buttonClasses}
           buttonContent={
             selected ? (
-              <div className="flex">
-                <div className="truncate">{selected.name}</div>
-                <div className="rounded px-2 ml-2 bg-grey-7 text-white">
-                  {selected.id}
-                </div>
-              </div>
+              <StudentContainer student={selected} />
             ) : (
               <>Select one…</>
             )
@@ -66,13 +71,7 @@ export default function App({
         >
           {students.map(item => (
             <Select.Option value={item} key={item.id}>
-              {item.name}
-              <div className="grow" />
-              <div
-                className={classnames('rounded px-2 ml-2 text-white bg-grey-7')}
-              >
-                {item.id}
-              </div>
+              <StudentContainer student={item} />
             </Select.Option>
           ))}
         </Select>

--- a/src/pattern-library/examples/select-non-popover-listbox.tsx
+++ b/src/pattern-library/examples/select-non-popover-listbox.tsx
@@ -34,20 +34,7 @@ export default function App() {
             buttonId={buttonId}
             value={value}
             onChange={setValue}
-            buttonContent={
-              value ? (
-                <>
-                  <div className="flex">
-                    <div className="truncate">{value.name}</div>
-                    <div className="rounded px-2 ml-2 bg-grey-7 text-white">
-                      {value.id}
-                    </div>
-                  </div>
-                </>
-              ) : (
-                <>Select one…</>
-              )
-            }
+            buttonContent={value ? value.name : <>Select one…</>}
           >
             {items.map(item => (
               <Select.Option
@@ -56,10 +43,6 @@ export default function App() {
                 disabled={item.disabled}
               >
                 {item.name}
-                <div className="grow" />
-                <div className="rounded px-2 ml-2 text-white bg-grey-7">
-                  {item.id}
-                </div>
               </Select.Option>
             ))}
           </Select>

--- a/src/pattern-library/examples/select-right.tsx
+++ b/src/pattern-library/examples/select-right.tsx
@@ -1,4 +1,3 @@
-import type { ComponentChildren } from 'preact';
 import { useId, useState } from 'preact/hooks';
 
 import { Select } from '../..';
@@ -11,14 +10,19 @@ const items = [
   { id: '5', name: 'Doris Evanescence' },
 ];
 
-function Bullet({ children }: { children: ComponentChildren }) {
+type Item = (typeof items)[number];
+
+function ItemContainer({ item }: { item: Item }) {
   return (
-    <div className="rounded px-2 ml-2 bg-grey-7 text-white">{children}</div>
+    <div className="flex">
+      <div className="rounded px-2 mr-2 bg-grey-7 text-white">{item.id}</div>
+      <div className="truncate">{item.name}</div>
+    </div>
   );
 }
 
 export default function App() {
-  const [value, setSelected] = useState<{ id: string; name: string }>();
+  const [value, setSelected] = useState<Item>();
   const selectId = useId();
 
   return (
@@ -30,22 +34,13 @@ export default function App() {
         onChange={setSelected}
         buttonId={selectId}
         buttonContent={
-          value ? (
-            <div className="flex">
-              <div className="truncate">{value.name}</div>
-              <Bullet>{value.id}</Bullet>
-            </div>
-          ) : (
-            <>Select one…</>
-          )
+          value ? <ItemContainer item={value} /> : <>Select one…</>
         }
         buttonClasses="!w-36"
       >
         {items.map(item => (
           <Select.Option value={item} key={item.id}>
-            {item.name}
-            <div className="grow" />
-            <Bullet>{item.id}</Bullet>
+            <ItemContainer item={item} />
           </Select.Option>
         ))}
       </Select>

--- a/src/pattern-library/examples/select-with-custom-options.tsx
+++ b/src/pattern-library/examples/select-with-custom-options.tsx
@@ -1,4 +1,3 @@
-import type { ComponentChildren } from 'preact';
 import { useId, useState } from 'preact/hooks';
 
 import { Select } from '../..';
@@ -16,9 +15,12 @@ const defaultItems: Item[] = [
   { id: '5', name: 'Doris Evanescence' },
 ];
 
-function Bullet({ children }: { children: ComponentChildren }) {
+function ItemContainer({ item }: { item: Item }) {
   return (
-    <div className="rounded px-2 ml-2 bg-grey-7 text-white">{children}</div>
+    <div className="flex">
+      <div className="rounded px-2 mr-2 bg-grey-7 text-white">{item.id}</div>
+      <div className="truncate">{item.name}</div>
+    </div>
   );
 }
 
@@ -34,21 +36,12 @@ export default function App({ items = defaultItems }: { items?: Item[] }) {
         onChange={setSelected}
         buttonId={selectId}
         buttonContent={
-          value ? (
-            <div className="flex">
-              <div className="truncate">{value.name}</div>
-              <Bullet>{value.id}</Bullet>
-            </div>
-          ) : (
-            <>Select one…</>
-          )
+          value ? <ItemContainer item={value} /> : <>Select one…</>
         }
       >
         {items.map(item => (
           <Select.Option value={item} key={item.id}>
-            {item.name}
-            <div className="grow" />
-            <Bullet>{item.id}</Bullet>
+            <ItemContainer item={item} />
           </Select.Option>
         ))}
       </Select>


### PR DESCRIPTION
This PR is the first one for https://github.com/hypothesis/frontend-shared/issues/1658

This PR only changes how selected options look like in both `Select` and `MultiSelect`, to look like in the [new UI designs](https://www.figma.com/design/rugQ2tONStRF3RL9UXZaGW/Search-Explorations?node-id=1862-693&t=dYvG3ythTTeUNTCy-0):

![image](https://github.com/user-attachments/assets/9922991d-4ea2-4a51-a020-05fa34ae5d21)

Everything related with `MultiSelect` checkboxes will come after.

### Changes

Before:

[Grabación de pantalla desde 2024-08-19 11-56-42.webm](https://github.com/user-attachments/assets/7dde6c18-5d8c-442e-b4ed-8b5da9dc9058)

After:

[Grabación de pantalla desde 2024-08-19 11-55-39.webm](https://github.com/user-attachments/assets/626a36ec-c6fb-4cf6-bd62-149fae096279)

### Considerations

With these changes, selected options have a tick on the right side. This looks slightly awkward with some of the examples in the pattern library, specifically the ones with custom options.

[Grabación de pantalla desde 2024-08-19 11-33-52.webm](https://github.com/user-attachments/assets/705f36b9-5d5e-48a0-91a4-0ed32d242bb4)

However, customizing options is just a capability provided by the component, and not its own responsibility to ensure it looks good. Many other things could look awkward even with previous design, so I think this should be considered the consumer's responsibility.

This PR adds a second commit which adjusts those examples to look better.

[Grabación de pantalla desde 2024-08-19 12-35-24.webm](https://github.com/user-attachments/assets/c7340803-cefb-4ba6-aebb-b54e201a05b0)

### Todo

- [x] Adjust keyboard navigation/focus ring UI
- [x] Update existing examples which don't look great with the new UI