### PR TITLE
Make Select button main content grow

### DIFF
--- a/src/components/input/Select.tsx
+++ b/src/components/input/Select.tsx
@@ -561,6 +561,8 @@ function SelectMain<T>({
           'focus-visible-ring transition-colors whitespace-nowrap',
           'w-full flex items-center justify-between gap-x-2 p-2',
           'bg-grey-0 disabled:bg-grey-1 disabled:text-grey-6',
+          // Buttons are center-aligned by default. Overwrite it.
+          'text-left',
           // Add inherited rounded corners so that the toggle is consistent with
           // the wrapper, which is the element rendering borders.
           // Using overflow-hidden in the parent is not an option here, because
@@ -586,7 +588,7 @@ function SelectMain<T>({
         }}
         data-testid="select-toggle-button"
       >
-        <div className="truncate">{buttonContent}</div>
+        <div className="truncate grow">{buttonContent}</div>
         <div className="text-grey-6">
           {listboxOpen ? <MenuCollapseIcon /> : <MenuExpandIcon />}
         </div>


### PR DESCRIPTION
This PR makes the content provided as `buttonContent` to a `Select` or `MultiSelect` component take all space available expect for the chevron.

This allows to pass a flex container to `buttonContent` and allow to place items at the end, right before the chevron icon.

Before:

https://github.com/user-attachments/assets/be399d66-bf06-4151-ad82-a2843903cece

After:

https://github.com/user-attachments/assets/6157129e-86f2-4749-935d-95dc9931ace2

The first use case for this is displaying a badge with the amount of items in the listbox, in the LMS dashboard filters.

Without this, we can only display the badge right after the text, and this would allow to "push" this badge to the end, right before the chevron.

It may be possible to work around this limitation applying other CSS properties in consuming code, but I haven't found one which works consistently and doesn't feel a bit hackier than this.