### PR TITLE
Add new shades of green, red and yellow

### DIFF
--- a/src/pattern-library/components/patterns/ColorsPage.tsx
+++ b/src/pattern-library/components/patterns/ColorsPage.tsx
@@ -55,9 +55,29 @@ const slateExamples = (
 
 const stateExamples = (
   <>
-    <ColorSwatch colorClass="bg-green-success" colorName="green-success" />
-    <ColorSwatch colorClass="bg-yellow-notice" colorName="yellow-notice" />
-    <ColorSwatch colorClass="bg-red-error" colorName="red-error" />
+    <ColorSwatch
+      colorClass="bg-green-success"
+      colorName="green-success (green alias)"
+    />
+    <ColorSwatch
+      colorClass="bg-yellow-notice"
+      colorName="yellow-notice (yellow alias)"
+    />
+    <ColorSwatch colorClass="bg-red-error" colorName="red-error (red alias)" />
+  </>
+);
+
+const highlightingExamples = (
+  <>
+    <ColorSwatch colorClass="bg-green-light" colorName="green-light" />
+    <ColorSwatch colorClass="bg-green" colorName="green" />
+    <ColorSwatch colorClass="bg-green-dark" colorName="green-dark" />
+    <ColorSwatch colorClass="bg-yellow-light" colorName="yellow-light" />
+    <ColorSwatch colorClass="bg-yellow" colorName="yellow" />
+    <ColorSwatch colorClass="bg-yellow-dark" colorName="yellow-dark" />
+    <ColorSwatch colorClass="bg-red-light" colorName="red-light" />
+    <ColorSwatch colorClass="bg-red" colorName="red" />
+    <ColorSwatch colorClass="bg-red-dark" colorName="red-dark" />
   </>
 );
 
@@ -87,6 +107,12 @@ export default function ColorsPage() {
         </p>
         <div className="my-4 flex flex-row flex-wrap gap-4">
           {slateExamples}
+        </div>
+      </Library.SectionL2>
+
+      <Library.SectionL2 title="Highlighting">
+        <div className="my-4 flex flex-row flex-wrap gap-4">
+          {highlightingExamples}
         </div>
       </Library.SectionL2>
 

--- a/src/tailwind.preset.js
+++ b/src/tailwind.preset.js
@@ -7,6 +7,11 @@ import { scrollShadows } from './tailwind.scroll-shadows.js';
 // Equivalent to spacing value 11; minimum touch-target size
 const minimumTouchDimension = '44px';
 
+// Default colors
+const green = '#00a36d';
+const yellow = '#fbc168';
+const red = '#d93c3f';
+
 export default /** @type {Partial<import('tailwindcss').Config>} */ ({
   theme: {
     extend: {
@@ -50,13 +55,22 @@ export default /** @type {Partial<import('tailwindcss').Config>} */ ({
           focus: '#59a7e8',
         },
         green: {
-          success: '#00a36d',
+          light: '#dfebe7',
+          DEFAULT: green,
+          dark: '#005c3d',
+          success: green,
         },
         yellow: {
-          notice: '#fbc168',
+          light: '#fef7ec',
+          DEFAULT: yellow,
+          dark: '#774903',
+          notice: yellow,
         },
         red: {
-          error: '#d93c3f',
+          light: '#f0e2e3',
+          DEFAULT: red,
+          dark: '#891b1d',
+          error: red,
         },
         brand: {
           dark: '#84141e',


### PR DESCRIPTION
This PR brings new "ligth" and "dark" shades for the green, yellow and red tailwind preset colors.

These colors where originally defined for the auto-grading project in LMS, but we are going to need them soon for premoderation in h and client:

![image](https://github.com/user-attachments/assets/9a1f8854-feb2-47f9-94e8-d7a6eb202701)

These new shades are defined together with the original "green-success", "yellow-notice" and "red-error", which still exist, and become aliases for the `DEFAULT` variants of their corresponding colors.

![image](https://github.com/user-attachments/assets/49153837-8b6b-4d52-acd8-882c6943db21)
