### PR TITLE
Revise pagination item calculation

### DIFF
--- a/src/components/navigation/Pagination.tsx
+++ b/src/components/navigation/Pagination.tsx
@@ -1,7 +1,7 @@
 import classnames from 'classnames';
 import type { ComponentChildren } from 'preact';
 
-import { pageNumberOptions } from '../../util/pagination';
+import { paginationItems } from '../../util/pagination';
 import { ArrowLeftIcon, ArrowRightIcon } from '../icons';
 import Button from '../input/Button';
 
@@ -75,7 +75,7 @@ export default function Pagination({
   // Pages are 1-indexed
   const hasNextPage = currentPage < totalPages;
   const hasPreviousPage = currentPage > 1;
-  const pageNumbers = pageNumberOptions(currentPage, totalPages);
+  const pageNumbers = paginationItems(currentPage, totalPages);
 
   const changePageTo = (pageNumber: number, element: HTMLElement) => {
     onChangePage(pageNumber);

--- a/src/components/navigation/test/Pagination-test.js
+++ b/src/components/navigation/test/Pagination-test.js
@@ -4,7 +4,7 @@ import Pagination, { $imports } from '../Pagination';
 
 describe('Pagination', () => {
   let fakeOnChangePage;
-  let fakePageNumberOptions;
+  let fakePaginationItems;
 
   const findButton = (wrapper, title) =>
     wrapper.find('button').filterWhere(n => n.props().title === title);
@@ -22,10 +22,10 @@ describe('Pagination', () => {
 
   beforeEach(() => {
     fakeOnChangePage = sinon.stub();
-    fakePageNumberOptions = sinon.stub().returns([1, 2, 3, 4, null, 10]);
+    fakePaginationItems = sinon.stub().returns([1, 2, 3, 4, null, 10]);
 
     $imports.$mock({
-      '../../util/pagination': { pageNumberOptions: fakePageNumberOptions },
+      '../../util/pagination': { paginationItems: fakePaginationItems },
     });
   });
 
@@ -103,7 +103,7 @@ describe('Pagination', () => {
 
   describe('page number buttons', () => {
     it('should render buttons for each page number available', () => {
-      fakePageNumberOptions.returns([1, 2, 3, 4, null, 10]);
+      fakePaginationItems.returns([1, 2, 3, 4, null, 10]);
       const wrapper = createComponent();
 
       [1, 2, 3, 4, 10].forEach(pageNumber => {
@@ -116,7 +116,7 @@ describe('Pagination', () => {
     });
 
     it('should invoke the onChangePage callback when page number button clicked', () => {
-      fakePageNumberOptions.returns([1, 2, 3, 4, null, 10]);
+      fakePaginationItems.returns([1, 2, 3, 4, null, 10]);
       const wrapper = createComponent();
 
       [1, 2, 3, 4, 10].forEach(pageNumber => {

--- a/src/util/test/pagination-test.js
+++ b/src/util/test/pagination-test.js
@@ -1,22 +1,129 @@
-import { pageNumberOptions } from '../pagination';
+import { paginationItems } from '../pagination';
 
-describe('sidebar/util/pagination', () => {
-  describe('pageNumberOptions', () => {
-    [
-      { args: [1, 10, 5], expected: [1, 2, 3, 4, null, 10] },
-      { args: [3, 10, 5], expected: [1, 2, 3, 4, null, 10] },
-      { args: [6, 10, 5], expected: [1, null, 5, 6, 7, null, 10] },
-      { args: [9, 10, 5], expected: [1, null, 7, 8, 9, 10] },
-      { args: [2, 3, 5], expected: [1, 2, 3] },
-      { args: [3, 10, 7], expected: [1, 2, 3, 4, 5, 6, null, 10] },
-      { args: [1, 1, 5], expected: [] },
-    ].forEach(testCase => {
-      it('should produce expected available page numbers', () => {
-        assert.deepEqual(
-          pageNumberOptions(...testCase.args),
-          testCase.expected,
-        );
+describe('paginationItems', () => {
+  [
+    // Only one page
+    {
+      current: 1,
+      total: 1,
+      expected: [],
+    },
+
+    // No pages elided.
+    {
+      current: 1,
+      total: 3,
+      expected: [1, 2, 3],
+    },
+
+    // Pages elided after current.
+    {
+      current: 1,
+      total: 4,
+      expected: [1, 2, null, 4],
+    },
+
+    // Pages elided before current.
+    {
+      current: 4,
+      total: 6,
+      expected: [1, null, 3, 4, 5, 6],
+    },
+
+    // Pages elided before and after current.
+    {
+      current: 4,
+      total: 7,
+      expected: [1, null, 3, 4, 5, null, 7],
+    },
+
+    // Custom boundary count
+    {
+      current: 6,
+      total: 10,
+      boundaryCount: 2,
+      expected: [1, 2, null, 5, 6, 7, null, 9, 10],
+    },
+
+    // Custom sibling count
+    {
+      current: 6,
+      total: 10,
+      siblingCount: 2,
+      expected: [1, null, 4, 5, 6, 7, 8, null, 10],
+    },
+
+    // Case where elide the page after the current one and then reduce the
+    // elided set so the number of items is consistent regardless of page.
+    {
+      current: 1,
+      total: 4,
+      boundaryCount: 1,
+      siblingCount: 0,
+      expected: [1, 2, null, 4],
+    },
+  ].forEach(({ current, total, boundaryCount, siblingCount, expected }) => {
+    it('should produce expected items', () => {
+      const items = paginationItems(current, total, {
+        boundaryCount,
+        siblingCount,
       });
+      assert.deepEqual(items, expected);
     });
+  });
+
+  function* configurations() {
+    for (let boundaryCount = 1; boundaryCount <= 3; boundaryCount++) {
+      for (let siblingCount = 0; siblingCount <= 2; siblingCount++) {
+        for (let total = 1; total <= 10; total++) {
+          yield { total, boundaryCount, siblingCount };
+        }
+      }
+    }
+  }
+
+  function isStrictlyIncreasing(list) {
+    return list.every((item, idx) => idx === 0 || item > list[idx - 1]);
+  }
+
+  it('should produce expected items for generated configurations', () => {
+    for (const { total, boundaryCount, siblingCount } of configurations()) {
+      const expectedItems =
+        total === 1
+          ? 0
+          : Math.min(total, 2 * boundaryCount + 2 * siblingCount + 3);
+
+      for (let current = 1; current <= total; current++) {
+        const items = paginationItems(current, total, {
+          boundaryCount,
+          siblingCount,
+        });
+
+        if (total === 1) {
+          assert.deepEqual(items, []);
+          continue;
+        }
+
+        assert.equal(
+          items.length,
+          expectedItems,
+          'incorrect pagination item count',
+        );
+        assert.include(items, 1, 'first page should be included');
+        assert.include(items, current, 'current page should be included');
+        assert.include(items, total, 'last page should be included');
+        assert.isAtMost(
+          items.filter(it => it === null).length,
+          2,
+          'should have at most two elided page indicators',
+        );
+
+        const numbers = items.filter(it => typeof it === 'number');
+        assert.isTrue(
+          isStrictlyIncreasing(numbers),
+          `${numbers.join(', ')} is not strictly increasing`,
+        );
+      }
+    }
   });
 });


### PR DESCRIPTION
Revise how the pagination items (page numbers and elided page markers) are calculated, such that the number of _items_ rather than the number of _numbered pages_ remains consistent as the user navigates through the list. Provided each item is rendered with a roughly consistent width, this keeps the overall width of the control and the position of child components consistent when navigating through the list.

<img width="672" alt="page-2" src="https://github.com/user-attachments/assets/ca943808-7351-4058-90b2-9ac604695a5e">

<img width="673" alt="page-5" src="https://github.com/user-attachments/assets/7484d3b4-1d4e-4713-98ad-daf362fd1017">

When this middle controls have a consistent width, the Pagination also works better in cases where the Prev/Next controls are adjacent to the middle items, rather than aligned with the edge of the content area above (the table here).

**Testing:**

Go to http://localhost:4001/navigation-pagination, navigate through the list. Observe that the number of items displayed is the same regardless of current page. Compare with https://patterns.hypothes.is/navigation-pagination where this is not the case.