### PR TITLE
Wrap Checkbox and RadioButton children in a span

### DIFF
--- a/src/components/input/ToggleInput.tsx
+++ b/src/components/input/ToggleInput.tsx
@@ -97,7 +97,7 @@ export default function ToggleInput({
           'min-w-min min-h-min',
         )}
       />
-      {children}
+      <span>{children}</span>
     </label>
   );
 }


### PR DESCRIPTION
This avoids a hazard where the Checkbox's flex layout can cause children to be displayed with an unexpected layout. See https://github.com/hypothesis/h/pull/9844.