### PR TITLE
Fix regressions introduced in Popover

### DIFF
--- a/src/components/feedback/Popover.tsx
+++ b/src/components/feedback/Popover.tsx
@@ -415,12 +415,18 @@ export default function Popover({
     <div
       className={classnames(
         'absolute z-5',
+        variant === 'panel' && [
+          'max-h-80 ',
+          'rounded border bg-white shadow hover:shadow-md focus-within:shadow-md',
+          !arrow && 'overflow-y-auto overflow-x-hidden',
+        ],
+        arrow && 'overflow-visible',
         asNativePopover && [
           // We don't want the popover to ever render outside the viewport,
           // and we give it a 16px gap
           'max-w-[calc(100%-16px)]',
           // Overwrite [popover] default styles
-          'p-0 m-0 overflow-visible',
+          'p-0 m-0',
         ],
         !asNativePopover && {
           // Hiding instead of unmounting so that popover size can be computed
@@ -429,6 +435,7 @@ export default function Popover({
           'right-0': align === 'right',
           'min-w-full': true,
         },
+        classes,
       )}
       ref={downcastRef(popoverRef)}
       popover={asNativePopover && 'auto'}
@@ -439,8 +446,8 @@ export default function Popover({
       {open && arrow && (
         <div
           className={classnames('absolute z-10', 'fill-white text-grey-3', {
-            'top-[calc(100%-1px)]': resolvedPlacement === 'above',
-            'bottom-[calc(100%-1px)]': resolvedPlacement === 'below',
+            'top-full': resolvedPlacement === 'above',
+            'bottom-full': resolvedPlacement === 'below',
             'left-2': align === 'left',
             'right-2': align === 'right',
           })}
@@ -453,20 +460,7 @@ export default function Popover({
           )}
         </div>
       )}
-      {open && (
-        <div
-          className={classnames(
-            variant === 'panel' && [
-              'max-h-80 overflow-y-auto overflow-x-hidden',
-              'rounded border bg-white shadow hover:shadow-md focus-within:shadow-md',
-            ],
-            classes,
-          )}
-          data-testid="popover-content"
-        >
-          {children}
-        </div>
-      )}
+      {open && children}
     </div>
   );
 }

--- a/src/components/feedback/test/Popover-test.js
+++ b/src/components/feedback/test/Popover-test.js
@@ -26,7 +26,7 @@ function TestComponent({ children, ...rest }) {
         {...rest}
       >
         {children ?? (
-          <>
+          <div data-testid="popover-content">
             Content of popover
             <button
               data-testid="inner-button"
@@ -34,7 +34,7 @@ function TestComponent({ children, ...rest }) {
             >
               Focusable element inside popover
             </button>
-          </>
+          </div>
         )}
       </Popover>
     </div>
@@ -469,16 +469,16 @@ describe('Popover', () => {
         arrow: true,
         placement: 'above',
         expectedPointer: 'PointerDownIcon',
-        expectedOffset: 14,
+        expectedOffset: 12,
       },
       {
         arrow: true,
         placement: 'below',
         expectedPointer: 'PointerUpIcon',
-        expectedOffset: 14,
+        expectedOffset: 12,
       },
-      { arrow: false, placement: 'above', expectedOffset: 6 },
-      { arrow: false, placement: 'below', expectedOffset: 6 },
+      { arrow: false, placement: 'above', expectedOffset: 4 },
+      { arrow: false, placement: 'below', expectedOffset: 4 },
     ].forEach(({ arrow, placement, expectedPointer, expectedOffset }) => {
       it('increases the offset between the anchor and the popover when arrow is true', () => {
         const wrapper = createComponent(


### PR DESCRIPTION
This PR reverts a few of the changes introduced in https://github.com/hypothesis/frontend-shared/pull/2011, which have caused a few visual regressions (see https://github.com/hypothesis/client/pull/7159#issuecomment-2984363252 and https://github.com/hypothesis/frontend-shared/pull/2013).

The root cause was that the DOM structure was changed, adding one extra element between the outermost Popover element and the `children`, and moving some of the classes to this new element, including the propagation of the `classes` prop.

https://github.com/hypothesis/frontend-shared/pull/2013 was an attempt at working around one of those issues, but by checking how we use `Popover.classes` in different places, I realized it would not be possible to consistently split those into `classes` and `containerClasses` (or `contentClasses`), specially considering `Select` makes use of these with its own `popoverClasses`, which would require splitting in two as well.

Instead, this PR restructures the DOM elements again, so that it is exactly as before, when `arrow` is false, and when it is true, it only changes `overflow-y-auto overflow-x-hidden` with `overflow-visible` in the outermost element.

This overflow difference was the motivation of the original DOM structure, but it's now clear the implemented solution was overkill.

Having visible overflow might require tweaks in consuming code, but since that is only going to affect new implementations where `arrow` is `true`, we can address those on a case-by-case basis, but ensuring all other existing `Popover` usages are "safe" of regressions.