### PR TITLE
Recalculate popover position when resized while open

### DIFF
--- a/src/components/feedback/Popover.tsx
+++ b/src/components/feedback/Popover.tsx
@@ -133,9 +133,9 @@ function usePopoverPositioning(
 
     // First of all, open popover if it's using the native API, otherwise its
     // size is 0x0 and positioning calculations won't work.
-    const popover = popoverRef.current;
+    const popover = popoverRef.current!;
     if (asNativePopover) {
-      popover?.togglePopover(true);
+      popover.togglePopover(true);
     }
 
     const cleanup = adjustPopoverPositioning();
@@ -151,12 +151,18 @@ function usePopoverPositioning(
       capture: true,
     });
 
+    // Readjust popover positioning if its resized, in case it dropped-up, and
+    // it needs to be moved down
+    const observer = new ResizeObserver(adjustPopoverPositioning);
+    observer.observe(popover);
+
     return () => {
       if (asNativePopover) {
         popover?.togglePopover(false);
       }
       cleanup();
       listeners.removeAll();
+      observer.disconnect();
     };
   }, [adjustPopoverPositioning, asNativePopover, popoverOpen, popoverRef]);
 }


### PR DESCRIPTION
This PR fixes an incorrect popover positioning when it gets resized or its contents change while it is open, as the position is calculated only when opened.

With this, we add a `ResizeObserver` which observes the popover, and if it gets resized, we re-calculate its position.

The incorrect position usually happens only if the popover had to pop up.

This is how it looks before the fix, when the contents of the popover change after it has been opened:

https://github.com/user-attachments/assets/4d16f1f2-7548-4599-a3eb-e936f553c594

And this is how it looks once fixed:

https://github.com/user-attachments/assets/5d7719b0-6589-48c9-91e7-4bb35c4ec894

> There's a bit of flickering in the screen recordings above. I think that's an issue on the video recording software, as I don't see that on my screen.

The first time I notice this issue was while working in at-mentions. The suggestions popover content can change while it's open, causing the position to be wrong.

### Test steps

1. Apply this diff:
    ```diff
    diff --git a/src/pattern-library/examples/popover-basic.tsx b/src/pattern-library/examples/popover-basic.tsx
    index e44656c..acc0092 100644
    --- a/src/pattern-library/examples/popover-basic.tsx
    +++ b/src/pattern-library/examples/popover-basic.tsx
    @@ -1,4 +1,4 @@
    -import { useRef, useState } from 'preact/hooks';
    +import { useCallback, useEffect, useRef, useState } from 'preact/hooks';
     
     import { Popover } from '../../components/feedback';
     import { Button } from '../../components/input';
    @@ -6,6 +6,27 @@ import { Button } from '../../components/input';
     export default function App() {
       const [open, setOpen] = useState(false);
       const buttonRef = useRef<HTMLButtonElement | null>(null);
    +  const [showSecondParagraph, setShowSecondParagraph] = useState(true);
    +  const timeoutRef = useRef<ReturnType<typeof setTimeout>>();
    +  const cancelTimeout = useCallback(() => {
    +    if (timeoutRef.current) {
    +      clearTimeout(timeoutRef.current);
    +    }
    +    timeoutRef.current = undefined;
    +  }, []);
    +
    +  useEffect(() => {
    +    if (open) {
    +      timeoutRef.current = setTimeout(() => {
    +        cancelTimeout();
    +        setShowSecondParagraph(false);
    +      }, 2000);
    +    } else {
    +      setShowSecondParagraph(true);
    +    }
    +
    +    return cancelTimeout;
    +  }, [cancelTimeout, open]);
     
       return (
         <div className="relative flex justify-center">
    @@ -22,7 +43,8 @@ export default function App() {
             anchorElementRef={buttonRef}
             classes="p-2"
           >
    -        The content of the popover goes here
    +        <p>The content of the popover goes here</p>
    +        {showSecondParagraph && <p>Disappears in 2s</p>}
           </Popover>
         </div>
       );
    ```
2. Go to http://localhost:4001/feedback-popover
3. Scroll or resize the window so that the first "Open popover" button is close to the bottom of the viewport. That will cause the popover to pop-up.
4. Open the popover and wait for 2 seconds for part of its content to disappear. In this branch, the popover should reposition to keep stuck on top of the button. In `main branch, it will keep its previous position, increasing the distance with the top of the button.