### PR TITLE
Render lazy-loaded components synchronously if already loaded

### DIFF
--- a/src/util/test/lazy-test.js
+++ b/src/util/test/lazy-test.js
@@ -55,6 +55,21 @@ describe('lazy', () => {
     );
   });
 
+  it('renders component on initial render if already loaded', async () => {
+    // First render, which triggers lazy loading.
+    fakeLoader.returns(Promise.resolve(fakeComponent));
+    const wrapper = mount(<LazyComponent text="test" />);
+    await delay(0);
+    wrapper.update();
+    assert.isTrue(wrapper.exists('[data-testid="loaded-component"]'));
+    wrapper.unmount();
+
+    // Second render, which should synchronously render the already-loaded
+    // component.
+    const wrapper2 = mount(<LazyComponent text="test" />);
+    assert.isTrue(wrapper2.exists('[data-testid="loaded-component"]'));
+  });
+
   it('supports load callback returning a module', async () => {
     fakeLoader.returns(Promise.resolve({ default: fakeComponent }));
     const wrapper = mount(<LazyComponent text="test" />);


### PR DESCRIPTION
Make lazy-loading components created by `lazy` render synchronously (ie. render the actual component on the first render) if the component was already loaded by a previous instance of the lazy wrapper component.

In h the async rendering was causing annotation cards to transition their height slightly after appearing. This change doesn't prevent the animation from happening when annotation cards first appear, but does prevent it on subsequen renders.