### PR TITLE
Fix Popover not opening when not using the native API

### DIFF
--- a/src/components/feedback/Popover.tsx
+++ b/src/components/feedback/Popover.tsx
@@ -192,8 +192,15 @@ function useOnClose(
 
   // When the popover API is not used, manually add listeners for Escape key
   // press and click away, to mimic the native popover behavior.
-  useClickAway(popoverRef, onClose, { enabled: !asNativePopover });
-  useKeyPress(['Escape'], onClose, { enabled: !asNativePopover });
+  // Disable these while the popover is closed, otherwise trying to open it
+  // by interacting with some other element will trigger a click-away and
+  // immediately close it
+  useClickAway(popoverRef, onClose, {
+    enabled: popoverOpen && !asNativePopover,
+  });
+  useKeyPress(['Escape'], onClose, {
+    enabled: popoverOpen && !asNativePopover,
+  });
 }
 
 export type PopoverProps = {

--- a/src/components/feedback/test/Popover-test.js
+++ b/src/components/feedback/test/Popover-test.js
@@ -223,7 +223,10 @@ describe('Popover', () => {
   context('when popover is not supported', () => {
     it('closes popover when Escape is pressed', () => {
       const onClose = sinon.stub();
-      createComponent({ onClose, asNativePopover: false });
+      const wrapper = createComponent({ onClose, asNativePopover: false });
+
+      // The popover needs to be open for the event handler to be attached
+      togglePopover(wrapper);
 
       document.body.dispatchEvent(
         new KeyboardEvent('keydown', { key: 'Escape' }),
@@ -234,7 +237,10 @@ describe('Popover', () => {
 
     it('closes popover when clicking away', () => {
       const onClose = sinon.stub();
-      createComponent({ onClose, asNativePopover: false });
+      const wrapper = createComponent({ onClose, asNativePopover: false });
+
+      // The popover needs to be open for the event handler to be attached
+      togglePopover(wrapper);
 
       const externalButton = document.createElement('button');
       document.body.append(externalButton);

--- a/src/components/input/Select.tsx
+++ b/src/components/input/Select.tsx
@@ -355,8 +355,7 @@ function SelectMain<T>({
   listboxOverflow = 'truncate',
   'aria-label': ariaLabel,
   'aria-labelledby': ariaLabelledBy,
-  /* eslint-disable-next-line no-prototype-builtins */
-  listboxAsPopover = HTMLElement.prototype.hasOwnProperty('popover'),
+  listboxAsPopover,
 }: SelectMainProps<T>) {
   const wrapperRef = useRef<HTMLDivElement | null>(null);
   const listboxRef = useRef<HTMLUListElement | null>(null);


### PR DESCRIPTION
This PR fixes some regressions introduced in https://github.com/hypothesis/frontend-shared/pull/1800, when `onClose` was implemented, and the logic to close the popover on click away and on Escape press was moved from the `Select` component to the `Popover`.

The issues affect only browsers where the native popover API is not supported.

### Context

Originally, the popover was part of `Select`, and `useCickAway()` was invoked there with the container wrapping both the toggle button and the popover.

After the `Popover` was extracted as a standalone component, we realized it had click-away capabilities built-in when using the native popover API, so we decided to move `useClickAway` there as well for consistency.

However, the element passed to `useClickAway` became the popover only, as it was no longer aware of any toggle or wrapper.

This introduced the first issue fixed here: Clicking the toggle button now triggers a `setOpen(true)`, but also a click-away, which sets it back to false, so the popover could not be opened anymore.

This has been addressed by ensuring `useClickAway` is enabled only while the popover is open.

But this introduces the second issue: We now have the oposite problem. The popover can be opened, but when trying to close it by clicking the toggle, it first triggers a click-away, closing the popover, and then triggers the click on the toggle button, opening it again immediately after.

This has been addressed by ensuring `useClickAway` ignores events triggered on the popover's anchor element, which is usually its toggle button.

### Considerations

I think the first solution is non-controversial, but the second one is making some assumptions which may not always be correct.

In the `Select` case, the anchor element is the toggle button, so the solution applied is correct, but in future we may want to anchor popovers to elements which are not triggers, in which case we would want `useClickAway` to behave the same when clicking on them.

I'm open to suggestions on alternative solutions for the second issue.

### Testing steps

The issue was reproducible only when not using the native API, so you first need to apply this diff:

```diff
diff --git a/src/components/feedback/Popover.tsx b/src/components/feedback/Popover.tsx
index 9c5ea3a..2dc8534 100644
--- a/src/components/feedback/Popover.tsx
+++ b/src/components/feedback/Popover.tsx
@@ -262,7 +262,7 @@ export default function Popover({
   variant = 'panel',
   restoreFocusOnClose = true,
   /* eslint-disable-next-line no-prototype-builtins */
-  asNativePopover = HTMLElement.prototype.hasOwnProperty('popover'),
+  asNativePopover = false,
 }: PopoverProps) {
   const popoverRef = useRef<HTMLDivElement | null>(null);
```

Then go to http://localhost:4001/feedback-popover and verify popovers can be opened/closed by clicking the toggle, clicking away or pressing <kbd>Escape</kbd>.

> [!NOTE]
> There's an unrelated issue when not using the native popover API, in which popovers never grow more than their anchor element. I'm addressing that separately.