### PR TITLE
Export CloseableContext from the root of the package

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,7 @@ export { confirm } from './util/prompts';
 
 // Components
 export * from './components/icons';
+export { default as CloseableContext } from './components/CloseableContext';
 export {
   AspectRatio,
   DataTable,


### PR DESCRIPTION
Export the `CloseableContext` symbol from the root of the package, since the `exports` definition no longer allows importing from a specific path deep inside the library.