### PR TITLE
Disable mangling of names when building minified bundles

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -26,6 +26,10 @@ if (isProd) {
         // See https://github.com/hypothesis/client/issues/4045.
         max_line_len: 1024,
       },
+
+      // Disable name mangling because it affects the readability of examples.
+      // See https://github.com/hypothesis/frontend-shared/issues/1949.
+      mangle: false,
     }),
   );
 


### PR DESCRIPTION
Some of the pattern library examples rely on function names being preserved in order to generate readable code via the `jsxToString` utility.

See https://github.com/terser/terser?tab=readme-ov-file#minify-options for notes on supported options.

Fixes https://github.com/hypothesis/frontend-shared/issues/1949