### PR TITLE
Fix typo in input placeholder color class

### DIFF
--- a/src/components/input/Input.tsx
+++ b/src/components/input/Input.tsx
@@ -16,7 +16,7 @@ export function inputStyles({ classes, feedback }: InputStylesOptions) {
   return classnames(
     'focus-visible-ring ring-inset border rounded w-full p-2',
     'bg-grey-0 focus:bg-white disabled:bg-grey-1',
-    'placeholder:text-color-grey-5 disabled:placeholder:color-grey-6',
+    'placeholder:text-grey-6 disabled:placeholder:text-grey-7',
 
     // On iOS, the input font size must be at least 16px to prevent the browser
     // from zooming into it on touch.


### PR DESCRIPTION
Part of https://github.com/hypothesis/client/issues/6866

This PR does two things:

1. Fix two typos in `Input` tailwind classes around placeholder text color.
2. Consolidate `Input` and `Textarea` ~text color and~ placeholder color, following the changes in https://github.com/hypothesis/client/pull/6966

~Inputs were previously inheriting the text color from the page, having inconsistent values. Now we settle to `grey-8`~

The previous placeholder color (even though it was not working due to the typo mentioned above) was too light in contrast with white background. Now we settle to `grey-6`, which has more than 4.5 contrast, as required by accessibility guidelines.

![image](https://github.com/user-attachments/assets/a6a7f019-b04a-4cde-ad3e-22a749c2e50a)
![image](https://github.com/user-attachments/assets/4fc1e37d-00f1-46b2-9cf9-2cd9b412198e)
![image](https://github.com/user-attachments/assets/fa1b964e-447f-49e9-8d45-834426d7f730)
