### PR TITLE
Make Popover a presentational component

### DIFF
--- a/src/components/feedback/Popover.tsx
+++ b/src/components/feedback/Popover.tsx
@@ -1,10 +1,13 @@
 import classnames from 'classnames';
-import type { ComponentChildren, RefObject } from 'preact';
-import { useCallback, useEffect, useLayoutEffect, useRef } from 'preact/hooks';
+import type { JSX, RefObject } from 'preact';
+import { useCallback, useEffect, useLayoutEffect } from 'preact/hooks';
 
 import { useClickAway } from '../../hooks/use-click-away';
 import { useKeyPress } from '../../hooks/use-key-press';
+import { useSyncedRef } from '../../hooks/use-synced-ref';
+import type { PresentationalProps } from '../../types';
 import { ListenerCollection } from '../../util/listener-collection';
+import { downcastRef } from '../../util/typing';
 
 /** Small space to apply between the anchor element and the popover */
 const POPOVER_ANCHOR_EL_GAP = '.15rem';
@@ -221,8 +224,6 @@ function useOnClose(
 }
 
 export type PopoverProps = {
-  children?: ComponentChildren;
-  classes?: string | string[];
   variant?: 'panel' | 'custom';
 
   /** Whether the popover is currently open or not */
@@ -256,7 +257,8 @@ export type PopoverProps = {
    * Defaults to true, as long as the browser supports it.
    */
   asNativePopover?: boolean;
-};
+} & PresentationalProps &
+  Omit<JSX.HTMLAttributes<HTMLDivElement>, 'popover'>;
 
 export default function Popover({
   anchorElementRef,
@@ -269,8 +271,10 @@ export default function Popover({
   restoreFocusOnClose = true,
   /* eslint-disable-next-line no-prototype-builtins */
   asNativePopover = HTMLElement.prototype.hasOwnProperty('popover'),
+  elementRef,
+  ...htmlAttributes
 }: PopoverProps) {
-  const popoverRef = useRef<HTMLDivElement | null>(null);
+  const popoverRef = useSyncedRef(elementRef);
 
   usePopoverPositioning(
     anchorElementRef,
@@ -318,10 +322,11 @@ export default function Popover({
         },
         classes,
       )}
-      ref={popoverRef}
+      ref={downcastRef(popoverRef)}
       popover={asNativePopover && 'auto'}
       data-testid="popover"
       data-component="Popover"
+      {...htmlAttributes}
     >
       {open && children}
     </div>

--- a/src/pattern-library/components/patterns/feedback/PopoverPage.tsx
+++ b/src/pattern-library/components/patterns/feedback/PopoverPage.tsx
@@ -8,8 +8,9 @@ export default function PopoverPage() {
       intro={
         <>
           <p>
-            <code>Popover</code> is a floating element rendered above other
-            content and positioned next to an anchor element.
+            <code>Popover</code> is a presentational component providing a
+            floating element rendered above other content and positioned next to
+            an anchor element.
           </p>
         </>
       }
@@ -61,6 +62,13 @@ export default function PopoverPage() {
         </Library.SectionL2>
 
         <Library.SectionL2 title="Popover component API">
+          <p>
+            <code>Popover</code> accepts all standard{' '}
+            <Library.Link href="/using-components#presentational-components-api">
+              presentational component props
+            </Library.Link>
+            .
+          </p>
           <Library.SectionL3 title="align">
             <Library.Info>
               <Library.InfoItem label="description">
@@ -111,19 +119,6 @@ export default function PopoverPage() {
               <Library.InfoItem label="default">
                 <code>true</code> if the browser supports <code>[popover]</code>
                 . Otherwise it is <code>false</code>
-              </Library.InfoItem>
-            </Library.Info>
-          </Library.SectionL3>
-          <Library.SectionL3 title="classes">
-            <Library.Info>
-              <Library.InfoItem label="description">
-                Additional CSS classes to pass to the popover.
-              </Library.InfoItem>
-              <Library.InfoItem label="type">
-                <code>string | string[]</code>
-              </Library.InfoItem>
-              <Library.InfoItem label="default">
-                <code>undefined</code>
               </Library.InfoItem>
             </Library.Info>
           </Library.SectionL3>


### PR DESCRIPTION
This PR makes the `Popover` a presentational component, accepting any DIV HTML attribute which is passed down to the outermost div.

The motivation for this PR is that we needed to be able to pass an `id` to `Popover`. Since I imagine we may need to add more arbitrary attributes in future, I checked how we handle similar components, and [PresentationalComponents](https://patterns.hypothes.is/using-components#presentational-components-api) seemed like a reasonable approach.