### PR TITLE
Export PopoverProps from the main package entry point

### DIFF
--- a/src/components/feedback/index.ts
+++ b/src/components/feedback/index.ts
@@ -9,6 +9,7 @@ export { default as ToastMessages } from './ToastMessages';
 export type { CalloutProps } from './Callout';
 export type { DialogProps } from './Dialog';
 export type { ModalDialogProps } from './ModalDialog';
+export type { PopoverProps } from './Popover';
 export type { SpinnerProps } from './Spinner';
 export type { SpinnerOverlayProps } from './SpinnerOverlay';
 export type {

--- a/src/index.ts
+++ b/src/index.ts
@@ -114,6 +114,7 @@ export type {
   CalloutProps,
   DialogProps,
   ModalDialogProps,
+  PopoverProps,
   SpinnerProps,
   SpinnerOverlayProps,
   ToastMessage,


### PR DESCRIPTION
We overlooked exporting `PopoverProps`. Fixing it now.