### PR TITLE
Add new `alignListbox` prop to `Select` to replace `right` one

### DIFF
--- a/src/components/input/Select.tsx
+++ b/src/components/input/Select.tsx
@@ -280,7 +280,7 @@ function useListboxPositioning(
   listboxRef: RefObject<HTMLElement | null>,
   listboxOpen: boolean,
   asPopover: boolean,
-  right: boolean,
+  alignListboxToRight: boolean,
 ) {
   const adjustListboxPositioning = useCallback(() => {
     const listboxEl = listboxRef.current;
@@ -343,17 +343,18 @@ function useListboxPositioning(
     // - right-aligned Selects: distance from right side of toggle button to
     //   left side of viewport
     const availableSpace =
-      (right ? buttonLeft + buttonWidth : bodyWidth - buttonLeft) -
-      LISTBOX_VIEWPORT_HORIZONTAL_GAP;
+      (alignListboxToRight
+        ? buttonLeft + buttonWidth
+        : bodyWidth - buttonLeft) - LISTBOX_VIEWPORT_HORIZONTAL_GAP;
 
     let left = buttonLeft;
     if (listboxWidth > availableSpace) {
       // If the listbox is not going to fit the available space, let it "grow"
       // in the opposite direction
-      left = right
+      left = alignListboxToRight
         ? LISTBOX_VIEWPORT_HORIZONTAL_GAP
         : left - (listboxWidth - availableSpace);
-    } else if (right && listboxWidth > buttonWidth) {
+    } else if (alignListboxToRight && listboxWidth > buttonWidth) {
       // If a right-aligned listbox fits the available space, but it's bigger
       // than the button, move it to the left so that it is aligned with the
       // right side of the button
@@ -367,7 +368,7 @@ function useListboxPositioning(
         : `calc(${absBodyTop + buttonDistanceToTop + buttonHeight}px + ${LISTBOX_TOGGLE_GAP})`,
       left: `${Math.max(LISTBOX_VIEWPORT_HORIZONTAL_GAP, left)}px`,
     });
-  }, [asPopover, buttonRef, listboxOpen, listboxRef, right]);
+  }, [asPopover, buttonRef, listboxOpen, listboxRef, alignListboxToRight]);
 
   useLayoutEffect(() => {
     const cleanup = adjustListboxPositioning();
@@ -417,13 +418,18 @@ type BaseSelectProps = CompositeProps & {
   /** Additional classes to pass to listbox */
   listboxClasses?: string | string[];
 
-  /**
-   * Align the listbox to the right.
-   * Useful when the listbox is bigger than the toggle button and this component
-   * is rendered next to the right side of the page/container.
-   * Defaults to false.
-   */
+  /** @deprecated Use `alignListbox="right"` instead */
   right?: boolean;
+
+  /**
+   * How to align the listbox relative to the toggle button.
+   *
+   * Useful when rendering a Select with a big listbox, close to the right side
+   * of the viewport. In that case it looks nicer if the listbox aligns with the
+   * right side of the toggle button and extends to the left.
+   * Defaults to 'left'.
+   */
+  alignListbox?: 'left' | 'right';
 
   'aria-label'?: string;
   'aria-labelledby'?: string;
@@ -478,6 +484,7 @@ function SelectMain<T>({
   containerClasses,
   onListboxScroll,
   right = false,
+  alignListbox = right ? 'right' : 'left',
   multiple,
   listboxOverflow = 'truncate',
   'aria-label': ariaLabel,
@@ -507,7 +514,7 @@ function SelectMain<T>({
     listboxRef,
     listboxOpen,
     listboxAsPopover,
-    right,
+    alignListbox === 'right',
   );
 
   const selectValue = useCallback(
@@ -610,7 +617,7 @@ function SelectMain<T>({
               // * Ensure screen readers detect button as a listbox handler
               // * Listbox size can be computed to correctly drop up or down
               hidden: !listboxOpen,
-              'right-0': right,
+              'right-0': alignListbox === 'right',
               'min-w-full': true,
             },
             listboxClasses,

--- a/src/components/input/test/Select-test.js
+++ b/src/components/input/test/Select-test.js
@@ -415,10 +415,10 @@ describe('Select', () => {
           getListbox(wrapper).getDOMNode().getBoundingClientRect().left,
       },
     ].forEach(({ listboxAsPopover, getListboxLeft }) => {
-      it('aligns listbox to the right if `right` prop is true', async () => {
+      it('aligns listbox to the right if `alignListbox="right"` is provided', async () => {
         const wrapper = createComponent({
           listboxAsPopover,
-          right: true,
+          alignListbox: 'right',
           buttonClasses: '!w-8', // Set a small width in the button
         });
         toggleListbox(wrapper);
@@ -464,9 +464,9 @@ describe('Select', () => {
     [
       // Content is small. The listbox matches the toggle button size regardless
       // the orientation.
-      ...[true, false].map(right => ({
+      ...['right', 'left'].map(alignListbox => ({
         name: 'short name',
-        right,
+        alignListbox,
         getExpectedCoordinates: (wrapper, listboxDOMNode) => {
           const buttonDOMNode = getToggleButton(wrapper).getDOMNode();
           const buttonLeft = buttonDOMNode.getBoundingClientRect().left;
@@ -482,7 +482,7 @@ describe('Select', () => {
       // sides but spans further to the opposite one
       {
         name: 'slightly longer name'.repeat(3),
-        right: false,
+        alignListbox: 'left',
         getExpectedCoordinates: (wrapper, listboxDOMNode) => {
           const buttonDOMNode = getToggleButton(wrapper).getDOMNode();
           const buttonRect = buttonDOMNode.getBoundingClientRect();
@@ -497,7 +497,7 @@ describe('Select', () => {
       },
       {
         name: 'slightly longer name'.repeat(3),
-        right: true,
+        alignListbox: 'right',
         getExpectedCoordinates: (wrapper, listboxDOMNode) => {
           const buttonDOMNode = getToggleButton(wrapper).getDOMNode();
           const buttonRect = buttonDOMNode.getBoundingClientRect();
@@ -515,7 +515,7 @@ describe('Select', () => {
       // further than the opposite side of the toggle button
       {
         name: 'very long name'.repeat(6),
-        right: false,
+        alignListbox: 'left',
         getExpectedCoordinates: (wrapper, listboxDOMNode) => {
           const listboxRect = listboxDOMNode.getBoundingClientRect();
           const bodyWidth = document.body.getBoundingClientRect().width;
@@ -529,7 +529,7 @@ describe('Select', () => {
       },
       {
         name: 'very long name'.repeat(6),
-        right: true,
+        alignListbox: 'right',
         getExpectedCoordinates: (wrapper, listboxDOMNode) => {
           const listboxRect = listboxDOMNode.getBoundingClientRect();
           return {
@@ -538,10 +538,10 @@ describe('Select', () => {
           };
         },
       },
-    ].forEach(({ name, right, getExpectedCoordinates }) => {
+    ].forEach(({ name, alignListbox, getExpectedCoordinates }) => {
       it('displays listbox in expected coordinates', async () => {
         const wrapper = createComponent(
-          { right, buttonContent: 'Select a value' },
+          { alignListbox, buttonContent: 'Select a value' },
           {
             items: ['1', '2', '3'].map(id => ({ id, name })),
           },

--- a/src/pattern-library/components/patterns/prototype/SelectPage.tsx
+++ b/src/pattern-library/components/patterns/prototype/SelectPage.tsx
@@ -332,21 +332,21 @@ export default function SelectPage() {
               withSource
             />
           </Library.Example>
-          <Library.Example title="right">
+          <Library.Example title="alignListbox">
             <Library.Info>
               <Library.InfoItem label="description">
-                Whether the listbox should be aligned to the right when it grows
-                bigger than the toggle button.
+                Whether the listbox should be aligned to the right or left side
+                of the toggle button.
               </Library.InfoItem>
               <Library.InfoItem label="type">
-                <code>boolean</code>
+                <code>{"'left' | 'right'"}</code>
               </Library.InfoItem>
               <Library.InfoItem label="default">
-                <code>false</code>
+                <code>{"'left'"}</code>
               </Library.InfoItem>
             </Library.Info>
             <Library.Demo
-              title="Right listbox"
+              title="Right-aligned listbox"
               exampleFile="select-right"
               withSource
             />

--- a/src/pattern-library/examples/select-right.tsx
+++ b/src/pattern-library/examples/select-right.tsx
@@ -29,7 +29,7 @@ export default function App() {
     <div className="mx-auto">
       <label htmlFor={selectId}>Select a person</label>
       <Select
-        right
+        alignListbox="right"
         value={value}
         onChange={setSelected}
         buttonId={selectId}


### PR DESCRIPTION
This PR deprecates the `right: true | false` prop in Selects, and replaces it with `alignListbox: 'left' | 'right'`.

The behavior does not change, but the new one is easier to understand and reason about.

The `right` is not removed for backwards compatibility. If it is provided and `alignListbox` is not, the behavior will be the same as providing `alignListbox: 'right'`.