### PR TITLE
Improve tests to work with both karma and vitest

### DIFF
--- a/src/components/feedback/test/Popover-test.js
+++ b/src/components/feedback/test/Popover-test.js
@@ -355,7 +355,7 @@ describe('Popover', () => {
       // Content is slightly longer than the anchor element. The popover matches
       // one of its sides but spans further to the opposite one
       {
-        children: 'slightly longer text'.repeat(2),
+        children: 'slightly longer text',
         align: 'left',
         getExpectedCoordinates: (popoverDOMNode, wrapper) => {
           const buttonDOMNode = getToggleButton(wrapper).getDOMNode();
@@ -388,7 +388,7 @@ describe('Popover', () => {
       // Content is very big, so popover spans to the edge of the viewport and
       // grows further than the opposite side of the anchor element
       {
-        children: 'very long text'.repeat(6),
+        children: 'very long text'.repeat(4),
         align: 'left',
         getExpectedCoordinates: popoverDOMNode => {
           const popoverRect = popoverDOMNode.getBoundingClientRect();

--- a/src/components/transition/test/Slider-test.js
+++ b/src/components/transition/test/Slider-test.js
@@ -1,4 +1,4 @@
-import { mount } from '@hypothesis/frontend-testing';
+import { mount, waitFor } from '@hypothesis/frontend-testing';
 
 import { testTransitionComponent } from '../../test/common-tests';
 import Slider from '../Slider';
@@ -57,16 +57,11 @@ describe('Slider', () => {
     assert.equal(containerStyle.height, '200px');
   });
 
-  it('should transition to collapsed if `direction` changes to `out`', done => {
+  it('should transition to collapsed if `direction` changes to `out`', async () => {
     const wrapper = createSlider({ direction: 'in' });
 
     wrapper.setProps({ direction: 'out' });
-
-    setTimeout(() => {
-      const containerStyle = wrapper.getDOMNode().style;
-      assert.equal(containerStyle.height, '0px');
-      done();
-    }, 1);
+    await waitFor(() => wrapper.getDOMNode().style.height === '0px');
   });
 
   it('should set the container height to "auto" when an expand transition finishes', () => {


### PR DESCRIPTION
This PR includes changes in tests that were found to fail when run with `vitest` instead of karma+mocha, as part of https://github.com/hypothesis/frontend-shared/pull/1947.