### PR TITLE
fix: Types after preact 10.25

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "mustache": "^4.2.0",
     "plop": "^4.0.0",
     "postcss": "^8.3.9",
-    "preact": "^10.5.6",
+    "preact": "^10.25.1",
     "prettier": "^3.0.0",
     "rollup": "^4.0.2",
     "rollup-plugin-string": "^3.0.0",
@@ -60,7 +60,7 @@
     "yalc": "^1.0.0-pre.50"
   },
   "peerDependencies": {
-    "preact": "^10.4.0"
+    "preact": "^10.25.1"
   },
   "scripts": {
     "build-lib": "babel src/ --out-dir lib/ --extensions '.js,.ts,.tsx' --source-maps --ignore '**/test' --ignore '**/karma.config.js'",

--- a/src/components/data/TableCell.tsx
+++ b/src/components/data/TableCell.tsx
@@ -8,7 +8,7 @@ import TableContext from './TableContext';
 import TableSectionContext from './TableSectionContext';
 
 export type TableCellProps = PresentationalProps &
-  Omit<JSX.HTMLAttributes<HTMLElement>, 'size'> & {
+  Omit<JSX.TdHTMLAttributes<HTMLElement>, 'size'> & {
     /** Remove default padding, allowing consuming code to control it */
     unpadded?: boolean;
   };

--- a/src/components/input/Button.tsx
+++ b/src/components/input/Button.tsx
@@ -41,7 +41,7 @@ type ComponentProps = {
 };
 
 export type HTMLButtonAttributes = Omit<
-  JSX.HTMLAttributes<HTMLButtonElement>,
+  JSX.ButtonHTMLAttributes<HTMLButtonElement>,
   'icon' | 'size'
 >;
 

--- a/src/components/input/Checkbox.tsx
+++ b/src/components/input/Checkbox.tsx
@@ -29,7 +29,7 @@ type ComponentProps = {
 
 export type CheckboxProps = CompositeProps &
   ComponentProps &
-  Omit<JSX.HTMLAttributes<HTMLInputElement>, 'size' | 'icon'>;
+  Omit<JSX.InputHTMLAttributes<HTMLInputElement>, 'size' | 'icon'>;
 
 /**
  * Render a labeled checkbox input. The checkbox is styled with two icons:

--- a/src/components/input/Input.tsx
+++ b/src/components/input/Input.tsx
@@ -34,7 +34,7 @@ type ComponentProps = FormControlProps & {
 
 export type InputProps = PresentationalProps &
   ComponentProps &
-  JSX.HTMLAttributes<HTMLInputElement>;
+  JSX.InputHTMLAttributes<HTMLInputElement>;
 
 /**
  * Render a text field input

--- a/src/components/input/RadioButton.tsx
+++ b/src/components/input/RadioButton.tsx
@@ -22,7 +22,7 @@ type ComponentProps = {
 
 export type RadioButtonProps = CompositeProps &
   ComponentProps &
-  Omit<JSX.HTMLAttributes<HTMLInputElement>, 'size' | 'icon'>;
+  Omit<JSX.InputHTMLAttributes<HTMLInputElement>, 'size' | 'icon'>;
 
 /**
  * Render a labeled radio input. The radio is styled with two icons: one for the

--- a/src/components/input/Textarea.tsx
+++ b/src/components/input/Textarea.tsx
@@ -8,7 +8,7 @@ import { inputStyles } from './Input';
 
 export type TextareaProps = PresentationalProps &
   FormControlProps &
-  JSX.HTMLAttributes<HTMLTextAreaElement>;
+  JSX.TextareaHTMLAttributes<HTMLTextAreaElement>;
 
 /**
  * Render a textarea

--- a/src/components/input/ToggleInput.tsx
+++ b/src/components/input/ToggleInput.tsx
@@ -22,7 +22,7 @@ type ComponentProps = {
 
 export type ToggleInputProps = CompositeProps &
   ComponentProps &
-  Omit<JSX.HTMLAttributes<HTMLInputElement>, 'size' | 'icon'>;
+  Omit<JSX.InputHTMLAttributes<HTMLInputElement>, 'size' | 'icon'>;
 
 /**
  * Render a labeled checkbox or radio input. The input is styled with two icons:

--- a/src/components/navigation/Link.tsx
+++ b/src/components/navigation/Link.tsx
@@ -14,7 +14,7 @@ type ComponentProps = {
 
 export type LinkProps = PresentationalProps &
   ComponentProps &
-  JSX.HTMLAttributes<HTMLAnchorElement>;
+  JSX.AnchorHTMLAttributes<HTMLAnchorElement>;
 
 /**
  * Styled component for a link (`<a>` element).

--- a/src/components/navigation/LinkButton.tsx
+++ b/src/components/navigation/LinkButton.tsx
@@ -16,7 +16,7 @@ type ComponentProps = {
 export type LinkButtonProps = PresentationalProps &
   Omit<ButtonProps, 'variant'> &
   ComponentProps &
-  JSX.HTMLAttributes<HTMLButtonElement>;
+  JSX.ButtonHTMLAttributes<HTMLButtonElement>;
 
 /**
  * Style a button as a link

--- a/src/pattern-library/components/patterns/input/ButtonPage.tsx
+++ b/src/pattern-library/components/patterns/input/ButtonPage.tsx
@@ -94,7 +94,7 @@ export default function ButtonPage() {
                 <code>HTMLButtonElement</code>.
               </Library.InfoItem>
               <Library.InfoItem label="type">
-                <code>{`Omit<preact.JSX.HTMLAttributes<HTMLButtonElement>, 'icon' | 'size'>`}</code>
+                <code>{`Omit<preact.JSX.ButtonHTMLAttributes<HTMLButtonElement>, 'icon' | 'size'>`}</code>
               </Library.InfoItem>
             </Library.Info>
           </Library.Example>

--- a/src/pattern-library/components/patterns/input/CheckboxPage.tsx
+++ b/src/pattern-library/components/patterns/input/CheckboxPage.tsx
@@ -159,7 +159,7 @@ const handleControlledChange = e => {
               <code>Checkbox</code> accepts HTML attributes for input elements
             </Library.InfoItem>
             <Library.InfoItem label="type">
-              <code>{`JSX.HTMLAttributes<HTMLInputElement>`}</code>
+              <code>{`JSX.InputHTMLAttributes<HTMLInputElement>`}</code>
             </Library.InfoItem>
           </Library.Info>
         </Library.Example>

--- a/src/pattern-library/components/patterns/input/InputPage.tsx
+++ b/src/pattern-library/components/patterns/input/InputPage.tsx
@@ -168,7 +168,7 @@ export default function InputPage() {
                 <code>Input</code> accepts HTML attributes for input elements.
               </Library.InfoItem>
               <Library.InfoItem label="type">
-                <code>{`JSX.HTMLAttributes<HTMLInputElement>`}</code>
+                <code>{`JSX.InputHTMLAttributes<HTMLInputElement>`}</code>
               </Library.InfoItem>
             </Library.Info>
           </Library.Example>

--- a/src/pattern-library/components/patterns/input/RadioButtonPage.tsx
+++ b/src/pattern-library/components/patterns/input/RadioButtonPage.tsx
@@ -96,7 +96,7 @@ export default function RadioButtonPage() {
               elements
             </Library.InfoItem>
             <Library.InfoItem label="type">
-              <code>{`JSX.HTMLAttributes<HTMLInputElement>`}</code>
+              <code>{`JSX.InputHTMLAttributes<HTMLInputElement>`}</code>
             </Library.InfoItem>
           </Library.Info>
         </Library.Example>

--- a/src/pattern-library/components/patterns/input/TextareaPage.tsx
+++ b/src/pattern-library/components/patterns/input/TextareaPage.tsx
@@ -159,7 +159,7 @@ export default function TextareaPage() {
                 elements.
               </Library.InfoItem>
               <Library.InfoItem label="type">
-                <code>{`JSX.HTMLAttributes<HTMLTextareaElement>`}</code>
+                <code>{`JSX.TextareaHTMLAttributes<HTMLTextareaElement>`}</code>
               </Library.InfoItem>
             </Library.Info>
           </Library.Example>

--- a/src/pattern-library/components/patterns/navigation/LinkButtonPage.tsx
+++ b/src/pattern-library/components/patterns/navigation/LinkButtonPage.tsx
@@ -106,13 +106,9 @@ export default function LinkButtonPage() {
                   Underline: none (default)
                 </LinkButton>
 
-                <LinkButton href="https://www.example.com" underline="hover">
-                  Underline: hover
-                </LinkButton>
+                <LinkButton underline="hover">Underline: hover</LinkButton>
 
-                <LinkButton href="https://www.example.com" underline="always">
-                  Underline: always
-                </LinkButton>
+                <LinkButton underline="always">Underline: always</LinkButton>
                 <p>
                   LinkButtons should be{' '}
                   <LinkButton underline="always" inline>
@@ -131,7 +127,9 @@ export default function LinkButtonPage() {
                 to <code>HTMLButtonElement</code>.
               </Library.InfoItem>
               <Library.InfoItem label="type">
-                <code>{'preact.JSX.ButtonHTMLAttributes<HTMLButtonElement>'}</code>
+                <code>
+                  {'preact.JSX.ButtonHTMLAttributes<HTMLButtonElement>'}
+                </code>
               </Library.InfoItem>
             </Library.Info>
           </Library.Example>

--- a/src/pattern-library/components/patterns/navigation/LinkButtonPage.tsx
+++ b/src/pattern-library/components/patterns/navigation/LinkButtonPage.tsx
@@ -131,7 +131,7 @@ export default function LinkButtonPage() {
                 to <code>HTMLButtonElement</code>.
               </Library.InfoItem>
               <Library.InfoItem label="type">
-                <code>{'preact.JSX.HTMLAttributes<HTMLButtonElement>'}</code>
+                <code>{'preact.JSX.ButtonHTMLAttributes<HTMLButtonElement>'}</code>
               </Library.InfoItem>
             </Library.Info>
           </Library.Example>

--- a/src/pattern-library/components/patterns/navigation/LinkPage.tsx
+++ b/src/pattern-library/components/patterns/navigation/LinkPage.tsx
@@ -74,7 +74,7 @@ export default function LinkPage() {
                 <code>HTMLAnchorElement</code>.
               </Library.InfoItem>
               <Library.InfoItem label="type">
-                <code>{'preact.JSX.HTMLAttributes<HTMLAnchorElement>'}</code>
+                <code>{'preact.JSX.AnchorHTMLAttributes<HTMLAnchorElement>'}</code>
               </Library.InfoItem>
               <Library.InfoItem label="example">
                 <Library.Code

--- a/src/pattern-library/components/patterns/navigation/LinkPage.tsx
+++ b/src/pattern-library/components/patterns/navigation/LinkPage.tsx
@@ -74,7 +74,9 @@ export default function LinkPage() {
                 <code>HTMLAnchorElement</code>.
               </Library.InfoItem>
               <Library.InfoItem label="type">
-                <code>{'preact.JSX.AnchorHTMLAttributes<HTMLAnchorElement>'}</code>
+                <code>
+                  {'preact.JSX.AnchorHTMLAttributes<HTMLAnchorElement>'}
+                </code>
               </Library.InfoItem>
               <Library.InfoItem label="example">
                 <Library.Code

--- a/yarn.lock
+++ b/yarn.lock
@@ -9414,9 +9414,9 @@ __metadata:
   linkType: hard
 
 "preact@npm:^10.18.1, preact@npm:^10.5.6":
-  version: 10.24.3
-  resolution: "preact@npm:10.24.3"
-  checksum: 372f601576f52d6417a750a8732cd83c4fc133b0b136f82ea69f013092266ad0213c160b71ae421a0fc7ab04caacb651c29dbf515e3aec26d82b0a8675e8786e
+  version: 10.25.0
+  resolution: "preact@npm:10.25.0"
+  checksum: f7ec537a2e21dfc5b9e0704af7c5b85388a2b675dbf49710261d85708bdc980e5d0b8f8601ba5c4d7cbd1295d3c6aaee9f5c70ad005d872ae89b22e7c46a17ed
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1795,7 +1795,7 @@ __metadata:
     mustache: ^4.2.0
     plop: ^4.0.0
     postcss: ^8.3.9
-    preact: ^10.5.6
+    preact: ^10.25.1
     prettier: ^3.0.0
     rollup: ^4.0.2
     rollup-plugin-string: ^3.0.0
@@ -1808,7 +1808,7 @@ __metadata:
     wouter-preact: ^3.0.0
     yalc: ^1.0.0-pre.50
   peerDependencies:
-    preact: ^10.4.0
+    preact: ^10.25.1
   languageName: unknown
   linkType: soft
 
@@ -9413,7 +9413,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"preact@npm:^10.18.1, preact@npm:^10.5.6":
+"preact@npm:^10.18.1, preact@npm:^10.25.1":
   version: 10.25.1
   resolution: "preact@npm:10.25.1"
   checksum: 7b31f82acfc5eaccc70c19b55ff2bc8edb3d636dfb84e254c9258871c69e1652876efe4bb3a5f21bf521386b001bc6c8831e535d41eecbe0f31c13a0e2a062a3

--- a/yarn.lock
+++ b/yarn.lock
@@ -9414,9 +9414,9 @@ __metadata:
   linkType: hard
 
 "preact@npm:^10.18.1, preact@npm:^10.5.6":
-  version: 10.25.0
-  resolution: "preact@npm:10.25.0"
-  checksum: f7ec537a2e21dfc5b9e0704af7c5b85388a2b675dbf49710261d85708bdc980e5d0b8f8601ba5c4d7cbd1295d3c6aaee9f5c70ad005d872ae89b22e7c46a17ed
+  version: 10.25.1
+  resolution: "preact@npm:10.25.1"
+  checksum: 7b31f82acfc5eaccc70c19b55ff2bc8edb3d636dfb84e254c9258871c69e1652876efe4bb3a5f21bf521386b001bc6c8831e535d41eecbe0f31c13a0e2a062a3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
My attempt to help out with #1797

The new per-element type interfaces introduces in Preact 10.25 should provide better type assistance but does require a switch over. Additionally, whilst I'm not familiar with this code base I stumbled upon what looks like docs while grepping through; I took the opportunity to update those (seemingly) accordingly?

There have been a few attribute fixes upstream already since 10.25, but not yet released. This PR is therefore a result of manually copying over the type changes since to see if there are any issues we hadn't yet caught. As such, this is based on an in-progress 10.25.1, not really 10.25.0.

There's a few issues remaining:
 - ~~`src/components/icons/SpinnerCircle.tsx`: Property `type` does not exist...~~
   - ~~Upstream issue, was missing on the interface. Will get that corrected~~ **FIXED**, will go out in next version
 - `src/pattern-library/components/patterns/navigation/LinkButtonPage.tsx`: Property `href` does not exist...
   - This error seems correct? Very unfamiliar with the code, but it does appear like you're trying to pass `href` to a button
 - ~~`src/components/input/Checkbox.tsx`: Property `call` does not exist...~~
   - ~~This one's a bit weirder and I need some time with yet. I'm not quite sure what's going wrong, but I'd assume it's an upstream issue with our types.~~ **FIXED**, will also go out in the next version