### PR TITLE
Add new clear Select.Option

### DIFF
--- a/src/components/input/test/Select-test.js
+++ b/src/components/input/test/Select-test.js
@@ -36,9 +36,15 @@ describe('Select', () => {
 
     const wrapper = mount(
       <Component value={undefined} onChange={sinon.stub()} {...props}>
-        <Component.Option value={undefined}>
-          <span data-testid="option-reset">Reset</span>
-        </Component.Option>
+        {Component === MultiSelect ? (
+          <Component.Option clear>
+            <span data-testid="option-reset">Reset</span>
+          </Component.Option>
+        ) : (
+          <Component.Option value={undefined}>
+            <span data-testid="option-reset">Reset</span>
+          </Component.Option>
+        )}
         {items.map(item => (
           <Component.Option
             value={item}

--- a/src/pattern-library/examples/select-multi-select.tsx
+++ b/src/pattern-library/examples/select-multi-select.tsx
@@ -36,7 +36,7 @@ export default function App() {
           )
         }
       >
-        <MultiSelect.Option value={undefined}>All students</MultiSelect.Option>
+        <MultiSelect.Option clear>All students</MultiSelect.Option>
         {items.map(item => (
           <MultiSelect.Option value={item} key={item.id}>
             {item.name}


### PR DESCRIPTION
Part of https://github.com/hypothesis/frontend-shared/issues/1658

Add a new `clear` prop to the `Select.Option`/`MultiSelect.Option` component, designed to define an element that clears the selected value.

```tsx
function Aapp() {
    return (
        <MultiSelect>
            <MultiSelect.Option clear>All students</MultiSelect.Option>
            <MultiSelect.Option value={1}>Joh Doe</MultiSelect.Option>
            <MultiSelect.Option value={2}>Jane Doe</MultiSelect.Option>
        </MultiSelect>
    );
}
```

### Context

In regular `Selects` this was already easy to achieve, by using the `undefined` or `null` values in one of the options and making it represent the "absence" of a selected value. However, in `MultiSelect` this was not as easy to do, because the "absence" of a selected value is an empty array.

We already more or less supported this by using the `undefined` value in MultiSelects as a way to clear the selection, but it had the limitation that any option with that value would never be marked as selected.

[Grabación de pantalla desde 2024-08-20 17-56-43.webm](https://github.com/user-attachments/assets/54996686-180c-4738-baf9-dee061337690)

This PR introduces a new boolean `clear` prop that makes the option behave differently, by setting current value as "empty" (whether that is `undefined` for `Select` or `[]` for `MultiSelect`) ad by making sure it is visually marked as selected when current value is "empty".

### Considerations

* Any option which sets the `clear` prop should not provide a value, as the value is implicit.
* Technically speaking, a consumer could define as many "clear" options as desired, and they would all get marked as selected, but the intention is that only one is used. 