### PR TITLE
Avoid nested anchors when using Link inside RouterLink

### DIFF
--- a/src/pattern-library/components/Library.tsx
+++ b/src/pattern-library/components/Library.tsx
@@ -573,7 +573,7 @@ export type LinkProps = {
  */
 function Link({ children, href }: LinkProps) {
   return (
-    <RouteLink href={href}>
+    <RouteLink href={href} asChild>
       <UILink underline="always">{children}</UILink>
     </RouteLink>
   );

--- a/src/pattern-library/components/PlaygroundApp.tsx
+++ b/src/pattern-library/components/PlaygroundApp.tsx
@@ -62,7 +62,7 @@ function NavLink({ route }: { route: PlaygroundRoute }) {
   return (
     <li className="-ml-[2px]">
       {route.route && (
-        <RouteLink href={route.route ?? ''}>
+        <RouteLink href={route.route ?? ''} asChild>
           <Link
             classes={classnames(
               'pl-4 rounded-l-none w-full border-l-2 hover:border-l-brand',


### PR DESCRIPTION
Fixes https://github.com/hypothesis/frontend-shared/issues/1668

Add missing `asChild` prop to wouter's `Link`s when wrapping a custom `Link` component.

See documentation for context: https://github.com/molefrog/wouter?tab=readme-ov-file#link-hrefpath-