### PR TITLE
Fix too low contrast in subtitles for selected RadioGroup.Radios

### DIFF
--- a/src/components/input/RadioGroup.tsx
+++ b/src/components/input/RadioGroup.tsx
@@ -41,12 +41,15 @@ function Radio<T extends RadioValue>({
       role="radio"
       aria-checked={isSelected}
       aria-disabled={disabled}
-      className={classnames('focus-visible-ring rounded-lg px-3 py-2 grow', {
-        'bg-grey-2': isSelected,
-        'hover:bg-grey-1': !isSelected && !disabled,
-        'opacity-70': disabled,
-        'cursor-pointer': !disabled,
-      })}
+      className={classnames(
+        'focus-visible-ring rounded-lg px-3 py-2 grow group',
+        {
+          'bg-grey-3/50': isSelected,
+          'hover:bg-grey-3/25': !isSelected && !disabled,
+          'opacity-70': disabled,
+          'cursor-pointer': !disabled,
+        },
+      )}
       data-value={value}
       onClick={!disabled ? () => onChange(value) : undefined}
       onKeyDown={
@@ -66,7 +69,14 @@ function Radio<T extends RadioValue>({
         {children}
       </div>
       {subtitle && (
-        <div className="pl-4 ml-1.5 mt-1 text-grey-6 text-sm">{subtitle}</div>
+        <div
+          className={classnames('pl-4 ml-1.5 mt-1 text-sm', {
+            'text-grey-7': isSelected,
+            'text-grey-6 group-hover:text-grey-7': !isSelected && !disabled,
+          })}
+        >
+          {subtitle}
+        </div>
       )}
     </div>
   );

--- a/src/components/input/test/RadioGroup-test.js
+++ b/src/components/input/test/RadioGroup-test.js
@@ -183,6 +183,19 @@ describe('RadioGroup', () => {
 
   it(
     'should pass a11y checks',
-    checkAccessibility({ content: createComponent }),
+    checkAccessibility([
+      {
+        name: 'no selected item',
+        content: createComponent,
+      },
+      {
+        name: 'selected item',
+        content: () => createComponent({ selected: 'one' }),
+      },
+      {
+        name: 'selected item with subtitle',
+        content: () => createComponent({ selected: 'four' }),
+      },
+    ]),
   );
 });


### PR DESCRIPTION
This PR fixes an accessibility issue in `RadioGroup` component, where the contrast between the text color used in subtitles and the background color used in selected radios, is too low.

In order to fix it, we now set a darker shade of grey in the subtitles when the radio is hovered or selected.

See before and after:

![image](https://github.com/user-attachments/assets/57c3c2f0-9761-4d23-9848-84aa2dc914e0)
![image](https://github.com/user-attachments/assets/4bf18d1d-e788-4fec-b000-d570f91aa4f0)

Additionally, selected and hover radio background color is now set with an opacity lower than 100%. This ensures there's always a different color for those, even if the container's background color is the same as the color used for selected radios.

See how they look when the container has the former background color:

Before:

https://github.com/user-attachments/assets/350f629f-4235-40bb-b0cd-5857af90eef4

After:

https://github.com/user-attachments/assets/820821d2-8c53-4a23-8e65-8585d31ac6a6