### PR TITLE
Allow an arrow to be added to popover component

### DIFF
--- a/src/components/feedback/test/Popover-test.js
+++ b/src/components/feedback/test/Popover-test.js
@@ -75,17 +75,23 @@ describe('Popover', () => {
     return popoverTop < buttonTop;
   };
 
-  const getDistanceBetweenButtonAndPopover = wrapper => {
+  const getDistanceBetweenButtonAndElement = (wrapper, element) => {
     const appearedAbove = popoverAppearedAbove(wrapper);
-    const { top: popoverTop, bottom: popoverBottom } = getPopover(wrapper)
-      .getDOMNode()
-      .getBoundingClientRect();
+    const { top: elementTop, bottom: elementBottom } =
+      element.getBoundingClientRect();
     const { top: buttonTop, bottom: buttonBottom } = getToggleButton(wrapper)
       .getDOMNode()
       .getBoundingClientRect();
 
     return Math.abs(
-      appearedAbove ? popoverBottom - buttonTop : buttonBottom - popoverTop,
+      appearedAbove ? elementBottom - buttonTop : buttonBottom - elementTop,
+    );
+  };
+
+  const getDistanceBetweenButtonAndPopover = wrapper => {
+    return getDistanceBetweenButtonAndElement(
+      wrapper,
+      getPopover(wrapper).getDOMNode(),
     );
   };
 
@@ -453,6 +459,46 @@ describe('Popover', () => {
           popoverRight.toFixed(0),
           expectedCoordinates.right.toFixed(0),
         );
+      });
+    });
+  });
+
+  describe('popover with arrow', () => {
+    [
+      {
+        arrow: true,
+        placement: 'above',
+        expectedPointer: 'PointerDownIcon',
+        expectedOffset: 14,
+      },
+      {
+        arrow: true,
+        placement: 'below',
+        expectedPointer: 'PointerUpIcon',
+        expectedOffset: 14,
+      },
+      { arrow: false, placement: 'above', expectedOffset: 6 },
+      { arrow: false, placement: 'below', expectedOffset: 6 },
+    ].forEach(({ arrow, placement, expectedPointer, expectedOffset }) => {
+      it('increases the offset between the anchor and the popover when arrow is true', () => {
+        const wrapper = createComponent(
+          { placement, arrow },
+          // Add some space so that the popover can render above
+          { paddingTop: 100 },
+        );
+        togglePopover(wrapper);
+
+        const offset = getDistanceBetweenButtonAndElement(
+          wrapper,
+          wrapper.find('[data-testid="popover-content"]').getDOMNode(),
+        );
+        assert.equal(offset, expectedOffset);
+
+        if (arrow) {
+          assert.isTrue(wrapper.exists(expectedPointer));
+        } else {
+          assert.isFalse(wrapper.exists('[data-testid="arrow"]'));
+        }
       });
     });
   });

--- a/src/pattern-library/components/patterns/feedback/PopoverPage.tsx
+++ b/src/pattern-library/components/patterns/feedback/PopoverPage.tsx
@@ -92,6 +92,25 @@ export default function PopoverPage() {
               </Library.InfoItem>
             </Library.Info>
           </Library.SectionL3>
+          <Library.SectionL3 title="arrow">
+            <Library.Info>
+              <Library.InfoItem label="description">
+                Determines if a small arrow pointing to the anchor element
+                should be displayed.
+              </Library.InfoItem>
+              <Library.InfoItem label="type">
+                <code>{'true | false'}</code>
+              </Library.InfoItem>
+              <Library.InfoItem label="default">
+                <code>{'false'}</code>
+              </Library.InfoItem>
+            </Library.Info>
+            <Library.Demo
+              title="Popover with arrow"
+              exampleFile="popover-with-arrow"
+              withSource
+            />
+          </Library.SectionL3>
           <Library.SectionL3 title="asNativePopover">
             <Library.Info>
               <Library.InfoItem label="description">

--- a/src/pattern-library/examples/popover-with-arrow.tsx
+++ b/src/pattern-library/examples/popover-with-arrow.tsx
@@ -1,0 +1,30 @@
+import { useRef, useState } from 'preact/hooks';
+
+import { Popover } from '../../components/feedback';
+import { Button } from '../../components/input';
+
+export default function App() {
+  const [open, setOpen] = useState(false);
+  const buttonRef = useRef<HTMLButtonElement | null>(null);
+
+  return (
+    <div className="relative flex justify-center">
+      <Button
+        variant="primary"
+        elementRef={buttonRef}
+        onClick={() => setOpen(prev => !prev)}
+      >
+        {open ? 'Close' : 'Open'} Popover
+      </Button>
+      <Popover
+        open={open}
+        onClose={() => setOpen(false)}
+        anchorElementRef={buttonRef}
+        classes="p-2"
+        arrow
+      >
+        The content of the popover goes here
+      </Popover>
+    </div>
+  );
+}


### PR DESCRIPTION
Add new `arrowed?: boolean` prop to `Popover` that allows an arrow/triangle pointing to the anchor element to be rendered.

The arrow is aligned to the same side as the popover, and points up or down depending on the Popover placement.

https://github.com/user-attachments/assets/9575a16b-246a-4a44-b401-132ef2f11f08

The functionality is very simple at this point and is not very customizable, but let's wait to see what new requirements appear before making it more complex.

Our initial use case is using the Popover for the share annotation behavior in the sidebar and the moderation queue. This is how it looks with the code from this PR:

https://github.com/user-attachments/assets/a642dd20-41c5-487d-9ed8-c73351eb1859

> [!TIP]
> This PR is easier to review [ignoring whitespaces](https://github.com/hypothesis/frontend-shared/pull/2011/files?w=1)

### TODO

- [x] Document new prop
- [x] Add tests