### PR TITLE
Prevent checkbox / radio button icon from being clipped when label is long

### DIFF
--- a/src/components/input/ToggleInput.tsx
+++ b/src/components/input/ToggleInput.tsx
@@ -91,7 +91,10 @@ export default function ToggleInput({
           // The ring needs to be applied here because the `input` has an
           // effectively-0 opacity.
           'peer-focus-visible:ring',
+          // Set preferred size of icon to match text.
           'w-em h-em',
+          // Set minimum size of icon to minimum size of SVG.
+          'min-w-min min-h-min',
         )}
       />
       {children}


### PR DESCRIPTION
When a checkbox or radio button had a label that filled the entire available width, the icon would begin to shrink and would be clipped. The icon had a preferred size set, but not a minimum size.

Set the minimum size to match the SVG, which means 16px.

Part of a fix for https://github.com/hypothesis/h/issues/9635. With the changes on this branch, the signup form looks like:

<img width="641" height="227" alt="With fix" src="https://github.com/user-attachments/assets/a295ea39-d414-4bd2-8169-c7884050d80d" />

(The issue suggests aligning the checkbox with the baseline of the label, that's not implemented yet)

----

**Testing:**

On http://localhost:4001/input-checkbox, edit the label text for any of the examples to fill an entire line. On `main`, this will cause the icon to shrink. On this branch it won't.