### PR TITLE
Add darker border to Select when listbox is open

### DIFF
--- a/src/components/input/InputGroup.tsx
+++ b/src/components/input/InputGroup.tsx
@@ -12,7 +12,9 @@ export const inputGroupStyles = classnames(
   // Restore border-radius on the leftmost and rightmost components in the group
   'input-group:first:rounded-l input-group:last:rounded-r',
   // "Collapse" borders between input components
-  'input-group:border-l-0 input-group:first:border-l',
+  'input-group:ml-[-1px] input-group:first:ml-0',
+  // Make sure focused element appears on top, preventing a cropped focus ring
+  'focus:z-1',
 );
 
 export type InputGroupProps = PresentationalProps &

--- a/src/components/input/Select.tsx
+++ b/src/components/input/Select.tsx
@@ -403,6 +403,7 @@ function SelectMain<T>({
     <div
       className={classnames(
         'relative w-full border rounded',
+        { 'border-grey-5': listboxOpen },
         inputGroupStyles,
         containerClasses,
       )}


### PR DESCRIPTION
Part of https://github.com/hypothesis/frontend-shared/issues/1658

As part of the new Select UI, this PR ensures a darker border is used in the `Select` and `MultiSelect` input while the listbox is open.

Before:

[Grabación de pantalla desde 2024-08-19 15-31-43.webm](https://github.com/user-attachments/assets/9be973ac-73c9-4650-8688-c4910aaf5fba)

After:

[Grabación de pantalla desde 2024-08-19 15-32-40.webm](https://github.com/user-attachments/assets/84388fab-5d0a-4dc9-ba12-92cf93d8c40e)


### TODO

- [x] This change does not look great when used inside a input group. Let's fix that.