### PR TITLE
Prevent accidental miss-clicks outside multi-select checkboxes

### DIFF
--- a/src/components/input/Checkbox.tsx
+++ b/src/components/input/Checkbox.tsx
@@ -1,4 +1,4 @@
-import type { JSX } from 'preact';
+import type { JSX, Ref } from 'preact';
 import { useState } from 'preact/hooks';
 
 import type { CompositeProps, IconComponent } from '../../types';
@@ -20,6 +20,11 @@ type ComponentProps = {
   checkedIcon?: IconComponent;
   /** type is always `checkbox` */
   type?: never;
+
+  /** Optional extra CSS classes appended to the container's className */
+  containerClasses?: string | string[];
+  /** Ref associated with the component's container */
+  containerRef?: Ref<HTMLLabelElement | undefined>;
 };
 
 export type CheckboxProps = CompositeProps &

--- a/src/components/input/RadioButton.tsx
+++ b/src/components/input/RadioButton.tsx
@@ -1,4 +1,4 @@
-import type { JSX } from 'preact';
+import type { JSX, Ref } from 'preact';
 
 import type { CompositeProps, IconComponent } from '../../types';
 import { RadioCheckedIcon, RadioIcon } from '../icons';
@@ -13,6 +13,11 @@ type ComponentProps = {
   checkedIcon?: IconComponent;
   /** type is always `radio` */
   type?: never;
+
+  /** Optional extra CSS classes appended to the container's className */
+  containerClasses?: string | string[];
+  /** Ref associated with the component's container */
+  containerRef?: Ref<HTMLLabelElement | undefined>;
 };
 
 export type RadioButtonProps = CompositeProps &

--- a/src/components/input/ToggleInput.tsx
+++ b/src/components/input/ToggleInput.tsx
@@ -1,5 +1,5 @@
 import classnames from 'classnames';
-import type { JSX } from 'preact';
+import type { JSX, Ref } from 'preact';
 
 import type { CompositeProps, IconComponent } from '../../types';
 import { downcastRef } from '../../util/typing';
@@ -13,6 +13,11 @@ type ComponentProps = {
   checkedIcon: IconComponent;
 
   type: 'checkbox' | 'radio';
+
+  /** Optional extra CSS classes appended to the container's className */
+  containerClasses?: string | string[];
+  /** Ref associated with the component's container */
+  containerRef?: Ref<HTMLLabelElement | undefined>;
 };
 
 export type ToggleInputProps = CompositeProps &
@@ -27,6 +32,7 @@ export type ToggleInputProps = CompositeProps &
 export default function ToggleInput({
   children,
   elementRef,
+  containerRef,
 
   checked,
   icon: UncheckedIcon,
@@ -36,20 +42,26 @@ export default function ToggleInput({
   onChange,
   id,
   type,
+  containerClasses,
   ...htmlAttributes
 }: ToggleInputProps) {
   const Icon = checked ? CheckedIcon : UncheckedIcon;
 
   return (
     <label
-      className={classnames('relative flex items-center gap-x-1.5', {
-        'cursor-pointer': !disabled,
-        'opacity-70': disabled,
-      })}
+      className={classnames(
+        'relative flex items-center gap-x-1.5',
+        {
+          'cursor-pointer': !disabled,
+          'opacity-70': disabled,
+        },
+        containerClasses,
+      )}
       htmlFor={id}
       data-composite-component={
         type === 'checkbox' ? 'Checkbox' : 'RadioButton'
       }
+      ref={downcastRef(containerRef)}
     >
       <input
         {...htmlAttributes}


### PR DESCRIPTION
We have experienced (and more people has reported) that it is easy to miss-click outside a checkbox on a `MultiSelect` option. This is problematic, because clicking on a checkbox appends/removes the item to the selection, but clicking outside of it is captured as a click on the main option's body, causing the whole selection to be replaced with just that option.

https://github.com/user-attachments/assets/803908d5-56d5-4ec6-9d7b-ac4f24b3b15d

This PR changes that behavior, so that clicking on "the surroundings" of the checkbox behaves as clicking the checkbox itself.

"The surroundings" in this case means anywhere inside the right side of the option, matching the option's padding. That way the checkbox is always clicked if you click anywhere on the "right" of an option.

This shows how it behaves with these changes:

https://github.com/user-attachments/assets/9c085e7c-813c-431d-bd39-a99a1cf653fc

> [!NOTE]  
> This PR is easier to review [ignoring whitespaces](https://github.com/hypothesis/frontend-shared/pull/1700/files?w=1)

### Todo

- [x] Make checkbox slightly bigger. This was previously done via `scale-125`.