### PR TITLE
Add containerClasses prop to Popover

### DIFF
--- a/src/components/feedback/Popover.tsx
+++ b/src/components/feedback/Popover.tsx
@@ -260,8 +260,16 @@ function useOnClose(
 
 export type PopoverProps = {
   children?: ComponentChildren;
-  classes?: string | string[];
   variant?: 'panel' | 'custom';
+
+  /**
+   * Additional classes to be passed to the first child element of the popover,
+   * the one directly wrapping `children`.
+   */
+  classes?: string | string[];
+
+  /** Additional classes to be passed to the outermost element */
+  containerClasses?: string | string[];
 
   /** Ref for the popover element. */
   elementRef?: RefObject<HTMLElement>;
@@ -386,6 +394,7 @@ export default function Popover({
   placement = 'below',
   arrow = false,
   classes,
+  containerClasses,
   variant = 'panel',
   onScroll,
   elementRef,
@@ -429,6 +438,7 @@ export default function Popover({
           'right-0': align === 'right',
           'min-w-full': true,
         },
+        containerClasses,
       )}
       ref={downcastRef(popoverRef)}
       popover={asNativePopover && 'auto'}

--- a/src/pattern-library/components/patterns/feedback/PopoverPage.tsx
+++ b/src/pattern-library/components/patterns/feedback/PopoverPage.tsx
@@ -136,7 +136,22 @@ export default function PopoverPage() {
           <Library.SectionL3 title="classes">
             <Library.Info>
               <Library.InfoItem label="description">
-                Additional CSS classes to pass to the popover.
+                Additional CSS classes to pass to the popover{"'"}s first child,
+                the one directly wrapping `children`.
+              </Library.InfoItem>
+              <Library.InfoItem label="type">
+                <code>string | string[]</code>
+              </Library.InfoItem>
+              <Library.InfoItem label="default">
+                <code>undefined</code>
+              </Library.InfoItem>
+            </Library.Info>
+          </Library.SectionL3>
+          <Library.SectionL3 title="containerClasses">
+            <Library.Info>
+              <Library.InfoItem label="description">
+                Additional CSS classes to pass to the popover{"'"}s outermost
+                element.
               </Library.InfoItem>
               <Library.InfoItem label="type">
                 <code>string | string[]</code>


### PR DESCRIPTION
As part of https://github.com/hypothesis/frontend-shared/pull/2011, a small breaking change was introduced intentionally, as I foresaw that would be the least disturbing approach.

This involved changing the element receiving the `classes` prop, from the outermost element, to the first children. The reasoning was described in [this comment](https://github.com/hypothesis/frontend-shared/pull/2011#discussion_r2153933634).

However, I have found a case where it was important that the classes were set in the outermost element, and this change has broken how it looks:

![image](https://github.com/user-attachments/assets/f0c86fc5-fbc7-492e-a6f0-27c4353d983d)

This PR adds a new `containerClasses` prop, which brings back the ability to pass classes to the outermost element.