### PR TITLE
Do not export nextFuzzyUpdate from package root entry point

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,6 @@ export type {
 
 // Utils
 export {
-  nextFuzzyUpdate,
   decayingInterval,
   formatRelativeDate,
   formatDateTime,


### PR DESCRIPTION
The `nextFuzzyUpdate` function is only used internally by `date-and-time` functions, but none of the downstream projects use it directly, so this PR removes it from the root entry point re-exports.

It's still exported by the internal module, and tested individually. 