### PR TITLE
Export useSelectContext for downstream projects to use

### DIFF
--- a/src/components/input/Select.tsx
+++ b/src/components/input/Select.tsx
@@ -2,7 +2,6 @@ import classnames from 'classnames';
 import type { ComponentChildren, JSX, RefObject, Ref } from 'preact';
 import {
   useCallback,
-  useContext,
   useId,
   useLayoutEffect,
   useMemo,
@@ -27,6 +26,7 @@ import {
 import Checkbox from './Checkbox';
 import { inputGroupStyles } from './InputGroup';
 import type { ListboxOverflow, SelectValueOptions } from './SelectContext';
+import { useSelectContext } from './SelectContext';
 import SelectContext from './SelectContext';
 
 export type SelectOptionStatus = {
@@ -81,7 +81,7 @@ function SelectOption<T>({
     e.target === checkboxRef.current ||
     e.target === checkboxContainerRef.current;
 
-  const selectContext = useContext(SelectContext);
+  const selectContext = useSelectContext();
   if (!selectContext) {
     throw new Error(
       'Select.Option can only be used as Select or MultiSelect child',
@@ -607,6 +607,7 @@ function SelectMain<T>({
           selectValue,
           multiple,
           listboxOverflow,
+          listboxOpen,
         }}
       >
         <ul

--- a/src/components/input/SelectContext.ts
+++ b/src/components/input/SelectContext.ts
@@ -1,4 +1,5 @@
 import { createContext } from 'preact';
+import { useContext } from 'preact/hooks';
 
 export type ListboxOverflow = 'truncate' | 'wrap';
 
@@ -23,8 +24,16 @@ export type SelectContextType<T = unknown> = (
   | MultiSelectContext<T>
 ) & {
   listboxOverflow: ListboxOverflow;
+  listboxOpen: boolean;
 };
 
 const SelectContext = createContext<SelectContextType | null>(null);
 
 export default SelectContext;
+
+/**
+ * Returns the context of the closest `Select` or `MultiSelect`, if any.
+ */
+export function useSelectContext(): SelectContextType | null {
+  return useContext(SelectContext);
+}

--- a/src/components/input/index.ts
+++ b/src/components/input/index.ts
@@ -10,6 +10,8 @@ export { default as RadioGroup } from './RadioGroup';
 export { Select, MultiSelect } from './Select';
 export { default as Textarea } from './Textarea';
 
+export { useSelectContext } from './SelectContext';
+
 export type { ButtonProps } from './Button';
 export type { CheckboxProps } from './Checkbox';
 export type { CloseButtonProps } from './CloseButton';

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,6 +61,7 @@ export {
   RadioGroup,
   Select,
   Textarea,
+  useSelectContext,
 } from './components/input';
 export {
   Card,

--- a/src/pattern-library/components/patterns/prototype/SelectPage.tsx
+++ b/src/pattern-library/components/patterns/prototype/SelectPage.tsx
@@ -600,6 +600,29 @@ export default function SelectPage() {
           </Library.Example>
         </Library.Pattern>
       </Library.Section>
+
+      <Library.Section
+        title="useSelectContext"
+        intro={
+          <p>
+            <code>useSelectContext()</code> is hook that can be used in custom{' '}
+            <code>Option</code> wrappers to know the state of the closest{' '}
+            <code>Select</code> or <code>MultiSelect</code>.
+          </p>
+        }
+      >
+        <Library.Pattern>
+          <Library.Usage symbolName="useSelectContext" />
+
+          <Library.Example>
+            <Library.Demo
+              title="useSelectContext usage"
+              exampleFile="select-use-select-context"
+              withSource
+            />
+          </Library.Example>
+        </Library.Pattern>
+      </Library.Section>
     </Library.Page>
   );
 }

--- a/src/pattern-library/examples/select-use-select-context.tsx
+++ b/src/pattern-library/examples/select-use-select-context.tsx
@@ -1,0 +1,31 @@
+import { useEffect } from 'preact/hooks';
+
+import { Select, useSelectContext } from '../../components/input';
+
+function CustomOption({ value }: { value: number }) {
+  const selectContext = useSelectContext();
+
+  useEffect(() => {
+    if (selectContext?.listboxOpen) {
+      // Expensive logic...
+    }
+  }, [selectContext?.listboxOpen]);
+
+  return <Select.Option value={value}>{value}</Select.Option>;
+}
+
+export default function App() {
+  return (
+    <div className="w-96">
+      <Select
+        value={undefined}
+        onChange={() => {}}
+        buttonContent="Select a value..."
+      >
+        <CustomOption value={1} />
+        <CustomOption value={2} />
+        <CustomOption value={3} />
+      </Select>
+    </div>
+  );
+}


### PR DESCRIPTION
This PR adds a new `useSelectContext()` hook, which is an alias for `useContext(SelectContext)`.

This hook is exposed from this library's entry point, and can be used by consumers which define their own custom `Select.Option` wrappers and want to dynamically react to the select status.

Additionally, the context now exposes a `listboxOpen` flag, which is `true` while the listbox is opened. This can be used to add behavior that is relevant only while the listbox is open, like event listeners or observers.

![image](https://github.com/user-attachments/assets/a772542b-3dbc-4819-8d02-ac8d9cf691b1)

A good use case for this hook is the logic added in https://github.com/hypothesis/lms/pull/6812, where the options sizes are computed to dynamically add a `title` attribute if they are truncated.

### TODO

- [x] Reference hook in documentation