### PR TITLE
Make sure selected option is focused when listbox is opened

### DIFF
--- a/src/components/input/Select.tsx
+++ b/src/components/input/Select.tsx
@@ -187,8 +187,9 @@ function SelectOption<T>({
       role="option"
       aria-disabled={disabled}
       aria-selected={selected}
-      // This is intended to be focused with arrow keys
-      tabIndex={-1}
+      // Set tabIndex to 0 for selected option, so that useArrowKeyNavigation
+      // initially focuses it
+      tabIndex={selected ? 0 : -1}
       ref={downcastRef(optionRef)}
       title={title}
     >

--- a/src/components/input/test/Select-test.js
+++ b/src/components/input/test/Select-test.js
@@ -118,18 +118,18 @@ describe('Select', () => {
     return listboxTop < buttonTop;
   };
 
+  const getOption = (wrapper, id) =>
+    wrapper.find(`[data-testid="option-${id}"]`).closest('[role="option"]');
+
   const clickOption = (wrapper, id) => {
     openListbox(wrapper);
-    wrapper.find(`[data-testid="option-${id}"]`).simulate('click');
+    getOption(wrapper, id).simulate('click');
   };
 
   function clickOptionCheckbox(wrapper, id) {
     openListbox(wrapper);
 
-    const checkbox = wrapper
-      .find(`[data-testid="option-${id}"]`)
-      .closest('[role="option"]')
-      .find('input[type="checkbox"]');
+    const checkbox = getOption(wrapper, id).find('input[type="checkbox"]');
 
     if (!checkbox.exists()) {
       throw new Error(
@@ -143,9 +143,7 @@ describe('Select', () => {
   const pressKeyInOption = (wrapper, id, key) => {
     openListbox(wrapper);
 
-    wrapper
-      .find(`[data-testid="option-${id}"]`)
-      .closest('[role="option"]')
+    getOption(wrapper, id)
       .getDOMNode()
       .dispatchEvent(new KeyboardEvent('keydown', { key }));
   };
@@ -153,10 +151,7 @@ describe('Select', () => {
   function pressKeyInOptionCheckbox(wrapper, id, key) {
     openListbox(wrapper);
 
-    const checkbox = wrapper
-      .find(`[data-testid="option-${id}"]`)
-      .closest('[role="option"]')
-      .find('input[type="checkbox"]');
+    const checkbox = getOption(wrapper, id).find('input[type="checkbox"]');
 
     if (!checkbox.exists()) {
       throw new Error(
@@ -320,11 +315,7 @@ describe('Select', () => {
     toggleListbox(wrapper);
 
     // Focus listbox option before closing listbox
-    wrapper
-      .find('[data-testid="option-3"]')
-      .getDOMNode()
-      .closest('[role="option"]')
-      .focus();
+    getOption(wrapper, '3').getDOMNode().focus();
 
     toggleListbox(wrapper);
     wrapper.update();
@@ -389,6 +380,19 @@ describe('Select', () => {
 
       assert.equal(listboxDidDropUp(wrapper), shouldDropUp);
     });
+  });
+
+  it('sets tabIndex=0 for the selected option', () => {
+    const wrapper = createComponent({ value: defaultItems[2] });
+    const getTabIndex = id => getOption(wrapper, id).prop('tabIndex');
+
+    openListbox(wrapper);
+
+    assert.equal(getTabIndex(1), -1);
+    assert.equal(getTabIndex(2), -1);
+    assert.equal(getTabIndex(3), 0);
+    assert.equal(getTabIndex(4), -1);
+    assert.equal(getTabIndex(5), -1);
   });
 
   context('when Option is rendered outside of Select', () => {
@@ -698,9 +702,7 @@ describe('Select', () => {
       openListbox(wrapper);
 
       // Spy on checkbox focus
-      const checkbox = wrapper
-        .find(`[data-testid="option-${optionId}"]`)
-        .closest('[role="option"]')
+      const checkbox = getOption(wrapper, optionId)
         .find('input[type="checkbox"]')
         .getDOMNode();
       const focusStub = sinon.stub(checkbox, 'focus');
@@ -717,10 +719,7 @@ describe('Select', () => {
       );
       openListbox(wrapper);
 
-      const option = wrapper
-        .find(`[data-testid="option-${optionId}"]`)
-        .closest('[role="option"]')
-        .getDOMNode();
+      const option = getOption(wrapper, optionId).getDOMNode();
       const focusStub = sinon.stub(option, 'focus');
 
       pressKeyInOptionCheckbox(wrapper, optionId, 'ArrowLeft');


### PR DESCRIPTION
This PR fixes an unintended regression introduced by making [options render only when the listbox is open](https://github.com/hypothesis/frontend-shared/pull/1762).

We now make sure the `tabIndex` is `0` for the selected option, which will make [`useArrowKeyNavigation` focus it the first time](https://github.com/hypothesis/frontend-shared/blob/986c9d5a7fdc1a269e1a4bcf26ba283f7c2d2bb6/src/hooks/use-arrow-key-navigation.ts#L162).

This worked before because the options were kept in the DOM, preserving their previously set `tabIndex`, but now we render them "from scratch" every time it is opened.

Before:

https://github.com/user-attachments/assets/0dc715e7-1064-4fbd-8423-b1fa31da0ccd

After:

https://github.com/user-attachments/assets/ee45dfcc-19e9-460e-b3d6-63f78f1d7896

### Testing steps

1. Check out this branch.
2. Go to http://localhost:4001/input-select
3. Using the keyboard, focus the first Select, then click <kbd>ArrowDown</kbd> to open the listbox. The first option should be focused.
4. Using arrows, move the focus to a different option, and select it by pressing <kbd>Enter</kbd>. The focus will return to the button.
5. Press <kbd>ArrowDown</kbd> again to open the listbox. The focused option should be the selected one.

If you follow these steps in `main` branch, you'll notice the first option is always focused when the listbox is opened, regardless of which one is selected.