### PR TITLE
Do not render Popover children while closed

### DIFF
--- a/src/components/feedback/Popover.tsx
+++ b/src/components/feedback/Popover.tsx
@@ -255,7 +255,7 @@ export default function Popover({
       data-testid="popover"
       data-component="Popover"
     >
-      {children}
+      {open && children}
     </div>
   );
 }

--- a/src/components/feedback/test/Popover-test.js
+++ b/src/components/feedback/test/Popover-test.js
@@ -18,18 +18,17 @@ function TestComponent({ children, ...rest }) {
         Anchor element
       </button>
       <Popover open={open} anchorElementRef={buttonRef} {...rest}>
-        {open &&
-          (children ?? (
-            <>
-              Content of popover
-              <button
-                data-testid="inner-button"
-                onClick={() => setOpen(prev => !prev)}
-              >
-                Focusable element inside popover
-              </button>
-            </>
-          ))}
+        {children ?? (
+          <>
+            Content of popover
+            <button
+              data-testid="inner-button"
+              onClick={() => setOpen(prev => !prev)}
+            >
+              Focusable element inside popover
+            </button>
+          </>
+        )}
       </Popover>
     </div>
   );

--- a/src/components/input/Select.tsx
+++ b/src/components/input/Select.tsx
@@ -467,10 +467,9 @@ function SelectMain<T>({
             aria-multiselectable={multiple}
             aria-labelledby={buttonId ?? defaultButtonId}
             aria-orientation="vertical"
-            data-listbox-open={listboxOpen}
             onScroll={onListboxScroll}
           >
-            {listboxOpen && children}
+            {children}
           </ul>
         </Popover>
       </SelectContext.Provider>

--- a/src/components/input/test/Select-test.js
+++ b/src/components/input/test/Select-test.js
@@ -79,7 +79,7 @@ describe('Select', () => {
   const toggleListbox = wrapper => getToggleButton(wrapper).simulate('click');
 
   const isListboxClosed = wrapper =>
-    wrapper.find('[role="listbox"]').prop('data-listbox-open') === false;
+    wrapper.find('Popover').prop('open') === false;
 
   const openListbox = wrapper => {
     if (isListboxClosed(wrapper)) {


### PR DESCRIPTION
Depends on https://github.com/hypothesis/frontend-shared/pull/1791

Make sure the `Popover` component renders its children only while it's open.

This also removes the requirement to control this in the `Select` component, while adding the same benefit for other places where we use `Popover`.