### PR TITLE
Create new Popover component

### DIFF
--- a/src/components/feedback/Popover.tsx
+++ b/src/components/feedback/Popover.tsx
@@ -1,0 +1,261 @@
+import classnames from 'classnames';
+import type { ComponentChildren, RefObject } from 'preact';
+import { useCallback, useLayoutEffect, useRef } from 'preact/hooks';
+
+import { ListenerCollection } from '../../util/listener-collection';
+
+/** Small space to apply between the anchor element and the popover */
+const POPOVER_ANCHOR_EL_GAP = '.15rem';
+
+/**
+ * Space in pixels to apply between the popover and the viewport sides to
+ * prevent it from growing to the very edges.
+ */
+export const POPOVER_VIEWPORT_HORIZONTAL_GAP = 8;
+
+type PopoverCSSProps =
+  | 'top'
+  | 'left'
+  | 'minWidth'
+  | 'marginBottom'
+  | 'bottom'
+  | 'marginTop';
+
+/**
+ * Manages the popover position manually to make sure it renders "next" to the
+ * anchor element (above or below). This is mainly needed when using the
+ * popover API, as that makes it render in the top layer, making it impossible
+ * to position it relative to the anchor element via regular CSS.
+ *
+ * @param asNativePopover - Native popover API is used to toggle the popover
+ * @param alignToRight - Whether the popover should be aligned to the right side
+ *                       of the anchor element or not
+ */
+function usePopoverPositioning(
+  anchorElementRef: RefObject<HTMLElement | undefined>,
+  popoverRef: RefObject<HTMLElement | undefined>,
+  popoverOpen: boolean,
+  asNativePopover: boolean,
+  alignToRight: boolean,
+) {
+  const adjustPopoverPositioning = useCallback(() => {
+    const popoverEl = popoverRef.current!;
+    const anchorEl = anchorElementRef.current!;
+
+    /**
+     * Set the positioning styles synchronously (not via <div style={computedStyles} />),
+     * to make sure positioning happens before other side effects.
+     * @return - A callback that undoes the property assignments
+     */
+    const setPopoverCSSProps = (
+      props: Partial<Record<PopoverCSSProps, string>>,
+    ) => {
+      Object.assign(popoverEl.style, props);
+      const keys = Object.keys(props) as PopoverCSSProps[];
+      return () => keys.map(prop => (popoverEl.style[prop] = ''));
+    };
+
+    const viewportHeight = window.innerHeight;
+    const {
+      top: anchorElDistanceToTop,
+      bottom: anchorElBottom,
+      left: anchorElLeft,
+      height: anchorElHeight,
+      width: anchorElWidth,
+    } = anchorEl.getBoundingClientRect();
+    const anchorElDistanceToBottom = viewportHeight - anchorElBottom;
+    const { height: popoverHeight, width: popoverWidth } =
+      popoverEl.getBoundingClientRect();
+
+    // The popover should render above only if there's not enough space below to
+    // fit it and there's more absolute space above than below
+    const shouldBeAbove =
+      anchorElDistanceToBottom < popoverHeight &&
+      anchorElDistanceToTop > anchorElDistanceToBottom;
+
+    if (!asNativePopover) {
+      // Set styles for non-popover mode
+      if (shouldBeAbove) {
+        return setPopoverCSSProps({
+          bottom: '100%',
+          marginBottom: POPOVER_ANCHOR_EL_GAP,
+        });
+      }
+
+      return setPopoverCSSProps({
+        top: '100%',
+        marginTop: POPOVER_ANCHOR_EL_GAP,
+      });
+    }
+
+    const { top: bodyTop, width: bodyWidth } =
+      document.body.getBoundingClientRect();
+    const absBodyTop = Math.abs(bodyTop);
+
+    // The available space is:
+    // - left-aligned popovers: distance from left side of anchor element to
+    //   right side of viewport
+    // - right-aligned popovers: distance from right side of anchor element to
+    //   left side of viewport
+    const availableSpace =
+      (alignToRight ? anchorElLeft + anchorElWidth : bodyWidth - anchorElLeft) -
+      POPOVER_VIEWPORT_HORIZONTAL_GAP;
+
+    let left = anchorElLeft;
+    if (popoverWidth > availableSpace) {
+      // If the popover is not going to fit the available space, let it "grow"
+      // in the opposite direction
+      left = alignToRight
+        ? POPOVER_VIEWPORT_HORIZONTAL_GAP
+        : left - (popoverWidth - availableSpace);
+    } else if (alignToRight && popoverWidth > anchorElWidth) {
+      // If a right-aligned popover fits the available space, but it's bigger
+      // than the anchor element, move it to the left so that it is aligned with
+      // the right side of the element
+      left -= popoverWidth - anchorElWidth;
+    }
+
+    return setPopoverCSSProps({
+      minWidth: `${anchorElWidth}px`,
+      top: shouldBeAbove
+        ? `calc(${absBodyTop + anchorElDistanceToTop - popoverHeight}px - ${POPOVER_ANCHOR_EL_GAP})`
+        : `calc(${absBodyTop + anchorElDistanceToTop + anchorElHeight}px + ${POPOVER_ANCHOR_EL_GAP})`,
+      left: `${Math.max(POPOVER_VIEWPORT_HORIZONTAL_GAP, left)}px`,
+    });
+  }, [asNativePopover, anchorElementRef, popoverRef, alignToRight]);
+
+  useLayoutEffect(() => {
+    if (!popoverOpen) {
+      return () => {};
+    }
+
+    // First of all, open popover if it's using the native API, otherwise its
+    // size is 0x0 and positioning calculations won't work.
+    const popover = popoverRef.current;
+    if (asNativePopover) {
+      popover?.togglePopover(true);
+    }
+
+    const cleanup = adjustPopoverPositioning();
+
+    if (!asNativePopover) {
+      return cleanup;
+    }
+
+    // Readjust popover position when any element scrolls, just in case that
+    // affected the anchor element position.
+    const listeners = new ListenerCollection();
+    listeners.add(document.body, 'scroll', adjustPopoverPositioning, {
+      capture: true,
+    });
+
+    return () => {
+      if (asNativePopover) {
+        popover?.togglePopover(false);
+      }
+      cleanup();
+      listeners.removeAll();
+    };
+  }, [adjustPopoverPositioning, asNativePopover, popoverOpen, popoverRef]);
+}
+
+export type PopoverProps = {
+  children?: ComponentChildren;
+  classes?: string | string[];
+  variant?: 'panel' | 'custom';
+
+  /** Whether the popover is currently open or not. Defaults to false */
+  open: boolean;
+  /** The element relative to which the popover should be positioned */
+  anchorElementRef: RefObject<HTMLElement | undefined>;
+
+  /**
+   * Determines to what side of the anchor element should the popover be
+   * aligned.
+   *
+   * Defaults to `left`
+   */
+  align?: 'right' | 'left';
+
+  /**
+   * Determines if focus should be restored when the popover is closed.
+   * Defaults to true.
+   */
+  restoreFocusOnClose?: boolean;
+
+  /**
+   * Used to determine if the popover API should be used.
+   * Defaults to true, as long as the browser supports it.
+   */
+  asNativePopover?: boolean;
+};
+
+export default function Popover({
+  anchorElementRef,
+  children,
+  open,
+  align = 'left',
+  classes,
+  variant = 'panel',
+  restoreFocusOnClose = true,
+  /* eslint-disable-next-line no-prototype-builtins */
+  asNativePopover = HTMLElement.prototype.hasOwnProperty('popover'),
+}: PopoverProps) {
+  const popoverRef = useRef<HTMLDivElement | null>(null);
+
+  usePopoverPositioning(
+    anchorElementRef,
+    popoverRef,
+    open,
+    asNativePopover,
+    align === 'right',
+  );
+
+  useLayoutEffect(() => {
+    const restoreFocusTo = open
+      ? (document.activeElement as HTMLElement)
+      : null;
+
+    return () => {
+      if (restoreFocusOnClose && restoreFocusTo) {
+        restoreFocusTo.focus();
+      }
+    };
+  }, [open, restoreFocusOnClose]);
+
+  return (
+    <div
+      className={classnames(
+        'absolute z-5',
+        variant === 'panel' && [
+          'max-h-80 overflow-y-auto overflow-x-hidden',
+          'rounded border bg-white shadow hover:shadow-md focus-within:shadow-md',
+        ],
+        asNativePopover && [
+          // We don't want the popover to ever render outside the viewport,
+          // and we give it a 16px gap
+          'max-w-[calc(100%-16px)]',
+          // Overwrite [popover] default styles
+          'p-0 m-0',
+        ],
+        !asNativePopover && {
+          // Hiding instead of unmounting so that popover size can be computed
+          // to position it above or below
+          hidden: !open,
+          'right-0': align === 'right',
+          'min-w-full': true,
+        },
+        classes,
+      )}
+      ref={popoverRef}
+      // nb. Use `undefined` rather than `false` because Preact doesn't
+      // handle boolean values correctly for this attribute (it will set
+      // `popover="false"` instead of removing the attribute).
+      popover={asNativePopover ? 'auto' : undefined}
+      data-testid="popover"
+      data-component="Popover"
+    >
+      {children}
+    </div>
+  );
+}

--- a/src/components/feedback/index.ts
+++ b/src/components/feedback/index.ts
@@ -1,6 +1,7 @@
 export { default as Callout } from './Callout';
 export { default as Dialog } from './Dialog';
 export { default as ModalDialog } from './ModalDialog';
+export { default as Popover } from './Popover';
 export { default as Spinner } from './Spinner';
 export { default as SpinnerOverlay } from './SpinnerOverlay';
 export { default as ToastMessages } from './ToastMessages';

--- a/src/components/feedback/test/Popover-test.js
+++ b/src/components/feedback/test/Popover-test.js
@@ -1,0 +1,320 @@
+import { mount } from 'enzyme';
+import { useRef, useState } from 'preact/hooks';
+
+import Popover, { POPOVER_VIEWPORT_HORIZONTAL_GAP } from '../Popover';
+
+function TestComponent({ children, ...rest }) {
+  const buttonRef = useRef(null);
+  const [open, setOpen] = useState(false);
+
+  return (
+    <div className="relative">
+      <button
+        data-testid="toggle-button"
+        className="p-2"
+        ref={buttonRef}
+        onClick={() => setOpen(prev => !prev)}
+      >
+        Anchor element
+      </button>
+      <Popover open={open} anchorElementRef={buttonRef} {...rest}>
+        {open &&
+          (children ?? (
+            <>
+              Content of popover
+              <button
+                data-testid="inner-button"
+                onClick={() => setOpen(prev => !prev)}
+              >
+                Focusable element inside popover
+              </button>
+            </>
+          ))}
+      </Popover>
+    </div>
+  );
+}
+
+describe('Popover', () => {
+  let wrappers;
+  let containers;
+
+  beforeEach(() => {
+    wrappers = [];
+    containers = [];
+  });
+
+  afterEach(() => {
+    wrappers.forEach(w => w.unmount());
+    containers.forEach(c => c.remove());
+  });
+
+  function createComponent(props = {}, options = {}) {
+    const { paddingTop = 0 } = options;
+
+    const container = document.createElement('div');
+    container.style.paddingTop = `${paddingTop}px`;
+    // Add horizontal paddings to the container, so that there's room for the
+    // popover to grow if needed
+    container.style.paddingLeft = '200px';
+    container.style.paddingRight = '200px';
+    containers.push(container);
+    document.body.append(container);
+
+    const wrapper = mount(<TestComponent {...props} />, {
+      attachTo: container,
+    });
+    wrappers.push(wrapper);
+
+    return wrapper;
+  }
+
+  const getPopover = wrapper => wrapper.find('Popover');
+
+  const getToggleButton = wrapper =>
+    wrapper.find('[data-testid="toggle-button"]');
+
+  const togglePopover = wrapper => getToggleButton(wrapper).simulate('click');
+
+  const popoverAppearedAbove = wrapper => {
+    const { top: popoverTop } = getPopover(wrapper)
+      .getDOMNode()
+      .getBoundingClientRect();
+    const { top: buttonTop } = getToggleButton(wrapper)
+      .getDOMNode()
+      .getBoundingClientRect();
+
+    return popoverTop < buttonTop;
+  };
+
+  [
+    {
+      restoreFocusOnClose: undefined, // Defaults to true
+      expectedFocusAfterClose: wrapper => getToggleButton(wrapper).getDOMNode(),
+    },
+    {
+      restoreFocusOnClose: true,
+      expectedFocusAfterClose: wrapper => getToggleButton(wrapper).getDOMNode(),
+    },
+    {
+      restoreFocusOnClose: false,
+      expectedFocusAfterClose: () => document.body,
+    },
+  ].forEach(({ restoreFocusOnClose, expectedFocusAfterClose }) => {
+    it('restores focus to toggle button after closing popover', () => {
+      const wrapper = createComponent({ restoreFocusOnClose });
+
+      // Focus toggle button before opening popover
+      getToggleButton(wrapper).getDOMNode().focus();
+      togglePopover(wrapper);
+      assert.isTrue(getPopover(wrapper).prop('open'));
+
+      // Focus something else before closing the popover
+      const innerButton = wrapper.find('[data-testid="inner-button"]');
+      innerButton.getDOMNode().focus();
+      // Close the popover with a different button inside the popover itself
+      innerButton.simulate('click');
+      assert.isFalse(getPopover(wrapper).prop('open'));
+
+      // After closing popover, the focus should have returned to the toggle
+      // button, which was the last focused element
+      assert.equal(document.activeElement, expectedFocusAfterClose(wrapper));
+    });
+  });
+
+  [
+    {
+      containerPaddingTop: 0,
+      asNativePopover: undefined,
+      shouldBeAbove: false,
+    },
+    {
+      containerPaddingTop: 0,
+      asNativePopover: true,
+      shouldBeAbove: false,
+    },
+    {
+      containerPaddingTop: 0,
+      asNativePopover: false,
+      shouldBeAbove: false,
+    },
+    {
+      containerPaddingTop: 1000,
+      asNativePopover: undefined,
+      shouldBeAbove: true,
+    },
+    {
+      containerPaddingTop: 1000,
+      asNativePopover: true,
+      shouldBeAbove: true,
+    },
+    {
+      containerPaddingTop: 1000,
+      asNativePopover: false,
+      shouldBeAbove: true,
+    },
+  ].forEach(({ containerPaddingTop, asNativePopover, shouldBeAbove }) => {
+    it('positions popover above or below based on available space', () => {
+      const wrapper = createComponent(
+        { asNativePopover },
+        { paddingTop: containerPaddingTop },
+      );
+      togglePopover(wrapper);
+
+      assert.equal(popoverAppearedAbove(wrapper), shouldBeAbove);
+    });
+  });
+
+  context('when popover is supported', () => {
+    [undefined, true].forEach(asNativePopover => {
+      it('opens via popover API', async () => {
+        const wrapper = createComponent({ asNativePopover });
+        let resolve;
+        const promise = new Promise(res => (resolve = res));
+
+        getPopover(wrapper).getDOMNode().addEventListener('toggle', resolve);
+        togglePopover(wrapper);
+
+        // This test will time out if the toggle event is not dispatched
+        await promise;
+      });
+
+      it('aligns popover to the right if `align="right"` is provided', () => {
+        const wrapper = createComponent({
+          children: 'A text much longer than the anchor element',
+          asNativePopover,
+          align: 'right',
+        });
+        togglePopover(wrapper);
+
+        const { left: buttonLeft } = getToggleButton(wrapper)
+          .getDOMNode()
+          .getBoundingClientRect();
+        const popoverLeftStyle = getPopover(wrapper).getDOMNode().style.left;
+        const popoverLeft = Number(popoverLeftStyle.replace('px', ''));
+
+        assert.isBelow(popoverLeft, buttonLeft);
+      });
+    });
+  });
+
+  context('when popover does not fit in available space', () => {
+    it('never renders a popover bigger than the viewport', () => {
+      const children = 'long text'.repeat(1000);
+      const wrapper = createComponent({ children });
+
+      togglePopover(wrapper);
+
+      const { width: popoverWidth } = getPopover(wrapper)
+        .getDOMNode()
+        .getBoundingClientRect();
+
+      assert.isBelow(popoverWidth, window.innerWidth);
+    });
+
+    [
+      // Content is small. The popover matches the anchor element size
+      // regardless the orientation.
+      ...['right', 'left'].map(align => ({
+        children: 'short text',
+        align,
+        getExpectedCoordinates: (popoverDOMNode, wrapper) => {
+          const buttonDOMNode = getToggleButton(wrapper).getDOMNode();
+          const buttonLeft = buttonDOMNode.getBoundingClientRect().left;
+
+          return {
+            left: buttonLeft,
+            right: popoverDOMNode.getBoundingClientRect().width + buttonLeft,
+          };
+        },
+      })),
+
+      // Content is slightly longer than the anchor element. The popover matches
+      // one of its sides but spans further to the opposite one
+      {
+        children: 'slightly longer text'.repeat(2),
+        align: 'left',
+        getExpectedCoordinates: (popoverDOMNode, wrapper) => {
+          const buttonDOMNode = getToggleButton(wrapper).getDOMNode();
+          const buttonRect = buttonDOMNode.getBoundingClientRect();
+          const popoverRect = popoverDOMNode.getBoundingClientRect();
+          const popoverRightOverhand = popoverRect.width - buttonRect.width;
+
+          return {
+            left: buttonRect.left,
+            right: buttonRect.right + popoverRightOverhand,
+          };
+        },
+      },
+      {
+        children: 'slightly longer text'.repeat(2),
+        align: 'right',
+        getExpectedCoordinates: (popoverDOMNode, wrapper) => {
+          const buttonDOMNode = getToggleButton(wrapper).getDOMNode();
+          const buttonRect = buttonDOMNode.getBoundingClientRect();
+          const popoverRect = popoverDOMNode.getBoundingClientRect();
+          const popoverLeftOverhang = popoverRect.width - buttonRect.width;
+
+          return {
+            left: buttonRect.left - popoverLeftOverhang,
+            right: buttonRect.right,
+          };
+        },
+      },
+
+      // Content is very big, so popover spans to the edge of the viewport and
+      // grows further than the opposite side of the anchor element
+      {
+        children: 'very long text'.repeat(6),
+        align: 'left',
+        getExpectedCoordinates: popoverDOMNode => {
+          const popoverRect = popoverDOMNode.getBoundingClientRect();
+          const bodyWidth = document.body.getBoundingClientRect().width;
+
+          return {
+            left:
+              bodyWidth - popoverRect.width - POPOVER_VIEWPORT_HORIZONTAL_GAP,
+            right: bodyWidth - POPOVER_VIEWPORT_HORIZONTAL_GAP,
+          };
+        },
+      },
+      {
+        children: 'very long text'.repeat(6),
+        align: 'right',
+        getExpectedCoordinates: popoverDOMNode => {
+          const popoverRect = popoverDOMNode.getBoundingClientRect();
+          return {
+            left: POPOVER_VIEWPORT_HORIZONTAL_GAP,
+            right: popoverRect.width + POPOVER_VIEWPORT_HORIZONTAL_GAP,
+          };
+        },
+      },
+    ].forEach(({ children, align, getExpectedCoordinates }) => {
+      it('displays popover at expected coordinates', () => {
+        const wrapper = createComponent({ align, children });
+
+        togglePopover(wrapper);
+
+        const popoverDOMNode = getPopover(wrapper).getDOMNode();
+        const popoverStyleLeft = popoverDOMNode.style.left;
+        const popoverLeft = Number(popoverStyleLeft.replace('px', ''));
+        const popoverRight =
+          popoverDOMNode.getBoundingClientRect().width + popoverLeft;
+
+        const expectedCoordinates = getExpectedCoordinates(
+          popoverDOMNode,
+          wrapper,
+        );
+
+        assert.equal(
+          popoverLeft.toFixed(0),
+          expectedCoordinates.left.toFixed(0),
+        );
+        assert.equal(
+          popoverRight.toFixed(0),
+          expectedCoordinates.right.toFixed(0),
+        );
+      });
+    });
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,6 +44,7 @@ export {
   Callout,
   Dialog,
   ModalDialog,
+  Popover,
   Spinner,
   SpinnerOverlay,
   ToastMessages,

--- a/src/pattern-library/components/patterns/input/SelectPage.tsx
+++ b/src/pattern-library/components/patterns/input/SelectPage.tsx
@@ -28,7 +28,7 @@ function SelectExample({
   ...rest
 }: Pick<
   SelectProps<ItemType>,
-  'buttonClasses' | 'containerClasses' | 'listboxClasses'
+  'buttonClasses' | 'containerClasses' | 'popoverClasses'
 > & {
   textOnly?: boolean;
   items?: ItemType[];
@@ -414,10 +414,10 @@ export default function SelectPage() {
               withSource
             />
           </Library.Example>
-          <Library.Example title="listboxClasses">
+          <Library.Example title="popoverClasses">
             <Library.Info>
               <Library.InfoItem label="description">
-                Additional classes to pass to listbox.
+                Additional classes to pass to the popover.
               </Library.InfoItem>
               <Library.InfoItem label="type">
                 <code>string | string[]</code>
@@ -426,9 +426,9 @@ export default function SelectPage() {
                 <code>undefined</code>
               </Library.InfoItem>
             </Library.Info>
-            <Library.Demo title="Custom listbox">
+            <Library.Demo title="Custom popover">
               <div className="w-96 mx-auto">
-                <SelectExample listboxClasses="border-4 border-yellow-notice" />
+                <SelectExample popoverClasses="border-4 border-yellow-notice" />
               </div>
             </Library.Demo>
           </Library.Example>


### PR DESCRIPTION
> Depends on https://github.com/hypothesis/frontend-shared/pull/1789

Extract the popover element and the logic to dynamically position it from `Select` and into its own `Popover` module.

This will allow us to use this component in other contexts.

### Considerations

The popover currently requires an anchor element to be provided, and calculates its position and size based on that.

For now, I decided to keep some decisions made, like the fact that the popover appears below the anchor element unless there's not enough space, in which case it appears above it.

It also matches the anchor element's size, unless it can't fit its content, in which case it grows.

It should be possible to customize both of those (define initial position, determine how to calculate size, etc.), but I'm not going to change that as part of this PR.

We may also need to support a different way to determine the anchor, like providing a rectangle rather than an anchor element.

### Out of scope

1. I have finally decided not to add a documentation page for `Popover` in this PR, as it has enough changes already.
    Separately, I will add a documentation page explaining the component, how it works and behaves by default, and including some examples.
    EDIT: Addressed in https://github.com/hypothesis/frontend-shared/pull/1793
2. I will also make the Popover render its children only when it's open, making the behavior transparent for the Select and consistent anywhere where the Popover is used.
    EDIT: This is addressed in https://github.com/hypothesis/frontend-shared/pull/1792

### Testing steps

Sanity check that all examples in http://localhost:4001/input-select keep working as expected

### TODO

- [x] Add tests for popover
- [x] Remove some tests from `Select`, if they overlap with Popover tests