### PR TITLE
Fix circular dependency warning

### DIFF
--- a/src/components/input/Select.tsx
+++ b/src/components/input/Select.tsx
@@ -23,9 +23,9 @@ import {
   MenuCollapseIcon,
   MenuExpandIcon,
 } from '../icons';
+import Checkbox from './Checkbox';
 import { inputGroupStyles } from './InputGroup';
 import SelectContext from './SelectContext';
-import { Checkbox } from './index';
 
 export type SelectOptionStatus = {
   selected: boolean;


### PR DESCRIPTION
In https://github.com/hypothesis/frontend-shared/pull/1664 we introduced a circular dependency between `Select.tsx` and `index.ts` by importing the `Checkbox` component from `index` instead of its own individual module, causing Rollup to throw warnings like this:

```
[16:24:11] Rollup warning: Export "Select" of module "src/components/input/Select.tsx" was reexported through module "src/components/input/index.ts" while both modules are dependencies of each other and will end up in different chunks by current Rollup settings. This scenario is not well supported at the moment as it will produce a circular dependency between chunks and will likely lead to broken execution order.
Either change the import in "src/pattern-library/examples/select-aria-label.tsx" to point directly to the exporting module or reconfigure "output.manualChunks" to ensure these modules end up in the same chunk. (undefined)
[16:24:11] Rollup warning: Export "Select" of module "src/components/input/Select.tsx" was reexported through module "src/components/input/index.ts" while both modules are dependencies of each other and will end up in different chunks by current Rollup settings. This scenario is not well supported at the moment as it will produce a circular dependency between chunks and will likely lead to broken execution order.
Either change the import in "src/pattern-library/examples/select-aria-labelledby.tsx" to point directly to the exporting module or reconfigure "output.manualChunks" to ensure these modules end up in the same chunk. (undefined)
[16:24:11] Rollup warning: Export "Select" of module "src/components/input/Select.tsx" was reexported through module "src/components/input/index.ts" while both modules are dependencies of each other and will end up in different chunks by current Rollup settings. This scenario is not well supported at the moment as it will produce a circular dependency between chunks and will likely lead to broken execution order.
Either change the import in "src/pattern-library/examples/select-basic.tsx" to point directly to the exporting module or reconfigure "output.manualChunks" to ensure these modules end up in the same chunk. (undefined)
[16:24:11] Rollup warning: Export "Select" of module "src/components/input/Select.tsx" was reexported through module "src/components/input/index.ts" while both modules are dependencies of each other and will end up in different chunks by current Rollup settings. This scenario is not well supported at the moment as it will produce a circular dependency between chunks and will likely lead to broken execution order.
Either change the import in "src/pattern-library/examples/select-disabled.tsx" to point directly to the exporting module or reconfigure "output.manualChunks" to ensure these modules end up in the same chunk. (undefined)
[16:24:11] Rollup warning: Export "MultiSelect" of module "src/components/input/Select.tsx" was reexported through module "src/components/input/index.ts" while both modules are dependencies of each other and will end up in different chunks by current Rollup settings. This scenario is not well supported at the moment as it will produce a circular dependency between chunks and will likely lead to broken execution order.
Either change the import in "src/pattern-library/examples/select-multi-select.tsx" to point directly to the exporting module or reconfigure "output.manualChunks" to ensure these modules end up in the same chunk. (undefined)
[16:24:11] Rollup warning: Export "Select" of module "src/components/input/Select.tsx" was reexported through module "src/components/input/index.ts" while both modules are dependencies of each other and will end up in different chunks by current Rollup settings. This scenario is not well supported at the moment as it will produce a circular dependency between chunks and will likely lead to broken execution order.
Either change the import in "src/pattern-library/examples/select-non-popover-listbox.tsx" to point directly to the exporting module or reconfigure "output.manualChunks" to ensure these modules end up in the same chunk. (undefined)
[16:24:11] Rollup warning: Export "Select" of module "src/components/input/Select.tsx" was reexported through module "src/components/input/index.ts" while both modules are dependencies of each other and will end up in different chunks by current Rollup settings. This scenario is not well supported at the moment as it will produce a circular dependency between chunks and will likely lead to broken execution order.
Either change the import in "src/pattern-library/examples/select-right.tsx" to point directly to the exporting module or reconfigure "output.manualChunks" to ensure these modules end up in the same chunk. (undefined)
```

This PR fixes that.