### PR TITLE
Set `NODE_ENV=production` when building npm package

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -18,6 +18,8 @@ jobs:
       run: yarn install --immutable
     - name: Build lib files
       run: yarn build
+      env:
+        NODE_ENV: production
     - name: Publish package
       run: npm publish --access public
       env:


### PR DESCRIPTION
This fixes an issue where Babel's JSX transform was run in development mode when building the npm package, bloating each JSX component with debug info.