### PR TITLE
Export ListenerCollection from the main entry point

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ export {
   formatRelativeDate,
   formatDateTime,
 } from './util/date-and-time';
+export { ListenerCollection } from './util/listener-collection';
 export { confirm } from './util/prompts';
 
 // Components
@@ -159,4 +160,5 @@ export type {
   DateFormatter,
   FormatDateTimeOptions,
 } from './util/date-and-time';
+export type { EventType } from './util/listener-collection';
 export type { ConfirmModalProps } from './util/prompts';

--- a/src/util/listener-collection.ts
+++ b/src/util/listener-collection.ts
@@ -14,7 +14,7 @@ export type Listener = {
  * `HTMLElement.onkeydown` here) If there is no such property, the type defaults
  * to `Event`.
  */
-type EventType<
+export type EventType<
   Target extends EventTarget,
   TypeName extends string,
 > = `on${TypeName}` extends keyof Target


### PR DESCRIPTION
We have similar `ListenerCollection` utilities in other projects, so exposing the one from this library so that we can remove a bit of duplicated code.