### PR TITLE
Move Select's toggle button padding to its children elements

### DIFF
--- a/src/components/input/Select.tsx
+++ b/src/components/input/Select.tsx
@@ -560,7 +560,7 @@ function SelectMain<T>({
         id={buttonId ?? defaultButtonId}
         className={classnames(
           'focus-visible-ring transition-colors whitespace-nowrap',
-          'w-full flex items-center justify-between gap-x-2 p-2',
+          'w-full flex items-center justify-between gap-x-2',
           'bg-grey-0 disabled:bg-grey-1 disabled:text-grey-6',
           // Buttons are center-aligned by default. Overwrite it.
           'text-left',
@@ -589,8 +589,8 @@ function SelectMain<T>({
         }}
         data-testid="select-toggle-button"
       >
-        <div className="truncate grow">{buttonContent}</div>
-        <div className="text-grey-6">
+        <div className="pl-2 py-2 truncate grow">{buttonContent}</div>
+        <div className="pr-2 py-2 text-grey-6">
           {listboxOpen ? <MenuCollapseIcon /> : <MenuExpandIcon />}
         </div>
       </button>


### PR DESCRIPTION
This PR changes how padding is handled in the `Select`'s toggle button, so that instead of having a surrounding padding in the button itself, we replace it with the corresponding padding to its two children.

This is important because the first children truncates its content via tailwind's `truncate`. This class, among other things, adds `overflow: hidden`, but we want to allow content to overflow as long as it doesn't grow outside of the button limits.

Before:

https://github.com/user-attachments/assets/3130234d-31fd-4052-a296-26613e620d15

After:

https://github.com/user-attachments/assets/ee57a952-be51-4e0f-aecd-86766761b2af

Visually, there should be no changes, but the element with the `truncate` class now spans to the button limits, making its behavior more intuitive.

> [!NOTE]
> The motivation for this change is described in this thread https://github.com/hypothesis/lms/pull/6820#discussion_r1839884418