### PR TITLE
Remove workaround when setting popover attribute

### DIFF
--- a/src/components/feedback/Popover.tsx
+++ b/src/components/feedback/Popover.tsx
@@ -248,10 +248,7 @@ export default function Popover({
         classes,
       )}
       ref={popoverRef}
-      // nb. Use `undefined` rather than `false` because Preact doesn't
-      // handle boolean values correctly for this attribute (it will set
-      // `popover="false"` instead of removing the attribute).
-      popover={asNativePopover ? 'auto' : undefined}
+      popover={asNativePopover && 'auto'}
       data-testid="popover"
       data-component="Popover"
     >

--- a/src/pattern-library/components/patterns/feedback/PopoverPage.tsx
+++ b/src/pattern-library/components/patterns/feedback/PopoverPage.tsx
@@ -147,7 +147,7 @@ export default function PopoverPage() {
                 <code>boolean</code>
               </Library.InfoItem>
               <Library.InfoItem label="default">
-                <code>false</code>
+                <code>true</code>
               </Library.InfoItem>
             </Library.Info>
           </Library.Example>


### PR DESCRIPTION
This PR removes a workaround we had to prevent `popover={false}` to result in a `popover` attribute being added to the DOM element.

That was fixed in https://github.com/preactjs/preact/pull/4393, so setting `false` now skips the attribute entirely.