### PR TITLE
Add a new `RadioButton` comppnent

### DIFF
--- a/images/icons/radio-checked.svg
+++ b/images/icons/radio-checked.svg
@@ -1,0 +1,5 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect x="0.5" y="0.5" width="15" height="15" rx="7.5" fill="#FAFAFA"/>
+<rect x="0.5" y="0.5" width="15" height="15" rx="7.5" stroke="currentColor"/>
+<rect x="3" y="3" width="10" height="10" rx="5" fill="currentColor"/>
+</svg>

--- a/images/icons/radio.svg
+++ b/images/icons/radio.svg
@@ -1,0 +1,4 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect x="0.5" y="0.5" width="15" height="15" rx="7.5" fill="#FAFAFA"/>
+<rect x="0.5" y="0.5" width="15" height="15" rx="7.5" stroke="currentColor"/>
+</svg>

--- a/src/components/icons/Radio.tsx
+++ b/src/components/icons/Radio.tsx
@@ -1,0 +1,31 @@
+// This file was auto-generated using scripts/generate-icons.js
+import type { JSX } from 'preact';
+
+export type RadioIconProps = JSX.SVGAttributes<SVGSVGElement>;
+
+/**
+ * Icon generated from radio.svg
+ */
+export default function RadioIcon(props: RadioIconProps) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="16"
+      height="16"
+      fill="none"
+      viewBox="0 0 16 16"
+      data-component="RadioIcon"
+      {...props}
+    >
+      <rect width="15" height="15" x=".5" y=".5" fill="#FAFAFA" rx="7.5" />
+      <rect
+        width="15"
+        height="15"
+        x=".5"
+        y=".5"
+        stroke="currentColor"
+        rx="7.5"
+      />
+    </svg>
+  );
+}

--- a/src/components/icons/RadioChecked.tsx
+++ b/src/components/icons/RadioChecked.tsx
@@ -1,0 +1,32 @@
+// This file was auto-generated using scripts/generate-icons.js
+import type { JSX } from 'preact';
+
+export type RadioCheckedIconProps = JSX.SVGAttributes<SVGSVGElement>;
+
+/**
+ * Icon generated from radio-checked.svg
+ */
+export default function RadioCheckedIcon(props: RadioCheckedIconProps) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="16"
+      height="16"
+      fill="none"
+      viewBox="0 0 16 16"
+      data-component="RadioCheckedIcon"
+      {...props}
+    >
+      <rect width="15" height="15" x=".5" y=".5" fill="#FAFAFA" rx="7.5" />
+      <rect
+        width="15"
+        height="15"
+        x=".5"
+        y=".5"
+        stroke="currentColor"
+        rx="7.5"
+      />
+      <rect width="10" height="10" x="3" y="3" fill="currentColor" rx="5" />
+    </svg>
+  );
+}

--- a/src/components/icons/index.ts
+++ b/src/components/icons/index.ts
@@ -91,6 +91,8 @@ export { default as PreviewIcon } from './Preview';
 export { default as PreviewFilledIcon } from './PreviewFilled';
 export { default as ProfileIcon } from './Profile';
 export { default as ProfileFilledIcon } from './ProfileFilled';
+export { default as RadioIcon } from './Radio';
+export { default as RadioCheckedIcon } from './RadioChecked';
 export { default as RefreshIcon } from './Refresh';
 export { default as ReplyIcon } from './Reply';
 export { default as ReplyAltIcon } from './ReplyAlt';

--- a/src/components/input/Checkbox.tsx
+++ b/src/components/input/Checkbox.tsx
@@ -1,20 +1,11 @@
-import classnames from 'classnames';
-import type { JSX } from 'preact';
-import { useState } from 'preact/hooks';
+import type { IconComponent } from '../../types';
+import { CheckboxCheckedIcon, CheckboxOutlineIcon } from '../icons';
+import ToggleInput, { type ToggleInputProps } from './ToggleInput';
 
-import type { CompositeProps, IconComponent } from '../../types';
-import { downcastRef } from '../../util/typing';
-import { CheckboxOutlineIcon, CheckboxCheckedIcon } from '../icons';
-
-type ComponentProps = {
-  /** Current checked state. Used when the Checkbox is controlled. */
-  checked?: boolean;
-
-  /**
-   * Default checked state. Used to set initial state when the Checkbox is not
-   * controlled.
-   */
-  defaultChecked?: boolean;
+export type CheckboxProps = Omit<
+  ToggleInputProps,
+  'icon' | 'checkedIcon' | 'type'
+> & {
   /** Custom icon to show when input is unchecked */
   icon?: IconComponent;
   /** Custom icon to show when input is checked */
@@ -23,89 +14,22 @@ type ComponentProps = {
   type?: never;
 };
 
-export type CheckboxProps = CompositeProps &
-  ComponentProps &
-  Omit<JSX.HTMLAttributes<HTMLInputElement>, 'size' | 'icon'>;
-
 /**
  * Render a labeled checkbox input. The checkbox is styled with two icons:
  * one for the unchecked state and one for the checked state. The input itself
  * is positioned exactly on top of the icon, but is non-visible.
  */
 export default function Checkbox({
-  children,
-  elementRef,
-
-  checked,
-  defaultChecked = false,
-  icon: UncheckedIcon = CheckboxOutlineIcon,
-  checkedIcon: CheckedIcon = CheckboxCheckedIcon,
-
-  disabled,
-  onChange,
-  id,
-  ...htmlAttributes
+  icon = CheckboxOutlineIcon,
+  checkedIcon = CheckboxCheckedIcon,
+  ...rest
 }: CheckboxProps) {
-  // If `checked` is present, treat this as a controlled component
-  const isControlled = typeof checked === 'boolean';
-  // Only use this local state if checkbox is uncontrolled
-  const [uncontrolledChecked, setUncontrolledChecked] =
-    useState(defaultChecked);
-  const isChecked = isControlled ? checked : uncontrolledChecked;
-
-  function handleChange(
-    this: void,
-    event: JSX.TargetedEvent<HTMLInputElement>,
-  ) {
-    onChange?.call(this, event);
-    if (!isControlled) {
-      setUncontrolledChecked((event.target as HTMLInputElement).checked);
-    }
-  }
-
-  const Icon = isChecked ? CheckedIcon : UncheckedIcon;
-
   return (
-    <label
-      className={classnames('relative flex items-center gap-x-1.5', {
-        'cursor-pointer': !disabled,
-        'opacity-70': disabled,
-      })}
-      htmlFor={id}
-      data-composite-component="Checkbox"
-    >
-      <input
-        {...htmlAttributes}
-        type="checkbox"
-        ref={downcastRef(elementRef)}
-        className={classnames(
-          // Set the special Tailwind peer class to allow sibling elements
-          // to style themselves based on the state of this element
-          'peer',
-          // Position this atop the icon and size it to the same dimensions
-          'absolute w-em h-em',
-          // Make checkbox input visually hidden, but
-          // some screen readers won't read out elements with 0 opacity
-          'opacity-[.00001]',
-          {
-            'cursor-pointer': !disabled,
-          },
-        )}
-        checked={isChecked}
-        disabled={disabled}
-        id={id}
-        onChange={handleChange}
-      />
-      <Icon
-        className={classnames(
-          // Add an outline ring to the icon when the input is focus-visible.
-          // The ring needs to be applied here because the `input` has an
-          // effectively-0 opacity.
-          'peer-focus-visible:ring',
-          'w-em h-em',
-        )}
-      />
-      {children}
-    </label>
+    <ToggleInput
+      icon={icon}
+      checkedIcon={checkedIcon}
+      type="checkbox"
+      {...rest}
+    />
   );
 }

--- a/src/components/input/Checkbox.tsx
+++ b/src/components/input/Checkbox.tsx
@@ -1,11 +1,19 @@
-import type { IconComponent } from '../../types';
-import { CheckboxCheckedIcon, CheckboxOutlineIcon } from '../icons';
-import ToggleInput, { type ToggleInputProps } from './ToggleInput';
+import type { JSX } from 'preact';
+import { useState } from 'preact/hooks';
 
-export type CheckboxProps = Omit<
-  ToggleInputProps,
-  'icon' | 'checkedIcon' | 'type'
-> & {
+import type { CompositeProps, IconComponent } from '../../types';
+import { CheckboxCheckedIcon, CheckboxOutlineIcon } from '../icons';
+import ToggleInput from './ToggleInput';
+
+type ComponentProps = {
+  /** Current checked state. Used when the Checkbox is controlled. */
+  checked?: boolean;
+
+  /**
+   * Default checked state. Used to set initial state when the Checkbox is not
+   * controlled.
+   */
+  defaultChecked?: boolean;
   /** Custom icon to show when input is unchecked */
   icon?: IconComponent;
   /** Custom icon to show when input is checked */
@@ -14,21 +22,47 @@ export type CheckboxProps = Omit<
   type?: never;
 };
 
+export type CheckboxProps = CompositeProps &
+  ComponentProps &
+  Omit<JSX.HTMLAttributes<HTMLInputElement>, 'size' | 'icon'>;
+
 /**
  * Render a labeled checkbox input. The checkbox is styled with two icons:
  * one for the unchecked state and one for the checked state. The input itself
  * is positioned exactly on top of the icon, but is non-visible.
  */
 export default function Checkbox({
+  checked,
+  defaultChecked = false,
   icon = CheckboxOutlineIcon,
   checkedIcon = CheckboxCheckedIcon,
+  onChange,
   ...rest
 }: CheckboxProps) {
+  // If `checked` is present, treat this as a controlled component
+  const isControlled = typeof checked === 'boolean';
+  // Only use this local state if checkbox is uncontrolled
+  const [uncontrolledChecked, setUncontrolledChecked] =
+    useState(defaultChecked);
+  const isChecked = isControlled ? checked : uncontrolledChecked;
+
+  function handleChange(
+    this: void,
+    event: JSX.TargetedEvent<HTMLInputElement>,
+  ) {
+    onChange?.call(this, event);
+    if (!isControlled) {
+      setUncontrolledChecked((event.target as HTMLInputElement).checked);
+    }
+  }
+
   return (
     <ToggleInput
       icon={icon}
       checkedIcon={checkedIcon}
       type="checkbox"
+      checked={isChecked}
+      onChange={handleChange}
       {...rest}
     />
   );

--- a/src/components/input/RadioButton.tsx
+++ b/src/components/input/RadioButton.tsx
@@ -1,0 +1,35 @@
+import type { JSX } from 'preact';
+
+import type { CompositeProps, IconComponent } from '../../types';
+import { RadioCheckedIcon, RadioIcon } from '../icons';
+import ToggleInput from './ToggleInput';
+
+type ComponentProps = {
+  checked?: boolean;
+
+  /** Custom icon to show when input is unchecked */
+  icon?: IconComponent;
+  /** Custom icon to show when input is checked */
+  checkedIcon?: IconComponent;
+  /** type is always `radio` */
+  type?: never;
+};
+
+export type RadioButtonProps = CompositeProps &
+  ComponentProps &
+  Omit<JSX.HTMLAttributes<HTMLInputElement>, 'size' | 'icon'>;
+
+/**
+ * Render a labeled radio input. The radio is styled with two icons: one for the
+ * unchecked state and one for the checked state. The input itself is positioned
+ * exactly on top of the icon, but is non-visible.
+ */
+export default function RadioButton({
+  icon = RadioIcon,
+  checkedIcon = RadioCheckedIcon,
+  ...rest
+}: RadioButtonProps) {
+  return (
+    <ToggleInput icon={icon} checkedIcon={checkedIcon} type="radio" {...rest} />
+  );
+}

--- a/src/components/input/ToggleInput.tsx
+++ b/src/components/input/ToggleInput.tsx
@@ -1,19 +1,12 @@
 import classnames from 'classnames';
 import type { JSX } from 'preact';
-import { useState } from 'preact/hooks';
 
 import type { CompositeProps, IconComponent } from '../../types';
 import { downcastRef } from '../../util/typing';
 
 type ComponentProps = {
-  /** Current checked state. Used when the input is controlled. */
   checked?: boolean;
 
-  /**
-   * Default checked state. Used to set initial state when the input is not
-   * controlled.
-   */
-  defaultChecked?: boolean;
   /** Custom icon to show when input is unchecked */
   icon: IconComponent;
   /** Custom icon to show when input is checked */
@@ -36,7 +29,6 @@ export default function ToggleInput({
   elementRef,
 
   checked,
-  defaultChecked = false,
   icon: UncheckedIcon,
   checkedIcon: CheckedIcon,
 
@@ -46,24 +38,7 @@ export default function ToggleInput({
   type,
   ...htmlAttributes
 }: ToggleInputProps) {
-  // If `checked` is present, treat this as a controlled component
-  const isControlled = typeof checked === 'boolean';
-  // Only use this local state if checkbox is uncontrolled
-  const [uncontrolledChecked, setUncontrolledChecked] =
-    useState(defaultChecked);
-  const isChecked = isControlled ? checked : uncontrolledChecked;
-
-  function handleChange(
-    this: void,
-    event: JSX.TargetedEvent<HTMLInputElement>,
-  ) {
-    onChange?.call(this, event);
-    if (!isControlled) {
-      setUncontrolledChecked((event.target as HTMLInputElement).checked);
-    }
-  }
-
-  const Icon = isChecked ? CheckedIcon : UncheckedIcon;
+  const Icon = checked ? CheckedIcon : UncheckedIcon;
 
   return (
     <label
@@ -93,10 +68,10 @@ export default function ToggleInput({
             'cursor-pointer': !disabled,
           },
         )}
-        checked={isChecked}
+        checked={checked}
         disabled={disabled}
         id={id}
-        onChange={handleChange}
+        onChange={onChange}
       />
       <Icon
         className={classnames(

--- a/src/components/input/ToggleInput.tsx
+++ b/src/components/input/ToggleInput.tsx
@@ -1,0 +1,113 @@
+import classnames from 'classnames';
+import type { JSX } from 'preact';
+import { useState } from 'preact/hooks';
+
+import type { CompositeProps, IconComponent } from '../../types';
+import { downcastRef } from '../../util/typing';
+
+type ComponentProps = {
+  /** Current checked state. Used when the input is controlled. */
+  checked?: boolean;
+
+  /**
+   * Default checked state. Used to set initial state when the input is not
+   * controlled.
+   */
+  defaultChecked?: boolean;
+  /** Custom icon to show when input is unchecked */
+  icon: IconComponent;
+  /** Custom icon to show when input is checked */
+  checkedIcon: IconComponent;
+
+  type: 'checkbox' | 'radio';
+};
+
+export type ToggleInputProps = CompositeProps &
+  ComponentProps &
+  Omit<JSX.HTMLAttributes<HTMLInputElement>, 'size' | 'icon'>;
+
+/**
+ * Render a labeled checkbox or radio input. The input is styled with two icons:
+ * one for the unchecked state and one for the checked state. The input itself
+ * is positioned exactly on top of the icon, but is non-visible.
+ */
+export default function ToggleInput({
+  children,
+  elementRef,
+
+  checked,
+  defaultChecked = false,
+  icon: UncheckedIcon,
+  checkedIcon: CheckedIcon,
+
+  disabled,
+  onChange,
+  id,
+  type,
+  ...htmlAttributes
+}: ToggleInputProps) {
+  // If `checked` is present, treat this as a controlled component
+  const isControlled = typeof checked === 'boolean';
+  // Only use this local state if checkbox is uncontrolled
+  const [uncontrolledChecked, setUncontrolledChecked] =
+    useState(defaultChecked);
+  const isChecked = isControlled ? checked : uncontrolledChecked;
+
+  function handleChange(
+    this: void,
+    event: JSX.TargetedEvent<HTMLInputElement>,
+  ) {
+    onChange?.call(this, event);
+    if (!isControlled) {
+      setUncontrolledChecked((event.target as HTMLInputElement).checked);
+    }
+  }
+
+  const Icon = isChecked ? CheckedIcon : UncheckedIcon;
+
+  return (
+    <label
+      className={classnames('relative flex items-center gap-x-1.5', {
+        'cursor-pointer': !disabled,
+        'opacity-70': disabled,
+      })}
+      htmlFor={id}
+      data-composite-component={
+        type === 'checkbox' ? 'Checkbox' : 'RadioButton'
+      }
+    >
+      <input
+        {...htmlAttributes}
+        type={type}
+        ref={downcastRef(elementRef)}
+        className={classnames(
+          // Set the special Tailwind peer class to allow sibling elements
+          // to style themselves based on the state of this element
+          'peer',
+          // Position this atop the icon and size it to the same dimensions
+          'absolute w-em h-em',
+          // Make input visually hidden, but some screen readers won't read out
+          // elements with 0 opacity
+          'opacity-[.00001]',
+          {
+            'cursor-pointer': !disabled,
+          },
+        )}
+        checked={isChecked}
+        disabled={disabled}
+        id={id}
+        onChange={handleChange}
+      />
+      <Icon
+        className={classnames(
+          // Add an outline ring to the icon when the input is focus-visible.
+          // The ring needs to be applied here because the `input` has an
+          // effectively-0 opacity.
+          'peer-focus-visible:ring',
+          'w-em h-em',
+        )}
+      />
+      {children}
+    </label>
+  );
+}

--- a/src/components/input/index.ts
+++ b/src/components/input/index.ts
@@ -5,6 +5,7 @@ export { default as IconButton } from './IconButton';
 export { default as Input } from './Input';
 export { default as InputGroup } from './InputGroup';
 export { default as OptionButton } from './OptionButton';
+export { default as RadioButton } from './RadioButton';
 export { Select, MultiSelect } from './Select';
 export { default as Textarea } from './Textarea';
 
@@ -15,5 +16,6 @@ export type { IconButtonProps } from './IconButton';
 export type { InputProps } from './Input';
 export type { InputGroupProps } from './InputGroup';
 export type { OptionButtonProps } from './OptionButton';
+export type { RadioButtonProps } from './RadioButton';
 export type { MultiSelectProps, SelectProps } from './Select';
 export type { TextareaProps } from './Textarea';

--- a/src/components/input/test/RadioButton-test.js
+++ b/src/components/input/test/RadioButton-test.js
@@ -1,0 +1,28 @@
+import { mount } from 'enzyme';
+
+import { testCompositeComponent } from '../../test/common-tests';
+import RadioButton from '../RadioButton';
+
+// Relatively simple test, as most of the logic is shared with Checkbox, and
+// covered by Checkbox-test
+describe('RadioButton', () => {
+  const createComponent = (props = {}) => {
+    return mount(<RadioButton {...props}>This is child content</RadioButton>);
+  };
+
+  testCompositeComponent(RadioButton, {
+    elementSelector: 'input[type="radio"]',
+  });
+
+  it('shows an icon representing radio state', () => {
+    const wrapper = createComponent();
+
+    assert.isTrue(wrapper.exists('RadioIcon'));
+    assert.isFalse(wrapper.exists('RadioCheckedIcon'));
+
+    wrapper.setProps({ checked: true });
+
+    assert.isFalse(wrapper.exists('RadioIcon'));
+    assert.isTrue(wrapper.exists('RadioCheckedIcon'));
+  });
+});

--- a/src/components/input/test/Select-test.js
+++ b/src/components/input/test/Select-test.js
@@ -108,7 +108,7 @@ describe('Select', () => {
     const checkbox = wrapper
       .find(`[data-testid="option-${id}"]`)
       .closest('[role="option"]')
-      .find('[type="checkbox"]');
+      .find('input[type="checkbox"]');
 
     if (!checkbox.exists()) {
       throw new Error(
@@ -130,7 +130,7 @@ describe('Select', () => {
     const checkbox = wrapper
       .find(`[data-testid="option-${id}"]`)
       .closest('[role="option"]')
-      .find('[type="checkbox"]');
+      .find('input[type="checkbox"]');
 
     if (!checkbox.exists()) {
       throw new Error(
@@ -524,7 +524,7 @@ describe('Select', () => {
       const checkbox = wrapper
         .find(`[data-testid="option-${optionId}"]`)
         .closest('[role="option"]')
-        .find('[type="checkbox"]')
+        .find('input[type="checkbox"]')
         .getDOMNode();
       const focusStub = sinon.stub(checkbox, 'focus');
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,6 +52,7 @@ export {
   InputGroup,
   MultiSelect,
   OptionButton,
+  RadioButton,
   Select,
   Textarea,
 } from './components/input';
@@ -120,6 +121,7 @@ export type {
   InputGroupProps,
   MultiSelectProps,
   OptionButtonProps,
+  RadioButtonProps,
   SelectProps,
   TextareaProps,
 } from './components/input';

--- a/src/pattern-library/components/patterns/input/RadioButtonPage.tsx
+++ b/src/pattern-library/components/patterns/input/RadioButtonPage.tsx
@@ -1,0 +1,106 @@
+import Library from '../../Library';
+
+export default function RadioButtonPage() {
+  return (
+    <Library.Page
+      title="Radio button"
+      intro={
+        <p>
+          <code>RadioButton</code> is a composite component that includes a
+          radio input and label.
+        </p>
+      }
+    >
+      <Library.Pattern>
+        <Library.Usage componentName="RadioButton" />
+        <Library.Example>
+          <Library.Demo
+            title="Basic RadioButton"
+            withSource
+            exampleFile="radio-button-basic"
+          />
+        </Library.Example>
+      </Library.Pattern>
+
+      <Library.Pattern title="Working with RadioButtons">
+        <Library.Example title="Controlled RadioButton">
+          <p>
+            <code>RadioButton</code>s are always expected to be controlled,
+            because only one in a group should be checked at once.
+          </p>
+          <p>
+            Because of this, there should be a parent component handling the
+            state for all of them, as <code>RadioButton</code>s do not know
+            about each other.
+          </p>
+        </Library.Example>
+
+        <Library.Example title="Customizing RadioButton icons">
+          <p>
+            <code>RadioButton</code> uses icons to style the radio, in unchecked
+            and checked states. Custom icons may be provided if desired.
+          </p>
+          <Library.Demo
+            withSource
+            title="RadioButton with custom icon and checkedIcon"
+            exampleFile="radio-button-custom-icons"
+          />
+        </Library.Example>
+      </Library.Pattern>
+
+      <Library.Pattern title="Component API">
+        <code>RadioButton</code> accepts all standard{' '}
+        <Library.Link href="/using-components#presentational-components-api">
+          presentational component props
+        </Library.Link>
+        .
+        <Library.Example title="checked">
+          <Library.Info>
+            <Library.InfoItem label="description">
+              Set whether the <code>RadioButton</code> is checked. The presence
+              of this component indicates that the <code>RadioButton</code> is
+              being used as a controlled component.
+            </Library.InfoItem>
+            <Library.InfoItem label="type">
+              <code>{`boolean`}</code>
+            </Library.InfoItem>
+            <Library.InfoItem label="default">
+              <code>{`undefined`}</code>
+            </Library.InfoItem>
+          </Library.Info>
+        </Library.Example>
+        <Library.Example title="icon">
+          <Library.Info>
+            <Library.InfoItem label="description">
+              <code>IconComponent</code> to use as the (unchecked) radio icon
+            </Library.InfoItem>
+            <Library.InfoItem label="type">
+              <code>{`IconComponent`}</code>
+            </Library.InfoItem>
+          </Library.Info>
+        </Library.Example>
+        <Library.Example title="checkedIcon">
+          <Library.Info>
+            <Library.InfoItem label="description">
+              <code>IconComponent</code> to use as the (checked) radio icon
+            </Library.InfoItem>
+            <Library.InfoItem label="type">
+              <code>{`IconComponent`}</code>
+            </Library.InfoItem>
+          </Library.Info>
+        </Library.Example>
+        <Library.Example title="...htmlAttributes">
+          <Library.Info>
+            <Library.InfoItem label="description">
+              <code>RadioButton</code> accepts HTML attributes for input
+              elements
+            </Library.InfoItem>
+            <Library.InfoItem label="type">
+              <code>{`JSX.HTMLAttributes<HTMLInputElement>`}</code>
+            </Library.InfoItem>
+          </Library.Info>
+        </Library.Example>
+      </Library.Pattern>
+    </Library.Page>
+  );
+}

--- a/src/pattern-library/examples/radio-button-basic.tsx
+++ b/src/pattern-library/examples/radio-button-basic.tsx
@@ -1,0 +1,41 @@
+import { useCallback, useState } from 'preact/hooks';
+
+import { RadioButton } from '../..';
+
+export default function App() {
+  const [value, setSelected] = useState<'one' | 'two' | 'three'>();
+  const onChange = useCallback((e: Event) => {
+    setSelected(
+      (e.target as HTMLInputElement).value as 'one' | 'two' | 'three',
+    );
+  }, []);
+
+  return (
+    <form className=" flex flex-col">
+      <RadioButton
+        name="option"
+        value="one"
+        checked={value === 'one'}
+        onChange={onChange}
+      >
+        Click me
+      </RadioButton>
+      <RadioButton
+        name="option"
+        value="two"
+        checked={value === 'two'}
+        onChange={onChange}
+      >
+        No, click me
+      </RadioButton>
+      <RadioButton
+        name="option"
+        value="three"
+        checked={value === 'three'}
+        disabled
+      >
+        Disabled
+      </RadioButton>
+    </form>
+  );
+}

--- a/src/pattern-library/examples/radio-button-custom-icons.tsx
+++ b/src/pattern-library/examples/radio-button-custom-icons.tsx
@@ -1,0 +1,35 @@
+import { useCallback, useState } from 'preact/hooks';
+
+import { HideIcon, RadioButton, ShowIcon } from '../..';
+
+export default function App() {
+  const [value, setSelected] = useState<'first' | 'second'>('first');
+  const onChange = useCallback((e: Event) => {
+    setSelected((e.target as HTMLInputElement).value as 'first' | 'second');
+  }, []);
+
+  return (
+    <form className="w-64 m-auto flex flex-col">
+      <RadioButton
+        name="option"
+        icon={HideIcon}
+        checkedIcon={ShowIcon}
+        value="first"
+        checked={value === 'first'}
+        onChange={onChange}
+      >
+        First {value === 'first' && <i>(checked)</i>}
+      </RadioButton>
+      <RadioButton
+        name="option"
+        icon={HideIcon}
+        checkedIcon={ShowIcon}
+        value="second"
+        checked={value === 'second'}
+        onChange={onChange}
+      >
+        Second {value === 'second' && <i>(checked)</i>}
+      </RadioButton>
+    </form>
+  );
+}

--- a/src/pattern-library/routes.ts
+++ b/src/pattern-library/routes.ts
@@ -21,6 +21,7 @@ import CloseButtonPage from './components/patterns/input/CloseButtonPage';
 import InputGroupPage from './components/patterns/input/InputGroupPage';
 import InputPage from './components/patterns/input/InputPage';
 import OptionButtonPage from './components/patterns/input/OptionButtonPage';
+import RadioButtonPage from './components/patterns/input/RadioButtonPage';
 import TextareaPage from './components/patterns/input/TextareaPage';
 import CardPage from './components/patterns/layout/CardPage';
 import OverlayPage from './components/patterns/layout/OverlayPage';
@@ -194,6 +195,12 @@ const routes: PlaygroundRoute[] = [
     group: 'input',
     component: OptionButtonPage,
     route: '/input-option-button',
+  },
+  {
+    title: 'RadioButton',
+    group: 'input',
+    component: RadioButtonPage,
+    route: '/input-radio-button',
   },
   {
     title: 'Selects',


### PR DESCRIPTION
Add a `RadioButton` component that uses part of the functionality from `Checkbox`, by extracting it to a reusable `ToggleInput` component.

https://github.com/user-attachments/assets/5aece1cc-f04a-4d19-8d56-6748f3fbf1ae

As opposed to the `Checkbox` component, which can be uncontrolled by internally handling state if props are not provided, `RadioButton` is expected to be controlled, because it has to be unchecked if another radio button from the same group gets checked.

Since every individual radio button does not know about the others, the state needs to be collectively handled by a parent component, otherwise, the custom icon never changes.

For convenience, in a follow-up PR I will provide a `RadioButtonGroup` component which will style a group of options as radio buttons.