### PR TITLE
Fix logo size

### DIFF
--- a/src/pattern-library/components/PlaygroundApp.tsx
+++ b/src/pattern-library/components/PlaygroundApp.tsx
@@ -163,9 +163,9 @@ export default function PlaygroundApp({
                   <h1 className="font-medium text-lg pl-6">
                     <Link
                       href={baseURL + '/'}
-                      classes="flex gap-x-3 text-stone-700"
+                      classes="flex gap-x-3 text-stone-700 items-center"
                     >
-                      <LogoIcon className="text-brand" />
+                      <LogoIcon className="text-brand w-6 h-6" />
                       Component Library
                     </Link>
                   </h1>


### PR DESCRIPTION
A few weeks ago we [updated and consolidated](https://github.com/hypothesis/frontend-shared/pull/1849/files) all our icons. Among other things, that accidentally reduced the default size of the logo icon.

This PR ensures the same size as before is used when rendered in the page header.

Before:
![image](https://github.com/user-attachments/assets/4ba3f68d-91e8-4c33-8126-a67d9e81bcaa)

After:
![image](https://github.com/user-attachments/assets/cdceb635-b163-41fd-b40c-41a6c9d71353)

> I checked the internet archive wayback machine to verify what was the size we used to be using. See https://web.archive.org/web/20250117183607/https://patterns.hypothes.is/