### PR TITLE
Add onClose property to Popover

### DIFF
--- a/src/components/input/Select.tsx
+++ b/src/components/input/Select.tsx
@@ -10,9 +10,7 @@ import {
 } from 'preact/hooks';
 
 import { useArrowKeyNavigation } from '../../hooks/use-arrow-key-navigation';
-import { useClickAway } from '../../hooks/use-click-away';
 import { useFocusAway } from '../../hooks/use-focus-away';
-import { useKeyPress } from '../../hooks/use-key-press';
 import { useSyncedRef } from '../../hooks/use-synced-ref';
 import type { CompositeProps } from '../../types';
 import { downcastRef } from '../../util/typing';
@@ -381,10 +379,8 @@ function SelectMain<T>({
     [onChange, closeListbox],
   );
 
-  // When clicking away, focusing away or pressing `Esc`, close the listbox
-  useClickAway(wrapperRef, closeListbox);
+  // Close the listbox when focusing away
   useFocusAway(wrapperRef, closeListbox);
-  useKeyPress(['Escape'], closeListbox);
 
   // Vertical arrow key for options in the listbox
   useArrowKeyNavigation(listboxRef, {
@@ -456,6 +452,7 @@ function SelectMain<T>({
         <Popover
           anchorElementRef={wrapperRef}
           open={listboxOpen}
+          onClose={closeListbox}
           asNativePopover={listboxAsPopover}
           align={alignListbox}
           classes={popoverClasses}

--- a/src/components/input/test/Select-test.js
+++ b/src/components/input/test/Select-test.js
@@ -221,41 +221,6 @@ describe('Select', () => {
     assert.isFalse(isListboxClosed(wrapper));
   });
 
-  it('closes listbox when Escape is pressed', () => {
-    const wrapper = createComponent();
-
-    toggleListbox(wrapper);
-    assert.isFalse(isListboxClosed(wrapper));
-
-    document.body.dispatchEvent(
-      new KeyboardEvent('keydown', { key: 'Escape' }),
-    );
-    wrapper.update();
-
-    // Listbox is closed after `Escape` is pressed
-    assert.isTrue(isListboxClosed(wrapper));
-  });
-
-  it('closes listbox when clicking away', () => {
-    const wrapper = createComponent();
-
-    toggleListbox(wrapper);
-    assert.isFalse(isListboxClosed(wrapper));
-
-    const externalButton = document.createElement('button');
-    document.body.append(externalButton);
-
-    externalButton.click();
-    wrapper.update();
-
-    try {
-      // Listbox is closed after other element is clicked
-      assert.isTrue(isListboxClosed(wrapper));
-    } finally {
-      externalButton.remove();
-    }
-  });
-
   it('closes listbox when focusing away', () => {
     const wrapper = createComponent();
     toggleListbox(wrapper);

--- a/src/pattern-library/components/patterns/feedback/PopoverPage.tsx
+++ b/src/pattern-library/components/patterns/feedback/PopoverPage.tsx
@@ -127,6 +127,21 @@ export default function PopoverPage() {
               </Library.InfoItem>
             </Library.Info>
           </Library.Example>
+          <Library.Example title="onClose">
+            <Library.Info>
+              <Library.InfoItem label="description">
+                Callback invoked when the popover is automatically closed by
+                clicking away or pressing <code>Escape</code>.
+                <br />
+                The caller should use this callback to keep local state in sync,
+                so that the popover is re-rendered with <code>open</code> set to{' '}
+                <code>false</code>.
+              </Library.InfoItem>
+              <Library.InfoItem label="type">
+                <code>{'() => void'}</code>
+              </Library.InfoItem>
+            </Library.Info>
+          </Library.Example>
           <Library.Example title="open">
             <Library.Info>
               <Library.InfoItem label="description">

--- a/src/pattern-library/examples/popover-basic.tsx
+++ b/src/pattern-library/examples/popover-basic.tsx
@@ -2,13 +2,10 @@ import { useRef, useState } from 'preact/hooks';
 
 import { Popover } from '../../components/feedback';
 import { Button } from '../../components/input';
-import { useClickAway } from '../../hooks/use-click-away';
 
 export default function App() {
   const [open, setOpen] = useState(false);
   const buttonRef = useRef<HTMLButtonElement | null>(null);
-
-  useClickAway(buttonRef, () => setOpen(false));
 
   return (
     <div className="relative flex justify-center">
@@ -19,7 +16,12 @@ export default function App() {
       >
         {open ? 'Close' : 'Open'} Popover
       </Button>
-      <Popover open={open} anchorElementRef={buttonRef} classes="p-2">
+      <Popover
+        open={open}
+        onClose={() => setOpen(false)}
+        anchorElementRef={buttonRef}
+        classes="p-2"
+      >
         The content of the popover goes here
       </Popover>
     </div>

--- a/src/pattern-library/examples/popover-custom.tsx
+++ b/src/pattern-library/examples/popover-custom.tsx
@@ -21,6 +21,7 @@ export default function App() {
       </Button>
       <Popover
         open={open}
+        onClose={() => setOpen(false)}
         anchorElementRef={buttonRef}
         variant="custom"
         classes="p-3 border-4 border-slate-7 bg-green-success text-white font-bold rounded-tr-lg rounded-bl-lg"

--- a/src/pattern-library/examples/popover-right.tsx
+++ b/src/pattern-library/examples/popover-right.tsx
@@ -21,6 +21,7 @@ export default function App() {
       </Button>
       <Popover
         open={open}
+        onClose={() => setOpen(false)}
         align="right"
         anchorElementRef={buttonRef}
         classes="p-2"


### PR DESCRIPTION
> Closes https://github.com/hypothesis/frontend-shared/issues/1799
> Depends on https://github.com/hypothesis/frontend-shared/pull/1793

 Add a new `onClose` mandatory prop to `Popover`, which is called when clicking away or pressing <kbd>Escape</kbd>.

When the native popover API is used, this is controlled via the [`toggle` event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/toggle_event). Otherwise, we fall back to `useClickAway` and `useKeyPress(['Escape'])`.

![image](https://github.com/user-attachments/assets/1a217d66-6fa4-427d-9117-ecf9d60726e2)
