### PR TITLE
Hide RadioButton documentation

### DIFF
--- a/src/components/input/RadioButton.tsx
+++ b/src/components/input/RadioButton.tsx
@@ -23,6 +23,11 @@ export type RadioButtonProps = CompositeProps &
  * Render a labeled radio input. The radio is styled with two icons: one for the
  * unchecked state and one for the checked state. The input itself is positioned
  * exactly on top of the icon, but is non-visible.
+ *
+ * Note:
+ * This component was created with the intention to make it the foundation for
+ * RadioGroup, but we finally found it easier to implement something from scratch.
+ * If we don't find a use case for this component, we'll remove it eventually.
  */
 export default function RadioButton({
   icon = RadioIcon,

--- a/src/pattern-library/routes.ts
+++ b/src/pattern-library/routes.ts
@@ -21,7 +21,6 @@ import CloseButtonPage from './components/patterns/input/CloseButtonPage';
 import InputGroupPage from './components/patterns/input/InputGroupPage';
 import InputPage from './components/patterns/input/InputPage';
 import OptionButtonPage from './components/patterns/input/OptionButtonPage';
-import RadioButtonPage from './components/patterns/input/RadioButtonPage';
 import RadioGroupPage from './components/patterns/input/RadioGroupPage';
 import TextareaPage from './components/patterns/input/TextareaPage';
 import CardPage from './components/patterns/layout/CardPage';
@@ -196,12 +195,6 @@ const routes: PlaygroundRoute[] = [
     group: 'input',
     component: OptionButtonPage,
     route: '/input-option-button',
-  },
-  {
-    title: 'RadioButton',
-    group: 'input',
-    component: RadioButtonPage,
-    route: '/input-radio-button',
   },
   {
     title: 'RadioGroup',


### PR DESCRIPTION
This PR removes `RadioButton` from the pattern library sidebar, effectively hiding its documentation.

This is to avoid confusion with the `RadioGroup` component, which has a similar purpose.

The `RadioButton` was initially created to serve as the foundation for `RadioGroup` items, but in the end we found it was easier to not use it and instead implement another component from scratch.

`RadioButton` could still be useful, but since we don't have a clear use case for it yet, it is harder to document when should be `RadioGroup` be chosen over `RadioButton` and viceversa.

We'll keep the component for now. If we end up using it we'll add the documentation entry point again. Otherwise, we'll eventually remove the component as well.