### PR TITLE
Support callback returning ES module in `lazy` utility

### DIFF
--- a/src/util/test/lazy-test.js
+++ b/src/util/test/lazy-test.js
@@ -55,6 +55,17 @@ describe('lazy', () => {
     );
   });
 
+  it('supports load callback returning a module', async () => {
+    fakeLoader.returns(Promise.resolve({ default: fakeComponent }));
+    const wrapper = mount(<LazyComponent text="test" />);
+
+    // Wait for component to load
+    await delay(0);
+    wrapper.update();
+
+    assert.isTrue(wrapper.exists('[data-testid="loaded-component"]'));
+  });
+
   it('passes props to loaded component', async () => {
     fakeLoader.returns(Promise.resolve(fakeComponent));
     const wrapper = mount(<LazyComponent text="test" customProp="value" />);


### PR DESCRIPTION
Make the `lazy` utility more convenient to use by allowing the `load` callback to return an ES module whose default export is a component.

With this change, this common usage:

```js
const Widget = lazy('Widget', () => import('./Widget').then(mod =>
mod.default), options)
```

Can be simplified to:

```js
const Widget = lazy('Widget', () => import('./Widget'), options);
```