### PR TITLE
Add a tailwind hyp-wrap-anywhere utility

### DIFF
--- a/src/tailwind.preset.js
+++ b/src/tailwind.preset.js
@@ -159,5 +159,14 @@ export default /** @type {Partial<import('tailwindcss').Config>} */ ({
       // See https://tailwindcss.com/docs/hover-focus-and-other-states#styling-based-on-parent-state
       addVariant('input-group', '.input-group &');
     }),
+    plugin(({ addUtilities }) => {
+      addUtilities({
+        // Tailwind v3 does not provide this specific break utility: https://v3.tailwindcss.com/docs/word-break
+        // Tailwind v4 does have an equivalent utility that we can eventually adopt https://tailwindcss.com/docs/overflow-wrap#wrapping-anywhere
+        '.hyp-wrap-anywhere': {
+          'overflow-wrap': 'anywhere',
+        },
+      });
+    }),
   ],
 });


### PR DESCRIPTION
Define here a tailwind utility equivalent to one that currently lives in [the client](https://github.com/hypothesis/client/blob/9860460d2dca9bdcea587aade5fae949d146e18c/tailwind.config.js#L240-L242), so that other projects can take advantage of it.

We are defining the utility here prefixed with `hyp-`, a practice that we should probably follow for all custom tailwind utilities, so that it's easier to track their usage.

Also, we are naming the utility `hyp-wrap-anywhere`, instead of `hyp-break-anywhere`, to be more in line with a utility that already exists in tailwind v4 https://tailwindcss.com/docs/overflow-wrap#wrapping-anywhere. This could make it easier to migrate to it in the future.