### PR TITLE
Update Pagination styling

### DIFF
--- a/src/components/navigation/Pagination.tsx
+++ b/src/components/navigation/Pagination.tsx
@@ -1,17 +1,25 @@
 import classnames from 'classnames';
-import type { JSX } from 'preact';
+import type { ComponentChildren } from 'preact';
 
-import type { PresentationalProps } from '../../types';
 import { pageNumberOptions } from '../../util/pagination';
 import { ArrowLeftIcon, ArrowRightIcon } from '../icons';
 import Button from '../input/Button';
-import type { ButtonProps } from '../input/Button';
 
-type NavigationButtonProps = PresentationalProps &
-  ButtonProps &
-  Omit<JSX.HTMLAttributes<HTMLButtonElement>, 'icon' | 'size'>;
+type NavigationButtonProps = {
+  children: ComponentChildren;
+  invisible?: boolean;
+  onClick: (e: MouseEvent) => void;
+  pressed?: boolean;
+  title?: string;
+};
 
-function NavigationButton({ ...buttonProps }: NavigationButtonProps) {
+function NavigationButton({
+  children,
+  invisible = false,
+  pressed = false,
+  onClick,
+  title,
+}: NavigationButtonProps) {
   return (
     <Button
       classes={classnames(
@@ -20,11 +28,22 @@ function NavigationButton({ ...buttonProps }: NavigationButtonProps) {
         // These colors are the same as the "dark" variant of IconButton
         'text-grey-7 enabled:hover:text-grey-9 enabled:hover:bg-grey-3',
         'disabled:text-grey-5 aria-pressed:bg-grey-3 aria-expanded:bg-grey-3',
+
+        // Disabled navigation buttons are rendered as invisible and disabled
+        // rather than removed so that the overall width of the component and
+        // positions of child controls doesn't change too much when navigating
+        // between pages.
+        invisible && 'invisible',
       )}
-      {...buttonProps}
+      disabled={invisible}
+      onClick={onClick}
+      pressed={pressed}
       size="custom"
+      title={title}
       variant="custom"
-    />
+    >
+      {children}
+    </Button>
   );
 }
 
@@ -76,18 +95,15 @@ export default function Pagination({
       className="flex items-center text-md select-none"
       data-testid="pagination-navigation"
     >
-      <div className="w-28">
-        {hasPreviousPage && (
-          <NavigationButton
-            title="Go to previous page"
-            onClick={e =>
-              changePageTo(currentPage - 1, e.target as HTMLElement)
-            }
-          >
-            <ArrowLeftIcon />
-            prev
-          </NavigationButton>
-        )}
+      <div className="mr-2">
+        <NavigationButton
+          invisible={!hasPreviousPage}
+          title="Go to previous page"
+          onClick={e => changePageTo(currentPage - 1, e.target as HTMLElement)}
+        >
+          <ArrowLeftIcon />
+          prev
+        </NavigationButton>
       </div>
       <ul
         className={classnames(
@@ -133,23 +149,20 @@ export default function Pagination({
       </ul>
       <div
         className={classnames(
-          'w-28 flex justify-end',
+          'ml-2 flex justify-end',
           // When page buttons are not shown, this element should grow to fill
           // available space. But when page buttons are shown, it should not.
           'grow md:grow-0',
         )}
       >
-        {hasNextPage && (
-          <NavigationButton
-            title="Go to next page"
-            onClick={e =>
-              changePageTo(currentPage + 1, e.target as HTMLElement)
-            }
-          >
-            next
-            <ArrowRightIcon />
-          </NavigationButton>
-        )}
+        <NavigationButton
+          invisible={!hasNextPage}
+          title="Go to next page"
+          onClick={e => changePageTo(currentPage + 1, e.target as HTMLElement)}
+        >
+          next
+          <ArrowRightIcon />
+        </NavigationButton>
       </div>
     </div>
   );

--- a/src/components/navigation/Pagination.tsx
+++ b/src/components/navigation/Pagination.tsx
@@ -73,7 +73,7 @@ export default function Pagination({
 
   return (
     <div
-      className="flex items-center text-md"
+      className="flex items-center text-md select-none"
       data-testid="pagination-navigation"
     >
       <div className="w-28 h-10">

--- a/src/components/navigation/Pagination.tsx
+++ b/src/components/navigation/Pagination.tsx
@@ -109,7 +109,15 @@ export default function Pagination({
         {pageNumbers.map((page, idx) => (
           <li key={idx}>
             {page === null ? (
-              <div data-testid="pagination-gap">...</div>
+              // Indicator for elided pages. Should be approximately the same
+              // width as a small page number. This reduces the variation of
+              // the component's width as the current page is advanced.
+              //
+              // Navigation buttons have `px-3.5`. This uses `px-3` since
+              // an ellipsis is slightly wider than a digit.
+              <div className="px-3 text-center" data-testid="pagination-gap">
+                …
+              </div>
             ) : (
               <NavigationButton
                 key={`page-${idx}`}

--- a/src/components/navigation/Pagination.tsx
+++ b/src/components/navigation/Pagination.tsx
@@ -76,7 +76,7 @@ export default function Pagination({
       className="flex items-center text-md select-none"
       data-testid="pagination-navigation"
     >
-      <div className="w-28 h-10">
+      <div className="w-28">
         {hasPreviousPage && (
           <NavigationButton
             title="Go to previous page"
@@ -133,7 +133,7 @@ export default function Pagination({
       </ul>
       <div
         className={classnames(
-          'w-28 h-10 flex justify-end',
+          'w-28 flex justify-end',
           // When page buttons are not shown, this element should grow to fill
           // available space. But when page buttons are shown, it should not.
           'grow md:grow-0',

--- a/src/components/navigation/Pagination.tsx
+++ b/src/components/navigation/Pagination.tsx
@@ -77,10 +77,6 @@ export default function Pagination({
   const hasPreviousPage = currentPage > 1;
   const pageNumbers = pageNumberOptions(currentPage, totalPages);
 
-  /**
-   * @param {number} pageNumber
-   * @param {HTMLElement} element
-   */
   const changePageTo = (pageNumber: number, element: HTMLElement) => {
     onChangePage(pageNumber);
     // Because changing pagination page doesn't reload the page (as it would

--- a/src/components/navigation/Pagination.tsx
+++ b/src/components/navigation/Pagination.tsx
@@ -18,7 +18,7 @@ function NavigationButton({ ...buttonProps }: NavigationButtonProps) {
         'px-3.5 py-2.5 gap-x-1',
         'font-semibold rounded',
         // These colors are the same as the "dark" variant of IconButton
-        'text-grey-7 bg-grey-2 enabled:hover:text-grey-9 enabled:hover:bg-grey-3',
+        'text-grey-7 enabled:hover:text-grey-9 enabled:hover:bg-grey-3',
         'disabled:text-grey-5 aria-pressed:bg-grey-3 aria-expanded:bg-grey-3',
       )}
       {...buttonProps}

--- a/src/components/navigation/test/Pagination-test.js
+++ b/src/components/navigation/test/Pagination-test.js
@@ -34,16 +34,18 @@ describe('Pagination', () => {
   });
 
   describe('prev button', () => {
-    it('should render a prev button when there are previous pages to show', () => {
+    it('should render enabled prev button when there are previous pages to show', () => {
       const wrapper = createComponent({ currentPage: 2 });
       const button = findButton(wrapper, 'Go to previous page');
-      assert.isTrue(button.exists());
+      assert.isFalse(button.find('button').hasClass('invisible'));
+      assert.isFalse(button.prop('disabled'));
     });
 
-    it('should not render a prev button if there are no previous pages to show', () => {
+    it('should render disabled prev button if there are no previous pages to show', () => {
       const wrapper = createComponent({ currentPage: 1 });
       const button = findButton(wrapper, 'Go to previous page');
-      assert.isFalse(button.exists());
+      assert.isTrue(button.find('button').hasClass('invisible'));
+      assert.isTrue(button.prop('disabled'));
     });
 
     it('should invoke the onChangePage callback when clicked', () => {
@@ -66,16 +68,18 @@ describe('Pagination', () => {
   });
 
   describe('next button', () => {
-    it('should render a next button when there are further pages to show', () => {
+    it('should render enabled button when there are further pages to show', () => {
       const wrapper = createComponent({ currentPage: 1 });
       const button = findButton(wrapper, 'Go to next page');
-      assert.isTrue(button.exists());
+      assert.isFalse(button.find('button').hasClass('invisible'));
+      assert.isFalse(button.prop('disabled'));
     });
 
-    it('should not render a next button if there are no further pages to show', () => {
+    it('should render disabled next button if there are no further pages to show', () => {
       const wrapper = createComponent({ currentPage: 10 });
       const button = findButton(wrapper, 'Go to next page');
-      assert.isFalse(button.exists());
+      assert.isTrue(button.find('button').hasClass('invisible'));
+      assert.isTrue(button.prop('disabled'));
     });
 
     it('should invoke the `onChangePage` callback when clicked', () => {


### PR DESCRIPTION
Update the styling of the Pagination control as follows:

 - Remove the background color from non-active items. This is a vestige from when this component was first created for use in the client's Notebook UI.
 - Use Unicode ellipsis for elided pages and page the elided-page markers approximately the same width as a (small) page number
 - Prevent text of pagination controls from being selected
 - Fix an issue where the Prev/Next button would have incorrect vertical alignment if the font size did not match that used in the client
 - Disable and hide prev/next controls rather than removing them when unavailable. This keeps the position of other controls consistent when moving from page to page, without needing to place these controls in a container with a hard-coded size

**Before:**

<img width="702" alt="pagination-before" src="https://github.com/user-attachments/assets/f56e31bd-e351-4fdf-a42b-4bf3e4b63c53">

**After:**

<img width="714" alt="pagination-after" src="https://github.com/user-attachments/assets/f17cab8e-e9a4-4255-a9f7-bfa4f0bf4f45">

