### PR TITLE
Add new Select.ClearOption

### DIFF
--- a/src/components/input/test/Select-test.js
+++ b/src/components/input/test/Select-test.js
@@ -36,9 +36,15 @@ describe('Select', () => {
 
     const wrapper = mount(
       <Component value={undefined} onChange={sinon.stub()} {...props}>
-        <Component.Option value={undefined}>
-          <span data-testid="option-reset">Reset</span>
-        </Component.Option>
+        {Component === MultiSelect ? (
+          <Component.ClearOption>
+            <span data-testid="option-reset">Reset</span>
+          </Component.ClearOption>
+        ) : (
+          <Component.Option value={undefined}>
+            <span data-testid="option-reset">Reset</span>
+          </Component.Option>
+        )}
         {items.map(item => (
           <Component.Option
             value={item}

--- a/src/pattern-library/examples/select-multi-select.tsx
+++ b/src/pattern-library/examples/select-multi-select.tsx
@@ -36,7 +36,7 @@ export default function App() {
           )
         }
       >
-        <MultiSelect.Option value={undefined}>All students</MultiSelect.Option>
+        <MultiSelect.ClearOption>All students</MultiSelect.ClearOption>
         {items.map(item => (
           <MultiSelect.Option value={item} key={item.id}>
             {item.name}


### PR DESCRIPTION
Part of https://github.com/hypothesis/frontend-shared/issues/1658

This PR is an alternative implementation to https://github.com/hypothesis/frontend-shared/pull/1670, where the "special" option to clear a MultiSelect is not identified by a prop, but instead it is exposed as a separate component, which is only exposed via `MultiSelect` and not via `Select` (although we could choose to expose it in both cases).

```tsx
function App() {
  const [students, setStudents] = useState<number[]>([]);

  return (
    <MultiSelect value={students} onChange={setStudents}>
      <MultiSelect.ClearOption>All students</MultiSelect.ClearOption>
      <MultiSelect.Option value={1}>Joh Doe</MultiSelect.Option>
      <MultiSelect.Option value={2}>Jane Doe</MultiSelect.Option>
    </MultiSelect>
  );
}
```

> Context and considerations here are the same described in https://github.com/hypothesis/frontend-shared/pull/1670

### Todo

- [ ] Document new component in pattern library.