### PR TITLE
Adjust select options gap

### DIFF
--- a/src/components/input/Select.tsx
+++ b/src/components/input/Select.tsx
@@ -179,7 +179,7 @@ function SelectOption<T>({
     >
       <div
         className={classnames(
-          'w-full flex justify-between items-center gap-2',
+          'w-full flex justify-between items-center gap-3',
           'rounded py-2 px-3',
           {
             'hover:bg-grey-1 group-focus-visible:ring': !disabled,


### PR DESCRIPTION
Part of https://github.com/hypothesis/frontend-shared/issues/1658

Increase the gap between Select/MultiSelect options icons and their content, to match the horizontal padding and make it look less heaped when the content grows to fill all available space.

Before:

![image](https://github.com/user-attachments/assets/adb174b2-dc0e-44ea-8f5c-2dbac9814890)

After:

![image](https://github.com/user-attachments/assets/9c673a14-0074-4b4f-8736-6c2fdb7928c8)
