### PR TITLE
Allow a ref to be passed to Select.Option components

### DIFF
--- a/src/components/input/Select.tsx
+++ b/src/components/input/Select.tsx
@@ -1,5 +1,5 @@
 import classnames from 'classnames';
-import type { ComponentChildren, JSX, RefObject } from 'preact';
+import type { ComponentChildren, JSX, RefObject, Ref } from 'preact';
 import {
   useCallback,
   useContext,
@@ -46,6 +46,9 @@ export type SelectOptionProps<T> = {
     | ComponentChildren
     | ((status: SelectOptionStatus) => ComponentChildren);
   classes?: string | string[];
+
+  /** Ref associated with the option's container element */
+  elementRef?: Ref<HTMLElement | undefined>;
 };
 
 function optionChildren(
@@ -66,9 +69,10 @@ function SelectOption<T>({
   children,
   disabled = false,
   classes,
+  elementRef,
 }: SelectOptionProps<T>) {
   const checkboxRef = useRef<HTMLElement | null>(null);
-  const optionRef = useRef<HTMLLIElement | null>(null);
+  const optionRef = useSyncedRef(elementRef);
 
   const selectContext = useContext(SelectContext);
   if (!selectContext) {
@@ -175,7 +179,7 @@ function SelectOption<T>({
       aria-selected={selected}
       // This is intended to be focused with arrow keys
       tabIndex={-1}
-      ref={optionRef}
+      ref={downcastRef(optionRef)}
     >
       <div
         className={classnames(

--- a/src/pattern-library/components/patterns/prototype/SelectPage.tsx
+++ b/src/pattern-library/components/patterns/prototype/SelectPage.tsx
@@ -489,6 +489,36 @@ export default function SelectPage() {
               </div>
             </Library.Demo>
           </Library.Example>
+          <Library.Example title="classes">
+            <Library.Info>
+              <Library.InfoItem label="description">
+                CSS class(es) that will be appended to the CSS classes applied
+                to the options{"'"}s outermost element.
+              </Library.InfoItem>
+              <Library.InfoItem label="type">
+                <code>string | string[] | undefined</code>
+              </Library.InfoItem>
+              <Library.InfoItem label="default">
+                <code>undefined</code>
+              </Library.InfoItem>
+            </Library.Info>
+          </Library.Example>
+          <Library.Example title="elementRef">
+            <Library.Info>
+              <Library.InfoItem label="description">
+                A <code>Ref</code> applied to the option{"'"}s outermost
+                element.
+              </Library.InfoItem>
+              <Library.InfoItem label="type">
+                <code>
+                  MutableRef{'<'}HTMLElement | undefined{'>'} | undefined
+                </code>
+              </Library.InfoItem>
+              <Library.InfoItem label="default">
+                <code>undefined</code>
+              </Library.InfoItem>
+            </Library.Info>
+          </Library.Example>
         </Library.Pattern>
       </Library.Section>
 


### PR DESCRIPTION
This will allow options to be tracked from consuming code, for example, to programmatically focus one option.

The first use case we have for this is to be able to focus the last option of the listbox, before unmounting another element which is focused and would cause the listbox to close when focusing out.