### PR TITLE
Add vitest summary reporter

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,3 +21,7 @@ updates:
     typescript-types:
       patterns:
         - '@types/*'
+    vitest:
+      patterns:
+        - 'vitest'
+        - '@vitest/*'

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "@babel/preset-react": "^7.0.0",
     "@babel/preset-typescript": "^7.18.6",
     "@hypothesis/frontend-build": "^3.2.1",
-    "@hypothesis/frontend-testing": "^1.4.0",
+    "@hypothesis/frontend-testing": "^1.6.0",
     "@rollup/plugin-babel": "^6.0.0",
     "@rollup/plugin-commonjs": "^28.0.0",
     "@rollup/plugin-dynamic-import-vars": "^2.1.2",

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -1,7 +1,11 @@
+import { SummaryReporter } from '@hypothesis/frontend-testing/vitest';
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
+    globals: true,
+    reporters: [new SummaryReporter()],
+
     browser: {
       provider: 'playwright',
       enabled: true,
@@ -9,7 +13,6 @@ export default defineConfig({
       screenshotFailures: false,
       instances: [{ browser: 'chromium' }],
     },
-    globals: true,
 
     // CSS bundle relied upon by accessibility tests (eg. for color-contrast
     // checks).

--- a/yarn.lock
+++ b/yarn.lock
@@ -1609,7 +1609,7 @@ __metadata:
     "@babel/preset-react": ^7.0.0
     "@babel/preset-typescript": ^7.18.6
     "@hypothesis/frontend-build": ^3.2.1
-    "@hypothesis/frontend-testing": ^1.4.0
+    "@hypothesis/frontend-testing": ^1.6.0
     "@rollup/plugin-babel": ^6.0.0
     "@rollup/plugin-commonjs": ^28.0.0
     "@rollup/plugin-dynamic-import-vars": ^2.1.2
@@ -1660,14 +1660,19 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@hypothesis/frontend-testing@npm:^1.4.0":
-  version: 1.5.0
-  resolution: "@hypothesis/frontend-testing@npm:1.5.0"
+"@hypothesis/frontend-testing@npm:^1.6.0":
+  version: 1.6.0
+  resolution: "@hypothesis/frontend-testing@npm:1.6.0"
   dependencies:
     axe-core: ^4.8.2
     enzyme: ^3.11.0
     preact: ^10.18.1
-  checksum: 26cbebeb23acb5fb6d29d26178d3b8dd617dcb948f7596aefdacac3fdf62c7ac02d78f5ec634b0bed5b63e001ad5bb26989df732b0caf971f2b0671620821fde
+  peerDependencies:
+    vitest: ^3.1.2
+  peerDependenciesMeta:
+    vitest:
+      optional: true
+  checksum: 1ac5404bc658bbf1c71548d39e4703ac65ec822794f0a654122b7c98767f3f5830449466ee4c46695a44bd03a65b35108dddc3d8d7b177eb738b11a34c4f38e7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Following-up on https://github.com/hypothesis/frontend-shared/pull/1947, this PR:

- Configures vitest to use the summary reporter introduced in https://github.com/hypothesis/frontend-testing/pull/76
- Updates to the latest version of `@hypothesis/frontend-testing`, as per the point above
- Adds a new dependabot group for vitest packages.