### PR TITLE
Expose RadioGroup and RadioGroupProps in package entry point

### DIFF
--- a/src/components/input/RadioGroup.tsx
+++ b/src/components/input/RadioGroup.tsx
@@ -74,7 +74,7 @@ function Radio<T extends RadioValue>({
 
 Radio.displayName = 'RadioGroup.Radio';
 
-export type RadioGroup<T extends RadioValue> = {
+export type RadioGroupProps<T extends RadioValue> = {
   children: ComponentChildren;
   selected?: T;
   onChange: (newSelected: T) => void;
@@ -105,7 +105,7 @@ function RadioGroupMain<T extends RadioValue>({
   'aria-label': label,
   'aria-labelledby': labelledBy,
   name,
-}: RadioGroup<T>) {
+}: RadioGroupProps<T>) {
   const containerRef = useRef<HTMLDivElement | null>(null);
 
   useArrowKeyNavigation(containerRef, {

--- a/src/components/input/index.ts
+++ b/src/components/input/index.ts
@@ -6,6 +6,7 @@ export { default as Input } from './Input';
 export { default as InputGroup } from './InputGroup';
 export { default as OptionButton } from './OptionButton';
 export { default as RadioButton } from './RadioButton';
+export { default as RadioGroup } from './RadioGroup';
 export { Select, MultiSelect } from './Select';
 export { default as Textarea } from './Textarea';
 
@@ -17,5 +18,6 @@ export type { InputProps } from './Input';
 export type { InputGroupProps } from './InputGroup';
 export type { OptionButtonProps } from './OptionButton';
 export type { RadioButtonProps } from './RadioButton';
+export type { RadioGroupProps } from './RadioGroup';
 export type { MultiSelectProps, SelectProps } from './Select';
 export type { TextareaProps } from './Textarea';

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,6 +53,7 @@ export {
   MultiSelect,
   OptionButton,
   RadioButton,
+  RadioGroup,
   Select,
   Textarea,
 } from './components/input';
@@ -122,6 +123,7 @@ export type {
   MultiSelectProps,
   OptionButtonProps,
   RadioButtonProps,
+  RadioGroupProps,
   SelectProps,
   TextareaProps,
 } from './components/input';


### PR DESCRIPTION
This solves an overlook from https://github.com/hypothesis/frontend-shared/pull/1683, where I forgot to expose the `RadioGroup` symbol the package's entry point to import via `import { RadioGroup } from '@hypothesis/frontend-shared'`.