### PR TITLE
Fix optional param for Express 5

### DIFF
--- a/scripts/serve-pattern-library.js
+++ b/scripts/serve-pattern-library.js
@@ -17,7 +17,7 @@ export function servePatternLibrary(port = 4001) {
   );
 
   // For any other path, serve the index.html file to allow client-side routing
-  app.get('/:path?', (req, res) => {
+  app.get('/{:path}', (req, res) => {
     res.sendFile(path.join(dirname, '../templates/index.html'));
   });
 


### PR DESCRIPTION
We recently updated to Express 5 via dependabot PR, but optional route params are defined differently in this version.

This PR fixes the only occurrence of a n optional route param to use the new approach.

More info can be found in the [upgrade guide](https://expressjs.com/en/guide/migrating-5.html#path-syntax).