### PR TITLE
Prevent Select listbox to grow out of viewport

### DIFF
--- a/src/components/input/SelectContext.ts
+++ b/src/components/input/SelectContext.ts
@@ -1,5 +1,7 @@
 import { createContext } from 'preact';
 
+export type ListboxOverflow = 'truncate' | 'wrap';
+
 export type SelectValueOptions = {
   closeListbox: boolean;
 };
@@ -16,9 +18,12 @@ type MultiSelectContext<T> = {
   multiple: true;
 };
 
-export type SelectContextType<T = unknown> =
+export type SelectContextType<T = unknown> = (
   | SingleSelectContext<T>
-  | MultiSelectContext<T>;
+  | MultiSelectContext<T>
+) & {
+  listboxOverflow: ListboxOverflow;
+};
 
 const SelectContext = createContext<SelectContextType | null>(null);
 

--- a/src/pattern-library/components/patterns/prototype/SelectPage.tsx
+++ b/src/pattern-library/components/patterns/prototype/SelectPage.tsx
@@ -241,7 +241,14 @@ export default function SelectPage() {
 
             <Library.Demo title="Plain text">
               <div className="mx-auto">
-                <SelectExample textOnly buttonClasses="!w-36" />
+                <SelectExample
+                  textOnly
+                  buttonClasses="!w-36"
+                  items={defaultItems.map(({ name, ...rest }) => ({
+                    ...rest,
+                    name: `${name} (this item has very long text)`,
+                  }))}
+                />
               </div>
             </Library.Demo>
 

--- a/src/pattern-library/examples/select-right.tsx
+++ b/src/pattern-library/examples/select-right.tsx
@@ -3,11 +3,11 @@ import { useId, useState } from 'preact/hooks';
 import { Select } from '../..';
 
 const items = [
-  { id: '1', name: 'All students' },
-  { id: '2', name: 'Albert Banana' },
-  { id: '3', name: 'Bernard California' },
-  { id: '4', name: 'Cecelia Davenport' },
-  { id: '5', name: 'Doris Evanescence' },
+  { id: '1', name: 'All students (this item has very long text)' },
+  { id: '2', name: 'Albert Banana (this item has very long text)' },
+  { id: '3', name: 'Bernard California (this item has very long text)' },
+  { id: '4', name: 'Cecelia Davenport (this item has very long text)' },
+  { id: '5', name: 'Doris Evanescence (this item has very long text)' },
 ];
 
 type Item = (typeof items)[number];


### PR DESCRIPTION
> Part of https://github.com/hypothesis/product-backlog/issues/1561

This PR update the logic that calculates styles for the Select's listbox when it is displayed, so that it takes into consideration the body width when calculating its position.

When we detect the listbox would render outside of the viewport, we let it "grow" in the oposite direction instead, to prevent horizontal scrolling.

https://github.com/user-attachments/assets/c4be9221-1121-4449-8c2a-b7a105ab6b75

https://github.com/user-attachments/assets/cf2b80fb-3261-444a-b56d-d1cde5c98756

As a side effect, the listbox can now be smaller than its content in some circumstances. For that, we now provide a new prop to decide if the content should be truncated, or wrap multiple lines.

Truncate:

https://github.com/user-attachments/assets/10ac64d5-cd81-4cb2-a673-a9928c7587c2

Wrap: 

https://github.com/user-attachments/assets/164beaf7-3c92-4572-a772-a4893373860b

Additionally, when the options have a more complex content, consumers can decide how to deal with content overflow.

### TODO

- [x] Add tests.
- [x] Make sure `right` listboxes render properly.
- [ ] Dynamically add `title` to items that get cropped.
- [x] Consider using available space on the opposite side when possible.
- [ ] Document `listboxOverflow` prop.
- [ ] Document listbox behavior when content is big

EDIT The missing points there ☝🏼 will be addressed separately to easy reviews.