### PR TITLE
Make sure continuous integration triggers on PR created from forks

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,5 +1,9 @@
 name: Continuous integration
-on: [push]
+on:
+  pull_request:
+  push:
+    branches:
+      - main
 jobs:
   ci:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Update the continuous integration workflow so that it triggers when pushing to `main` branch, but also when creating a pull request.

So far we were running it only when pushing to any branch, which was fine as long as the PR was created directly from this repository.

However, if a PR was created from a fork, continuous integration would not trigger. Now it should.