### PR TITLE
Make RadioGroup space be evenly split among all radios

### DIFF
--- a/src/components/input/RadioGroup.tsx
+++ b/src/components/input/RadioGroup.tsx
@@ -42,7 +42,7 @@ function Radio<T extends RadioValue>({
       aria-checked={isSelected}
       aria-disabled={disabled}
       className={classnames(
-        'focus-visible-ring rounded-lg px-3 py-2 grow group',
+        'focus-visible-ring rounded-lg px-3 py-2 flex-1 group',
         {
           'bg-grey-3/50': isSelected,
           'hover:bg-grey-3/25': !isSelected && !disabled,


### PR DESCRIPTION
While working on https://github.com/hypothesis/lms/pull/6632 I realized there was a small size difference between the radios of both radio groups there.

The difference is subtle, but noticeable.

https://github.com/user-attachments/assets/93b6a919-efa0-4372-a7fd-8b434ed4a272

This PR makes sure all radios take the same amount of available space, by using `flex-1` instead of `grow` in each one of them.

This is how it looks with the changes:

https://github.com/user-attachments/assets/4be887d8-4bc8-4c52-b0ea-685c43ae0213
