### PR TITLE
Set a font size of at least 16px for inputs on mobile

### DIFF
--- a/src/components/input/Input.tsx
+++ b/src/components/input/Input.tsx
@@ -17,6 +17,11 @@ export function inputStyles({ classes, feedback }: InputStylesOptions) {
     'focus-visible-ring ring-inset border rounded w-full p-2',
     'bg-grey-0 focus:bg-white disabled:bg-grey-1',
     'placeholder:text-color-grey-5 disabled:placeholder:color-grey-6',
+
+    // On iOS, the input font size must be at least 16px to prevent the browser
+    // from zooming into it on touch.
+    'touch:text-at-least-16px',
+
     {
       'ring-2': !!feedback,
       'ring-red-error': feedback === 'error',

--- a/src/tailwind.preset.js
+++ b/src/tailwind.preset.js
@@ -70,6 +70,13 @@ export default /** @type {Partial<import('tailwindcss').Config>} */ ({
           inverted: '#f2f2f2',
         },
       },
+      fontSize: {
+        // Set font size to the maximum of 16px and the inherited size.
+        //
+        // On iOS, the input font size must be at least 16px to prevent the
+        // browser from zooming into it on touch.
+        'at-least-16px': 'max(16px, 100%)',
+      },
       keyframes: {
         'fade-in': {
           '0%': {


### PR DESCRIPTION
To prevent iOS from zooming into `input` and `textarea` fields when tapped, set a font size that is the maximum of 16px and the size inherited from the parent element.

This has no effect in the pattern library website, because the inputs there already had a font size of 16px. It does however make a difference in other downstream UIs like new groups forms in h which use a smaller size. We may wish to change the base size for text to 16px in those UIs in future, but that is a global change which has more complexity. The change here ensures that this size threshold is always met.