### PR TITLE
Refine appearance of DataTable loading state

### DIFF
--- a/src/components/data/DataTable.tsx
+++ b/src/components/data/DataTable.tsx
@@ -401,15 +401,15 @@ export default function DataTable<Row>({
       <TableBody>
         {!loading && tableRows}
         {noContent && (
-          <tr>
-            <td colSpan={columns.length} className="text-center p-3">
+          <TableRow>
+            <TableCell colSpan={columns.length} classes="text-center p-3">
               {loading ? (
-                <SpinnerSpokesIcon className="inline w-4em h-4em" />
+                <SpinnerSpokesIcon className="inline w-2em h-2em" />
               ) : (
                 <>{emptyMessage}</>
               )}
-            </td>
-          </tr>
+            </TableCell>
+          </TableRow>
         )}
       </TableBody>
       {children}


### PR DESCRIPTION
 - Make the loading spinner smaller
 - Use `TableRow`/`TableCell` to render the spinner's container. This aligns the styling more closely with that of the first row when populated.

**Before:**

<img width="640" alt="data-table-loading-before" src="https://github.com/user-attachments/assets/dad5cced-ce89-4429-84da-d445627ec03b">

**After:**

<img width="640" alt="data-table-loading-after" src="https://github.com/user-attachments/assets/1b009812-3dcb-434b-9bc7-a9bb8b1f7784">
